### PR TITLE
Create NotificationsUnread.js

### DIFF
--- a/packages/matchbox-icons/src/icons/NotificationsUnread.js
+++ b/packages/matchbox-icons/src/icons/NotificationsUnread.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { createSvgIcon } from '../IconBase';
+
+export default createSvgIcon(
+  <g transform="translate(4.000000, 1.000000)">
+    <path d="M8,21 C9.1,21 10,20.1 10,19 L6,19 C6,20.1 6.89,21 8,21 Z M6.00263347,3.82050695 C3.44243033,4.66541678 2,7.10262748 2,10 L2,15 L0,17 L0,18 L16,18 L16,17 L14,15 L14,10 C14,9.88627792 13.9977496,9.77324193 13.9932702,9.66096269 C13.3696151,9.88055264 12.6987568,10 12,10 C8.6862915,10 6,7.3137085 6,4 C6,3.93995892 6.0008819,3.88012382 6.00263347,3.82050695 Z" id="Bell"></path>
+    <circle id="Signal" fill="currentColor" cx="12" cy="4" r="4"></circle>
+  </g>,
+  'NotificationsUnread'
+);


### PR DESCRIPTION
This creates the following version of a Notifications series icon (adapted from the material icons "Notifications" bell icon):

<img width="213" alt="screenshot 2018-05-08 22 03 59" src="https://user-images.githubusercontent.com/159370/39791864-ccd1475e-530b-11e8-99d8-abe16657a441.png">

But splits up the "dot" into a separate SVG path which has `fill: "currentColor"` applied inline. The effect is that by default, it will all be the "currentColor" value, but if you override the icon level's "fill" with a different color, the dot will stay colored with the "color" value.

Like this:

<img width="84" alt="screenshot 2018-05-08 22 06 04" src="https://user-images.githubusercontent.com/159370/39791912-0c2f3712-530c-11e8-85a5-826c809ccb65.png">

which happens by applying the following styles to the icon (however you apply CSS, this example uses an SCSS color method):

```css
  fill: black;
  color: color(blue);
```
