### PR TITLE
FAD-5588: Better support for fixed size form layouts

### DIFF
--- a/src/components/Error/Error.js
+++ b/src/components/Error/Error.js
@@ -2,11 +2,12 @@ import React from 'react';
 import { Icon } from '../Icon';
 import styles from './Error.module.scss';
 
-const Error = ({ error }) => (
-  <div className={styles.Error}>
+const Error = ({ error, inline }) => {
+  const errorClass = inline ? styles.InlineError : styles.Error;
+  return <div className={errorClass}>
     <span className={styles.Message}><Icon name='Error' className={styles.Icon} size={13} />{ error }</span>
-  </div>
-);
+  </div>;
+};
 
 Error.displayName = 'Error';
 export default Error;

--- a/src/components/Error/Error.module.scss
+++ b/src/components/Error/Error.module.scss
@@ -4,6 +4,11 @@
   padding-top: spacing(small);
 }
 
+.InlineError {
+  padding-left: spacing(small);
+  display: inline;
+}
+
 .Icon {
   float: left;
   margin-right: rem(5);

--- a/src/components/Label/Label.js
+++ b/src/components/Label/Label.js
@@ -5,13 +5,15 @@ import styles from './Label.module.scss';
 const Label = ({
   label,
   id,
-  className
+  className,
+  children
 }) => (
   <label
     id={id && `${id}Label`}
     htmlFor={id}
     className={classnames(styles.Label, className)} >
     { label }
+    { children }
   </label>
 );
 

--- a/src/components/TextField/TextField.js
+++ b/src/components/TextField/TextField.js
@@ -46,6 +46,7 @@ class TextField extends Component {
       PropTypes.node
     ]),
     error: PropTypes.string,
+    inlineErrors: PropTypes.bool,
     onChange: PropTypes.func,
     onFocus: PropTypes.func,
     onBlur: PropTypes.func
@@ -94,6 +95,7 @@ class TextField extends Component {
       label,
       labelHidden,
       helpText,
+      inlineErrors,
       error,
       onChange,
       onFocus,
@@ -116,13 +118,18 @@ class TextField extends Component {
       ? ' *'
       : '';
 
-    const labelMarkup = label && !labelHidden
-      ? <Label
-          id={id}
-          label={`${label}${requiredIndicator}`} />
-      : null;
+    let labelMarkup;
+    const renderLabel = !labelHidden || inlineErrors;
+    if (label && renderLabel) {
+      const errorMsg = error && inlineErrors ? <Error inline={true} error={error} /> : null;
+      labelMarkup = <Label
+        id={id}
+        label={`${label}${requiredIndicator}`}>
+        {errorMsg}
+      </Label>;
+    }
 
-    const errorMarkup = error
+    const errorMarkup = error && !inlineErrors
       ? <Error error={error} />
       : null;
 

--- a/src/components/TextField/TextField.js
+++ b/src/components/TextField/TextField.js
@@ -21,6 +21,7 @@ class TextField extends Component {
     disabled: PropTypes.bool,
     readOnly: PropTypes.bool,
     required: PropTypes.bool,
+    resize: PropTypes.oneOf(['none', 'both', 'horizontal', 'vertical', 'block', 'inline']),
     label: PropTypes.string,
     labelHidden: PropTypes.bool,
     helpText: PropTypes.oneOfType([
@@ -52,6 +53,7 @@ class TextField extends Component {
 
   static defaultProps = {
     required: false,
+    resize: 'both',
     type: 'text'
   };
 
@@ -88,6 +90,7 @@ class TextField extends Component {
       disabled,
       readOnly,
       required,
+      resize,
       label,
       labelHidden,
       helpText,
@@ -148,7 +151,7 @@ class TextField extends Component {
       onBlur,
       onChange,
       className: styles.Input,
-      style: { paddingLeft, paddingRight }
+      style: { paddingLeft, paddingRight, resize }
       // 'aria-describedby':
       // 'aria-labelledby':
       // 'aria-invalid':

--- a/src/components/TextField/TextField.js
+++ b/src/components/TextField/TextField.js
@@ -21,6 +21,9 @@ class TextField extends Component {
     disabled: PropTypes.bool,
     readOnly: PropTypes.bool,
     required: PropTypes.bool,
+    /**
+     * 'none' | 'both' | 'horizontal' | 'vertical' | 'block' | 'inline'
+     */
     resize: PropTypes.oneOf(['none', 'both', 'horizontal', 'vertical', 'block', 'inline']),
     label: PropTypes.string,
     labelHidden: PropTypes.bool,
@@ -46,6 +49,9 @@ class TextField extends Component {
       PropTypes.node
     ]),
     error: PropTypes.string,
+    /**
+     * Inlines the error message next to the field label. Label prop required.
+     */
     inlineErrors: PropTypes.bool,
     onChange: PropTypes.func,
     onFocus: PropTypes.func,

--- a/stories/TextField.js
+++ b/stories/TextField.js
@@ -25,6 +25,15 @@ export default storiesOf('TextField', module)
     />
   ))
 
+  .addWithInfo('with an inline error', () => (
+    <TextField
+      id='id'
+      label='Name'
+      inlineErrors={true}
+      error='You forgot my name!'
+    />
+  ))
+
   .addWithInfo('multiline', () => (
     <TextField
       id='id'


### PR DESCRIPTION
Fixed size forms suffer "pop" as they reflow when components are shown or hidden conditionally. This PR is meant to deal with some of that in context with the in-app support form.

## Fixed Size TextField
It's tricky to cleanly set `resize: none` on `<textarea />` elements. This PR adds a `resize` prop to mirror the HTML attribute.

### Questions / Issues
 - Use `htmlResize` as prop name to match other React HTML props? (e.g. htmlFor)
 - Default to `resize: none` instead of the current behaviour preserving `resize: both`?

## Inline Errors In TextFields
Fixed size forms containing form components pop when their `Error` components are rendered. To resolve, this PR includes the following:
 - `Error` supports an `inline` prop to force `display: inline`.
 - `Label` components now render their children so we can put errors under `Labels`.
 - `TextArea` supports an `inlineErrors` prop to use inline `Errors` in its `Labels`.

### Questions / Issues
 - Add `inlineErrors` support to other Matchbox form elements?
