### PR TITLE
Select placeholder value

### DIFF
--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -7,8 +7,6 @@ import { Icon } from '../Icon';
 import classnames from 'classnames';
 import styles from './Select.module.scss';
 
-const PLACEHOLDER_VALUE = '_placeholder';
-
 const Option = ({ option }) => {
   if (typeof option === 'object') {
     const { value, label = value, ...rest } = option;
@@ -60,6 +58,7 @@ class Select extends Component {
       placeholder,
       disabled,
       error,
+      placeholderValue = '',
       ...rest
     } = this.props;
 
@@ -93,7 +92,7 @@ class Select extends Component {
       : null;
 
     const placeholderOption = placeholder
-      ? <option label={placeholder} value={PLACEHOLDER_VALUE} disabled />
+      ? <option label={placeholder} value={placeholderValue} disabled />
       : null;
 
     const helpMarkup = helpText

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -61,9 +61,9 @@ class Select extends Component {
       label,
       helpText,
       placeholder,
+      placeholderValue,
       disabled,
       error,
-      placeholderValue,
       ...rest
     } = this.props;
 
@@ -82,8 +82,14 @@ class Select extends Component {
       !label && styles.labelHidden
     );
 
-    const optionMarkup = options && options.length
-      ? options.map((option, key) => <Option option={option} key={key} />)
+    let combined = options;
+
+    if (placeholder) {
+      combined = [ { label: placeholder, value: placeholderValue, disabled: true }, ...combined ];
+    }
+
+    const optionMarkup = combined && combined.length
+      ? combined.map((option, key) => <Option option={option} key={key} />)
       : null;
 
     const labelMarkup = label
@@ -94,10 +100,6 @@ class Select extends Component {
 
     const errorMarkup = error
       ? <Error error={error} />
-      : null;
-
-    const placeholderOption = placeholder
-      ? <option label={placeholder} value={placeholderValue} disabled />
       : null;
 
     const helpMarkup = helpText
@@ -111,7 +113,6 @@ class Select extends Component {
           className={inputClasses}
           disabled={disabled}
           {...rest} >
-          { placeholderOption }
           { optionMarkup }
         </select>
         <Icon name='CaretDown' className={dropdownClasses} />

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -19,6 +19,10 @@ const Option = ({ option }) => {
 class Select extends Component {
   static displayName = 'Select';
 
+  static defaultProps = {
+    placeholderValue: ''
+  }
+
   static propTypes = {
     id: PropTypes.string,
     /**
@@ -36,6 +40,7 @@ class Select extends Component {
       ])
     ).isRequired,
     placeholder: PropTypes.string,
+    placeholderValue: PropTypes.string,
     disabled: PropTypes.bool,
     label: PropTypes.string,
     helpText: PropTypes.oneOfType([
@@ -58,7 +63,7 @@ class Select extends Component {
       placeholder,
       disabled,
       error,
-      placeholderValue = '',
+      placeholderValue,
       ...rest
     } = this.props;
 

--- a/stories/Select.js
+++ b/stories/Select.js
@@ -27,6 +27,7 @@ export default storiesOf('Select', module)
       id='id'
       label='Select an option'
       placeholder='Leslie Knope'
+      defaultValue=''
       options={options2}
     />
   ))
@@ -67,18 +68,11 @@ export default storiesOf('Select', module)
     />
   ))
 
-  .addWithInfo('with default value', () => (
-    <Select
-      defaultValue="2"
-      options={options2}
-    />
-  ))
-
   .addWithInfo('with custom value for placeholder', () => (
       <Select
         placeholderValue="NONE"
         placeholder='Select one'
+        defaultValue="NONE"
         options={options2}
       />
     ));
-  

--- a/stories/Select.js
+++ b/stories/Select.js
@@ -72,4 +72,13 @@ export default storiesOf('Select', module)
       defaultValue="2"
       options={options2}
     />
-  ));
+  ))
+
+  .addWithInfo('with custom value for placeholder', () => (
+      <Select
+        placeholderValue="NONE"
+        placeholder='Select one'
+        options={options2}
+      />
+    ));
+  


### PR DESCRIPTION
To avoid possible problems with validation, this PR removes the default value (which was `_placeholder`) for placeholder `<option/>` item and allows to set custom values. So, by default, value for placeholder `<option/>` will be empty but can set to a desired value using `placeholderValue` prop.