### PR TITLE
Better help text spacing for text fields

### DIFF
--- a/src/components/Checkbox/Checkbox.module.scss
+++ b/src/components/Checkbox/Checkbox.module.scss
@@ -106,7 +106,7 @@
 
 .HelpText {
   font-size: rem(13);
-  line-height: rem(15);
+  line-height: 1.3em;
   color: color(gray, 4);
   padding-left: 27px;
 }

--- a/src/components/Radio/Radio.module.scss
+++ b/src/components/Radio/Radio.module.scss
@@ -94,9 +94,9 @@
 }
 
 .HelpText {
-  padding-top: 3px;
+  padding-top: rem(6);
   font-size: rem(13);
-  line-height: rem(15);
+  line-height: 1.3em;
   color: color(gray, 4);
   padding-left: 27px;
 }

--- a/src/components/Select/Select.module.scss
+++ b/src/components/Select/Select.module.scss
@@ -36,7 +36,7 @@
   line-height: rem(24);
 
   box-shadow: shadow();
-  
+
   transition: border 0.15s;
 
   &:hover {
@@ -69,8 +69,8 @@
 }
 
 .HelpText {
-  padding-top: rem(3);
+  padding-top: rem(6);
   font-size: rem(13);
-  line-height: rem(15);
+  line-height: 1.3em;
   color: color(gray, 4);
 }

--- a/src/components/TextField/TextField.module.scss
+++ b/src/components/TextField/TextField.module.scss
@@ -52,9 +52,9 @@
 }
 
 .HelpText {
-  padding-top: rem(9);
+  padding-top: rem(6);
   font-size: rem(13);
-  line-height: rem(15);
+  line-height: 1.3em;
   color: color(gray, 4);
 }
 

--- a/src/components/TextField/TextField.module.scss
+++ b/src/components/TextField/TextField.module.scss
@@ -52,7 +52,7 @@
 }
 
 .HelpText {
-  padding-top: rem(3);
+  padding-top: rem(9);
   font-size: rem(13);
   line-height: rem(15);
   color: color(gray, 4);


### PR DESCRIPTION
I adjusted the help text in the dev console, it was at 0.1666667rem and moving it to 0.5rem made it look good, I think. Converted the numbers and I think this does the right thing.