### PR TITLE
FAD-5588: Inline errors for TextField

### DIFF
--- a/src/components/Error/Error.js
+++ b/src/components/Error/Error.js
@@ -2,11 +2,14 @@ import React from 'react';
 import { Icon } from '../Icon';
 import styles from './Error.module.scss';
 
-const Error = ({ error, inline }) => {
-  const errorClass = inline ? styles.InlineError : styles.Error;
-  return <div className={errorClass}>
+const Error = (props) => {
+  const {
+    error,
+    wrapper: WrapperComponent = 'div'
+  } = props;
+  return <WrapperComponent className={styles.Error}>
     <span className={styles.Message}><Icon name='Error' className={styles.Icon} size={13} />{ error }</span>
-  </div>;
+  </WrapperComponent>;
 };
 
 Error.displayName = 'Error';

--- a/src/components/Error/Error.module.scss
+++ b/src/components/Error/Error.module.scss
@@ -4,11 +4,6 @@
   padding-top: spacing(small);
 }
 
-.InlineError {
-  padding-left: spacing(small);
-  display: inline;
-}
-
 .Icon {
   float: left;
   margin-right: rem(5);

--- a/src/components/TextField/TextField.js
+++ b/src/components/TextField/TextField.js
@@ -6,6 +6,8 @@ import { Connect } from '../Connect';
 import classnames from 'classnames';
 import styles from './TextField.module.scss';
 
+const InlineErrorWrapper = ({ children }) => <span className={styles.InlineError}>{children}</span>;
+
 class TextField extends Component {
   static displayName = 'TextField';
 
@@ -119,9 +121,11 @@ class TextField extends Component {
       : '';
 
     let labelMarkup;
-    const renderLabel = !labelHidden || inlineErrors;
-    if (label && renderLabel) {
-      const errorMsg = error && inlineErrors ? <Error inline={true} error={error} /> : null;
+    const errorWrapper = inlineErrors ? InlineErrorWrapper : 'div';
+    const renderLabel = label && (!labelHidden || inlineErrors);
+    if (renderLabel) {
+      const renderErrorInLabel = error && inlineErrors;
+      const errorMsg = renderErrorInLabel ? <Error wrapper={errorWrapper} error={error} /> : null;
       labelMarkup = <Label
         id={id}
         label={`${label}${requiredIndicator}`}>

--- a/src/components/TextField/TextField.module.scss
+++ b/src/components/TextField/TextField.module.scss
@@ -16,6 +16,10 @@
   background: rgba(color(red), 0.06);
 }
 
+.InlineError {
+  padding-left: spacing(small);
+}
+
 .Input {
   position: relative;
   display: block;


### PR DESCRIPTION
 - `TextField` accepts `inlineErrors` boolean prop
 - `TextFields` with `inlineErrors=true`:
    - render errors inside their `Labels`
    - give their `Errors` a styled `<span/>` as their wrapper
- `Errors` accept `wrapper` component prop

Added a `TextField` story to demo inline errors.