### PR TITLE
Fix height of a connected select

### DIFF
--- a/src/components/Select/Select.module.scss
+++ b/src/components/Select/Select.module.scss
@@ -55,6 +55,14 @@
   }
 }
 
+// Firefox doesn't respect line-height of <select>
+// @see https://bugzilla.mozilla.org/show_bug.cgi?id=1241167
+@-moz-document url-prefix() {
+  .Input {
+    height: rem(36);
+  }
+}
+
 .Dropdown {
   position: absolute;
   z-index: 1;


### PR DESCRIPTION
Firefox / Chrome
<img width="1385" alt="screen shot 2018-01-27 at 10 22 19 am" src="https://user-images.githubusercontent.com/1335605/35474114-a4da6f18-0357-11e8-860b-3499422e4817.png">
