### PR TITLE
FAD-6286: resizable Snackbar, numeric Select values

### DIFF
--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -33,7 +33,7 @@ class Select extends Component {
     options: PropTypes.arrayOf(
       PropTypes.oneOfType([
         PropTypes.shape({
-          value: PropTypes.string.isRequired,
+          value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
           label: PropTypes.string.isRequired
         }),
         PropTypes.string.isRequired,

--- a/src/components/Snackbar/Snackbar.js
+++ b/src/components/Snackbar/Snackbar.js
@@ -15,6 +15,11 @@ class Snackbar extends Component {
     status: PropTypes.oneOf(['default', 'success', 'danger']),
 
     /**
+     * Snackbar max-width in rem.
+     */
+    maxWidth: PropTypes.number,
+
+    /**
      * Callback when dismiss button is clicked.
      */
     onDismiss: PropTypes.func.isRequired,
@@ -29,13 +34,15 @@ class Snackbar extends Component {
   };
 
   static defaultProps = {
-    status: 'default'
+    status: 'default',
+    maxWidth: 380
   }
 
   render() {
     const {
       children,
       status,
+      maxWidth,
       onDismiss,
       ...rest
     } = this.props;
@@ -47,7 +54,7 @@ class Snackbar extends Component {
 
     return (
       <div className={snackbarStyles} {...rest}>
-        <div className={styles.Content}>{ children }</div>
+        <div className={styles.Content} style={{ maxWidth }}>{ children }</div>
         <a className={styles.Dismiss} onClick={onDismiss}>
           <Icon name='Close' size={21} className={styles.DismissIcon} />
         </a>

--- a/src/components/Snackbar/Snackbar.js
+++ b/src/components/Snackbar/Snackbar.js
@@ -15,7 +15,7 @@ class Snackbar extends Component {
     status: PropTypes.oneOf(['default', 'success', 'danger']),
 
     /**
-     * Snackbar max-width in rem.
+     * Snackbar max-width in pixels.
      */
     maxWidth: PropTypes.number,
 

--- a/src/components/Snackbar/Snackbar.module.scss
+++ b/src/components/Snackbar/Snackbar.module.scss
@@ -25,7 +25,6 @@
   margin-right: -4px;
   padding: rem(12) spacing();
   min-width: rem(200);
-  max-width: rem(380);
   font-size: rem(16);
   font-weight: 500;
 

--- a/stories/Select.js
+++ b/stories/Select.js
@@ -9,7 +9,7 @@ import { Select } from '../src';
 const options = ['Foo', 2, 'Bar'];
 const options2 = [
   {
-    value: '1',
+    value: 1,
     label: 'One',
     pass: 'through'
   },

--- a/stories/Snackbar.js
+++ b/stories/Snackbar.js
@@ -22,4 +22,8 @@ export default storiesOf('Snackbar', module)
 
   .add('Danger', withInfo()(() => (
     <Snackbar status='danger' onDismiss={action('Dismissed')}>Template deleted</Snackbar>
+  )))
+
+  .add('Large', withInfo()(() => (
+    <Snackbar maxWidth={700}>This one is large enough to get into some bacon ipsum dolor amet pork loin tri-tip turkey capicola. Rump doner short ribs biltong burgdoggen meatloaf. Prosciutto pork loin bacon, biltong landjaeger salami ham spare ribs flank cupim porchetta leberkas.</Snackbar>
   )));


### PR DESCRIPTION
 - Adds optional `maxWidth` prop to Snackbar for large chunks of text
 - Addresses #113 