### PR TITLE
Add box shadows to select

### DIFF
--- a/src/components/Connect/Connect.module.scss
+++ b/src/components/Connect/Connect.module.scss
@@ -13,13 +13,13 @@
 }
 
 .hasLeft > * {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
+  border-top-left-radius: 0 !important;
+  border-bottom-left-radius: 0 !important;
 }
 
 .hasRight > * {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
+  border-top-right-radius: 0 !important;
+  border-bottom-right-radius: 0 !important;
 }
 
 .Left, .Right {
@@ -33,15 +33,15 @@
 .Left {
   margin-right: -1px;
   * {
-    border-top-right-radius: 0 !important;
-    border-bottom-right-radius: 0 !important;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
   }
 }
 
 .Right {
   margin-left: -1px;
   * {
-    border-top-left-radius: 0 !important;
-    border-bottom-left-radius: 0 !important;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
   }
 }

--- a/src/components/Pagination/Pagination.module.scss
+++ b/src/components/Pagination/Pagination.module.scss
@@ -17,7 +17,7 @@
 }
 
 .Page, .Start, .End {
-  width: rem(39);
+  min-width: rem(42);
 }
 
 .Selected {

--- a/src/components/Select/Select.module.scss
+++ b/src/components/Select/Select.module.scss
@@ -35,6 +35,8 @@
   font-size: rem(15);
   line-height: rem(24);
 
+  box-shadow: shadow();
+  
   transition: border 0.15s;
 
   &:hover {

--- a/stories/Pagination.js
+++ b/stories/Pagination.js
@@ -21,7 +21,7 @@ export default storiesOf('Pagination', module)
 
   .addWithInfo('with lots of pages', () => (
     <Pagination
-      pages={13}
+      pages={30}
       pageRange={7}
       onChange={action('Page Changed')}
     />

--- a/stories/TextField.js
+++ b/stories/TextField.js
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { StoryContainer } from './helpers';
 
-import { TextField, Button, Select, Icon } from '../src';
+import { TextField, Button, Select, Icon, Tooltip } from '../src';
 
 export default storiesOf('TextField', module)
   .addDecorator((getStory) => (
@@ -55,7 +55,7 @@ export default storiesOf('TextField', module)
         id='id'
         label='Date Range'
         value='July 21, 2017 - July 28, 2017'
-        connectLeft={<Button>Injection Time</Button>}
+        connectLeft={<Tooltip content='Hey'><Button>Injection Time</Button></Tooltip>}
         connectRight={<Select options={
           ['Last 24 Hours', 'Last Week']
         }/>}


### PR DESCRIPTION
Closes #57 
Could not find a way to correctly disable box-shadow or apply border-radius 0 when using `Tooltip` with `Select` or `Button`. So instead i'm just adding box-shadows to Selects so at least they'll look the same as Buttons ¯\_(ツ)_/¯

- Fixes Connect's border-radius `!important` overrides
- Fixes Pagination button widths