### PR TITLE
Add positioning support for popovers

### DIFF
--- a/src/components/Popover/Popover.js
+++ b/src/components/Popover/Popover.js
@@ -26,6 +26,10 @@ class Popover extends Component {
       * Opens the popover
       */
     open: PropTypes.bool,
+    left: PropTypes.bool,
+    right: PropTypes.bool,
+    top: PropTypes.bool,
+    bottom: PropTypes.bool,
     /**
       * Popover Content
       */
@@ -34,6 +38,11 @@ class Popover extends Component {
       PropTypes.node
     ])
   };
+
+  static defaultProps = {
+    right: true,
+    bottom: true
+  }
 
   state = {
     open: false
@@ -69,6 +78,10 @@ class Popover extends Component {
       className = '',
       open,
       manualTrigger,
+      top,
+      bottom,
+      left,
+      right,
       ...rest
     } = this.props;
 
@@ -82,7 +95,9 @@ class Popover extends Component {
 
     const wrapperClasses = classnames(
       styles.Wrapper,
-      shouldBeOpen && styles.open
+      shouldBeOpen && styles.open,
+      top && styles.top,
+      left && styles.left
     );
 
     const triggerMarkup = <span onClick={this.handleTrigger}>{ trigger }</span>;

--- a/src/components/Popover/Popover.module.scss
+++ b/src/components/Popover/Popover.module.scss
@@ -52,6 +52,7 @@
 }
 
 .Wrapper {
+  display: inline-block;
   position: relative;
 }
 
@@ -60,5 +61,36 @@
     pointer-events: auto;
     opacity: 1;
     transform: translate(0, 0) scale(1);
+  }
+}
+
+.top {
+  .Tip {
+    top: auto;
+    bottom: rem(-14);
+    margin: 0 0 rem(7);
+    border-top: none;
+    border-left: none;
+    border-bottom: 1px solid color(gray, 8);
+    border-right: 1px solid color(gray, 8);
+    border-bottom-right-radius: border-radius(large);
+  }
+
+  .Popover {
+    top: auto;
+    bottom: 100%;
+    margin: 0 0 rem(14);
+  }
+}
+
+.left {
+  .Popover {
+    left: auto;
+    right: 0;
+  }
+
+  .Tip {
+    left: auto;
+    right: rem(21);
   }
 }

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -41,7 +41,7 @@ export class Tooltip extends Component {
   };
 
   static defaultProps = {
-    left: true,
+    right: true,
     bottom: true,
     horizontalOffset: '0px',
     forcePosition: false,
@@ -59,7 +59,7 @@ export class Tooltip extends Component {
       content,
       dark,
       top,
-      right,
+      left,
       horizontalOffset,
       preferredPosition,
       forcePosition,
@@ -67,16 +67,16 @@ export class Tooltip extends Component {
     } = this.props;
 
     const positionTop = preferredPosition.top || (top && !forcePosition);
-    const positionRight = preferredPosition.left || (right && !forcePosition);
+    const positionLeft = preferredPosition.left || (left && !forcePosition);
 
     const wrapperClasses = classnames(
       styles.Wrapper,
       dark && styles.dark,
       positionTop && styles.top,
-      positionRight && styles.right,
+      positionLeft && styles.left,
     );
 
-    const offset = positionRight ? { right: horizontalOffset } : { left: horizontalOffset };
+    const offset = positionLeft ? { right: horizontalOffset } : { left: horizontalOffset };
 
     return (
       <span className={wrapperClasses} ref={positionRef}>

--- a/src/components/Tooltip/Tooltip.module.scss
+++ b/src/components/Tooltip/Tooltip.module.scss
@@ -46,7 +46,7 @@ $arrow-margin: 10px;
   }
 }
 
-.right {
+.left {
   .Tooltip {
     left: auto;
     right: 0;

--- a/stories/Popover.js
+++ b/stories/Popover.js
@@ -10,13 +10,21 @@ export default storiesOf('Popover', module)
     <StoryContainer>{ getStory() }</StoryContainer>
   ))
   .addWithInfo('With Datepicker', () => (
-      <Button.Group>
-        <Popover
-          sectioned
-          trigger={<Button onClick={action('Trigger Click')} value={new Date}>Button</Button>}
-          style={{ width: '400px' }}>
-          <Datepicker />
-        </Popover>
-        <Button>Test</Button>
-      </Button.Group>
-    ));
+    <Button.Group>
+      <Popover
+        sectioned
+        trigger={<Button onClick={action('Trigger Click')}>Button</Button>}
+        style={{ width: '400px' }}>
+        <Datepicker />
+      </Popover>
+      <Button>Test</Button>
+    </Button.Group>
+  ))
+  .addWithInfo('With Positioning', () => (
+    <div style={{ textAlign: 'center', marginTop: '40px' }}>
+      <Popover sectioned left top
+        trigger={<Button onClick={action('Trigger Click')}>Button</Button>} >
+        <small>Top & Left</small>
+      </Popover>
+    </div>
+  ));

--- a/stories/Tooltip.js
+++ b/stories/Tooltip.js
@@ -34,12 +34,12 @@ storiesOf('Tooltip', module)
     </div>
   ))
 
-  .addWithInfo('Right with horizontal offset',
+  .addWithInfo('Left with horizontal offset',
   () => (
     <div style={{ textAlign: 'center' }}>
       <Tooltip
         content='Messages an ISP or other remote domain accepted'
-        right horizontalOffset='-10px'>
+        left horizontalOffset='-10px'>
         Hover
       </Tooltip>
     </div>


### PR DESCRIPTION
Adds `top`, `left`, `right`, `bottom` bool props to `Popover`
Reverses Tooltip `left` & `right` logic