### PR TITLE
Declarative action list sections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,10 +19,10 @@
       "dev": true,
       "requires": {
         "@babel/types": "7.0.0-beta.44",
-        "jsesc": "2.5.1",
-        "lodash": "4.17.10",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
+        "jsesc": "^2.5.1",
+        "lodash": "^4.2.0",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
       },
       "dependencies": {
         "jsesc": {
@@ -74,9 +74,9 @@
       "integrity": "sha512-r4snW6Q8ICL3Y8hGzYJRvyG/+sc+kvkewXNedG9tQjoHmUFMwMSv/o45GWQUQswevGnWghiGkpRPivFfOuMsOA==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.0"
       }
     },
     "@babel/template": {
@@ -88,7 +88,7 @@
         "@babel/code-frame": "7.0.0-beta.44",
         "@babel/types": "7.0.0-beta.44",
         "babylon": "7.0.0-beta.44",
-        "lodash": "4.17.10"
+        "lodash": "^4.2.0"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -106,9 +106,9 @@
           "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
           "dev": true,
           "requires": {
-            "chalk": "2.3.0",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.0"
           }
         },
         "babylon": {
@@ -131,10 +131,10 @@
         "@babel/helper-split-export-declaration": "7.0.0-beta.44",
         "@babel/types": "7.0.0-beta.44",
         "babylon": "7.0.0-beta.44",
-        "debug": "3.1.0",
-        "globals": "11.5.0",
-        "invariant": "2.2.4",
-        "lodash": "4.17.10"
+        "debug": "^3.1.0",
+        "globals": "^11.1.0",
+        "invariant": "^2.2.0",
+        "lodash": "^4.2.0"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -152,9 +152,9 @@
           "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
           "dev": true,
           "requires": {
-            "chalk": "2.3.0",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.0"
           }
         },
         "babylon": {
@@ -186,9 +186,9 @@
       "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2",
-        "lodash": "4.17.10",
-        "to-fast-properties": "2.0.0"
+        "esutils": "^2.0.2",
+        "lodash": "^4.2.0",
+        "to-fast-properties": "^2.0.0"
       },
       "dependencies": {
         "to-fast-properties": {
@@ -206,15 +206,15 @@
       "dev": true,
       "requires": {
         "@storybook/components": "3.4.3",
-        "babel-runtime": "6.26.0",
-        "deep-equal": "1.0.1",
-        "glamor": "2.20.40",
-        "glamorous": "4.12.5",
-        "global": "4.3.2",
-        "make-error": "1.3.4",
-        "prop-types": "15.6.1",
-        "react-inspector": "2.3.0",
-        "uuid": "3.2.1"
+        "babel-runtime": "^6.26.0",
+        "deep-equal": "^1.0.1",
+        "glamor": "^2.20.40",
+        "glamorous": "^4.12.1",
+        "global": "^4.3.2",
+        "make-error": "^1.3.4",
+        "prop-types": "^15.6.1",
+        "react-inspector": "^2.2.2",
+        "uuid": "^3.2.1"
       },
       "dependencies": {
         "uuid": {
@@ -233,15 +233,15 @@
       "requires": {
         "@storybook/client-logger": "3.4.3",
         "@storybook/components": "3.4.3",
-        "babel-runtime": "6.26.0",
-        "glamor": "2.20.40",
-        "glamorous": "4.12.5",
-        "global": "4.3.2",
-        "marksy": "6.0.3",
-        "nested-object-assign": "1.0.2",
-        "prop-types": "15.6.1",
-        "react-addons-create-fragment": "15.6.2",
-        "util-deprecate": "1.0.2"
+        "babel-runtime": "^6.26.0",
+        "glamor": "^2.20.40",
+        "glamorous": "^4.12.1",
+        "global": "^4.3.2",
+        "marksy": "^6.0.3",
+        "nested-object-assign": "^1.0.1",
+        "prop-types": "^15.6.1",
+        "react-addons-create-fragment": "^15.5.3",
+        "util-deprecate": "^1.0.2"
       }
     },
     "@storybook/addon-links": {
@@ -251,9 +251,9 @@
       "dev": true,
       "requires": {
         "@storybook/components": "3.4.3",
-        "babel-runtime": "6.26.0",
-        "global": "4.3.2",
-        "prop-types": "15.6.1"
+        "babel-runtime": "^6.26.0",
+        "global": "^4.3.2",
+        "prop-types": "^15.6.1"
       }
     },
     "@storybook/addon-options": {
@@ -262,7 +262,7 @@
       "integrity": "sha512-FGNS0GjpxcokIXjpnL9v3UQf1rIQuGQX46FUvIt0dIjeNnjumonsOKcg3WGb8oNN5RS1e79Gccsk2s02EDgrGg==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.26.0"
       }
     },
     "@storybook/addons": {
@@ -278,8 +278,8 @@
       "dev": true,
       "requires": {
         "@storybook/channels": "3.4.3",
-        "global": "4.3.2",
-        "json-stringify-safe": "5.0.1"
+        "global": "^4.3.2",
+        "json-stringify-safe": "^5.0.1"
       }
     },
     "@storybook/channels": {
@@ -300,9 +300,9 @@
       "integrity": "sha512-++sBqTD6V6nZ5EaY8ecW+rMtgLEQBP18d2b2OYAdMuDffIKL7olfcgmlW9bchm40zLecbV5TGTjZFGbXXJ4sWw==",
       "dev": true,
       "requires": {
-        "glamor": "2.20.40",
-        "glamorous": "4.12.5",
-        "prop-types": "15.6.1"
+        "glamor": "^2.20.40",
+        "glamorous": "^4.12.1",
+        "prop-types": "^15.6.1"
       }
     },
     "@storybook/core": {
@@ -316,28 +316,28 @@
         "@storybook/client-logger": "3.4.3",
         "@storybook/node-logger": "3.4.3",
         "@storybook/ui": "3.4.3",
-        "autoprefixer": "7.2.6",
-        "babel-runtime": "6.26.0",
-        "chalk": "2.4.1",
-        "commander": "2.15.1",
-        "css-loader": "0.28.11",
-        "dotenv": "5.0.1",
-        "events": "2.0.0",
-        "express": "4.16.3",
-        "file-loader": "1.1.11",
-        "global": "4.3.2",
-        "json-loader": "0.5.7",
-        "postcss-flexbugs-fixes": "3.3.1",
-        "postcss-loader": "2.1.5",
-        "prop-types": "15.6.1",
-        "qs": "6.5.2",
-        "serve-favicon": "2.5.0",
-        "shelljs": "0.8.2",
-        "style-loader": "0.20.3",
-        "url-loader": "0.6.2",
-        "webpack": "3.11.0",
-        "webpack-dev-middleware": "1.12.2",
-        "webpack-hot-middleware": "2.22.1"
+        "autoprefixer": "^7.2.6",
+        "babel-runtime": "^6.26.0",
+        "chalk": "^2.3.2",
+        "commander": "^2.15.0",
+        "css-loader": "^0.28.11",
+        "dotenv": "^5.0.1",
+        "events": "^2.0.0",
+        "express": "^4.16.3",
+        "file-loader": "^1.1.11",
+        "global": "^4.3.2",
+        "json-loader": "^0.5.7",
+        "postcss-flexbugs-fixes": "^3.2.0",
+        "postcss-loader": "^2.1.2",
+        "prop-types": "^15.6.1",
+        "qs": "^6.5.1",
+        "serve-favicon": "^2.4.5",
+        "shelljs": "^0.8.1",
+        "style-loader": "^0.20.3",
+        "url-loader": "^0.6.2",
+        "webpack": "^3.11.0",
+        "webpack-dev-middleware": "^1.12.2",
+        "webpack-hot-middleware": "^2.22.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -346,7 +346,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "^1.9.0"
           }
         },
         "autoprefixer": {
@@ -355,12 +355,12 @@
           "integrity": "sha512-Iq8TRIB+/9eQ8rbGhcP7ct5cYb/3qjNYAR2SnzLCEcwF6rvVOax8+9+fccgXk4bEhQGjOZd5TLhsksmAdsbGqQ==",
           "dev": true,
           "requires": {
-            "browserslist": "2.11.3",
-            "caniuse-lite": "1.0.30000833",
-            "normalize-range": "0.1.2",
-            "num2fraction": "1.2.2",
-            "postcss": "6.0.22",
-            "postcss-value-parser": "3.3.0"
+            "browserslist": "^2.11.3",
+            "caniuse-lite": "^1.0.30000805",
+            "normalize-range": "^0.1.2",
+            "num2fraction": "^1.2.2",
+            "postcss": "^6.0.17",
+            "postcss-value-parser": "^3.2.3"
           }
         },
         "chalk": {
@@ -369,9 +369,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "has-flag": {
@@ -386,8 +386,8 @@
           "integrity": "sha512-2I7AVP73MvK33U7B9TKlYZAqdROyMXDYSMvHLX43qy3GCOaJNiV6i0v/sv9idWIaQ42Yn2dNv79Q5mKXbKhAZg==",
           "dev": true,
           "requires": {
-            "loader-utils": "1.1.0",
-            "schema-utils": "0.4.5"
+            "loader-utils": "^1.1.0",
+            "schema-utils": "^0.4.5"
           }
         },
         "supports-color": {
@@ -396,7 +396,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -407,9 +407,9 @@
       "integrity": "sha512-GD4OYJ8GsayVhIg306sfgcKDk9j8YfuSKIAWvdB/g7IDlw0pDgueONALVEEE2XWJtCwcsUyDtCYzXFgCBWLEjA==",
       "dev": true,
       "requires": {
-        "@storybook/react-komposer": "2.0.4",
-        "@storybook/react-simple-di": "1.3.0",
-        "babel-runtime": "6.26.0"
+        "@storybook/react-komposer": "^2.0.1",
+        "@storybook/react-simple-di": "^1.2.1",
+        "babel-runtime": "6.x.x"
       }
     },
     "@storybook/node-logger": {
@@ -418,7 +418,7 @@
       "integrity": "sha512-RpHpWoo+HpR2yGyhzbQN22x3aoeAtADz+G4e7kwC11q/yaFawdQSMIAhIMGOpQLl1G+ojx+uCLU5HWDHb864bA==",
       "dev": true,
       "requires": {
-        "npmlog": "4.1.2"
+        "npmlog": "^4.1.2"
       }
     },
     "@storybook/podda": {
@@ -427,8 +427,8 @@
       "integrity": "sha512-g7dsdsn50AhlGZ8iIDKdF8bi7Am++iFOq+QN+hNKz3FvgLuf8Dz+mpC/BFl90eE9bEYxXqXKeMf87399Ec5Qhw==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "immutable": "3.8.2"
+        "babel-runtime": "^6.11.6",
+        "immutable": "^3.8.1"
       }
     },
     "@storybook/react": {
@@ -445,37 +445,37 @@
         "@storybook/core": "3.4.3",
         "@storybook/node-logger": "3.4.3",
         "@storybook/ui": "3.4.3",
-        "airbnb-js-shims": "1.4.1",
-        "babel-loader": "7.1.4",
-        "babel-plugin-macros": "2.2.0",
-        "babel-plugin-react-docgen": "1.9.0",
-        "babel-plugin-transform-regenerator": "6.26.0",
-        "babel-plugin-transform-runtime": "6.23.0",
-        "babel-preset-env": "1.6.1",
-        "babel-preset-minify": "0.3.0",
-        "babel-preset-react": "6.24.1",
-        "babel-preset-stage-0": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "case-sensitive-paths-webpack-plugin": "2.1.2",
-        "common-tags": "1.7.2",
-        "core-js": "2.5.6",
-        "dotenv-webpack": "1.5.5",
-        "find-cache-dir": "1.0.0",
-        "glamor": "2.20.40",
-        "glamorous": "4.12.5",
-        "global": "4.3.2",
-        "html-loader": "0.5.5",
-        "html-webpack-plugin": "2.30.1",
-        "json5": "0.5.1",
-        "lodash.flattendeep": "4.4.0",
-        "markdown-loader": "2.0.2",
-        "prop-types": "15.6.1",
-        "react-dev-utils": "5.0.1",
-        "redux": "3.7.2",
-        "uglifyjs-webpack-plugin": "1.2.5",
-        "util-deprecate": "1.0.2",
-        "webpack": "3.11.0",
-        "webpack-hot-middleware": "2.22.1"
+        "airbnb-js-shims": "^1.4.1",
+        "babel-loader": "^7.1.4",
+        "babel-plugin-macros": "^2.2.0",
+        "babel-plugin-react-docgen": "^1.9.0",
+        "babel-plugin-transform-regenerator": "^6.26.0",
+        "babel-plugin-transform-runtime": "^6.23.0",
+        "babel-preset-env": "^1.6.1",
+        "babel-preset-minify": "^0.3.0",
+        "babel-preset-react": "^6.24.1",
+        "babel-preset-stage-0": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "case-sensitive-paths-webpack-plugin": "^2.1.2",
+        "common-tags": "^1.7.2",
+        "core-js": "^2.5.3",
+        "dotenv-webpack": "^1.5.5",
+        "find-cache-dir": "^1.0.0",
+        "glamor": "^2.20.40",
+        "glamorous": "^4.12.1",
+        "global": "^4.3.2",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^2.30.1",
+        "json5": "^0.5.1",
+        "lodash.flattendeep": "^4.4.0",
+        "markdown-loader": "^2.0.2",
+        "prop-types": "^15.6.1",
+        "react-dev-utils": "^5.0.0",
+        "redux": "^3.7.2",
+        "uglifyjs-webpack-plugin": "^1.2.4",
+        "util-deprecate": "^1.0.2",
+        "webpack": "^3.11.0",
+        "webpack-hot-middleware": "^2.22.1"
       },
       "dependencies": {
         "core-js": {
@@ -492,11 +492,11 @@
       "integrity": "sha1-wsDUp12bSpwMa0bxSrBQ9FitS7A=",
       "dev": true,
       "requires": {
-        "@storybook/react-stubber": "1.0.1",
-        "babel-runtime": "6.26.0",
-        "hoist-non-react-statics": "1.2.0",
-        "lodash.pick": "4.4.0",
-        "shallowequal": "0.2.2"
+        "@storybook/react-stubber": "^1.0.0",
+        "babel-runtime": "^6.11.6",
+        "hoist-non-react-statics": "^1.2.0",
+        "lodash.pick": "^4.4.0",
+        "shallowequal": "^0.2.2"
       }
     },
     "@storybook/react-simple-di": {
@@ -505,10 +505,10 @@
       "integrity": "sha512-RH6gPQaYMs/VzQX2dgbZU8DQMKFXVOv1ruohHjjNPys4q+YdqMFMDe5jOP1AUE3j9g01x0eW7bVjRawSpl++Ew==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "create-react-class": "15.6.3",
-        "hoist-non-react-statics": "1.2.0",
-        "prop-types": "15.6.1"
+        "babel-runtime": "6.x.x",
+        "create-react-class": "^15.6.2",
+        "hoist-non-react-statics": "1.x.x",
+        "prop-types": "^15.6.0"
       }
     },
     "@storybook/react-stubber": {
@@ -517,7 +517,7 @@
       "integrity": "sha512-k+CHH+vA8bQfCmzBTtJsPkITFgD+C/w19KuByZ9WeEvNUFtnDaCqfP+Vp3/OR+3IAfAXYYOWolqPLxNPcEqEjw==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.5.0"
       }
     },
     "@storybook/storybook-deployer": {
@@ -526,10 +526,10 @@
       "integrity": "sha512-islhy4R8i8sxdLD71X2Wy1wo5ZgsDCVqHVN91+1lB+zAOweLTi1aQm2dcRh+me65jAopkJdFjmbiQ2TVgjAo2w==",
       "dev": true,
       "requires": {
-        "git-url-parse": "8.3.1",
-        "parse-repo": "1.0.4",
-        "shelljs": "0.8.2",
-        "yargs": "11.0.0"
+        "git-url-parse": "^8.1.0",
+        "parse-repo": "^1.0.4",
+        "shelljs": "^0.8.1",
+        "yargs": "^11.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -550,9 +550,9 @@
           "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "dev": true,
           "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "strip-ansi": {
@@ -561,7 +561,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "yargs": {
@@ -570,18 +570,18 @@
           "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
           "dev": true,
           "requires": {
-            "cliui": "4.1.0",
-            "decamelize": "1.2.0",
-            "find-up": "2.1.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "9.0.2"
+            "cliui": "^4.0.0",
+            "decamelize": "^1.1.1",
+            "find-up": "^2.1.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^9.0.2"
           }
         },
         "yargs-parser": {
@@ -590,7 +590,7 @@
           "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0"
+            "camelcase": "^4.1.0"
           }
         }
       }
@@ -602,26 +602,26 @@
       "dev": true,
       "requires": {
         "@storybook/components": "3.4.3",
-        "@storybook/mantra-core": "1.7.2",
-        "@storybook/podda": "1.2.3",
-        "@storybook/react-komposer": "2.0.4",
-        "babel-runtime": "6.26.0",
-        "deep-equal": "1.0.1",
-        "events": "2.0.0",
-        "fuse.js": "3.2.0",
-        "global": "4.3.2",
-        "keycode": "2.2.0",
-        "lodash.debounce": "4.0.8",
-        "lodash.pick": "4.4.0",
-        "lodash.sortby": "4.7.0",
-        "lodash.throttle": "4.1.1",
-        "prop-types": "15.6.1",
-        "qs": "6.5.2",
-        "react-fuzzy": "0.5.2",
-        "react-icons": "2.2.7",
-        "react-modal": "3.4.4",
-        "react-split-pane": "0.1.77",
-        "react-treebeard": "2.1.0"
+        "@storybook/mantra-core": "^1.7.2",
+        "@storybook/podda": "^1.2.3",
+        "@storybook/react-komposer": "^2.0.3",
+        "babel-runtime": "^6.26.0",
+        "deep-equal": "^1.0.1",
+        "events": "^2.0.0",
+        "fuse.js": "^3.2.0",
+        "global": "^4.3.2",
+        "keycode": "^2.1.9",
+        "lodash.debounce": "^4.0.8",
+        "lodash.pick": "^4.4.0",
+        "lodash.sortby": "^4.7.0",
+        "lodash.throttle": "^4.1.1",
+        "prop-types": "^15.6.1",
+        "qs": "^6.5.1",
+        "react-fuzzy": "^0.5.2",
+        "react-icons": "^2.2.7",
+        "react-modal": "^3.3.2",
+        "react-split-pane": "^0.1.77",
+        "react-treebeard": "^2.1.0"
       }
     },
     "@types/node": {
@@ -636,8 +636,8 @@
       "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
       "dev": true,
       "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
       }
     },
     "abab": {
@@ -658,7 +658,7 @@
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "dev": true,
       "requires": {
-        "mime-types": "2.1.18",
+        "mime-types": "~2.1.18",
         "negotiator": "0.6.1"
       }
     },
@@ -674,7 +674,7 @@
       "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
       "dev": true,
       "requires": {
-        "acorn": "4.0.13"
+        "acorn": "^4.0.3"
       },
       "dependencies": {
         "acorn": {
@@ -691,7 +691,7 @@
       "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.5.3"
+        "acorn": "^5.0.0"
       }
     },
     "acorn-jsx": {
@@ -700,7 +700,7 @@
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0"
+        "acorn": "^3.0.4"
       },
       "dependencies": {
         "acorn": {
@@ -729,18 +729,18 @@
       "integrity": "sha512-b7S3d+DPRMwaDAs0cgKQTMLO/JG/iSehIlzEGvt2FpxIztRDDABEjWI73AfTxkSiK3/OsraPRYxVNAX3yhSNLw==",
       "dev": true,
       "requires": {
-        "array-includes": "3.0.3",
-        "array.prototype.flatmap": "1.2.1",
-        "array.prototype.flatten": "1.2.1",
-        "es5-shim": "4.5.10",
-        "es6-shim": "0.35.3",
-        "function.prototype.name": "1.1.0",
-        "object.entries": "1.0.4",
-        "object.getownpropertydescriptors": "2.0.3",
-        "object.values": "1.0.4",
-        "promise.prototype.finally": "3.1.0",
-        "string.prototype.padend": "3.0.0",
-        "string.prototype.padstart": "3.0.0"
+        "array-includes": "^3.0.3",
+        "array.prototype.flatmap": "^1.2.0",
+        "array.prototype.flatten": "^1.2.0",
+        "es5-shim": "^4.5.10",
+        "es6-shim": "^0.35.3",
+        "function.prototype.name": "^1.1.0",
+        "object.entries": "^1.0.4",
+        "object.getownpropertydescriptors": "^2.0.3",
+        "object.values": "^1.0.4",
+        "promise.prototype.finally": "^3.1.0",
+        "string.prototype.padend": "^3.0.0",
+        "string.prototype.padstart": "^3.0.0"
       }
     },
     "ajv": {
@@ -749,10 +749,10 @@
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "dev": true,
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.1.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       }
     },
     "ajv-keywords": {
@@ -767,9 +767,9 @@
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       }
     },
     "alphanum-sort": {
@@ -808,7 +808,7 @@
       "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
       "dev": true,
       "requires": {
-        "color-convert": "1.9.0"
+        "color-convert": "^1.9.0"
       }
     },
     "any-observable": {
@@ -823,8 +823,8 @@
       "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
       "dev": true,
       "requires": {
-        "micromatch": "3.1.10",
-        "normalize-path": "2.1.1"
+        "micromatch": "^3.1.4",
+        "normalize-path": "^2.1.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -845,16 +845,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0",
-            "array-unique": "0.3.2",
-            "extend-shallow": "2.0.1",
-            "fill-range": "4.0.0",
-            "isobject": "3.0.1",
-            "repeat-element": "1.1.2",
-            "snapdragon": "0.8.2",
-            "snapdragon-node": "2.1.1",
-            "split-string": "3.1.0",
-            "to-regex": "3.0.2"
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -863,7 +863,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -874,13 +874,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "posix-character-classes": "0.1.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -889,7 +889,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             },
             "extend-shallow": {
@@ -898,7 +898,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             },
             "is-accessor-descriptor": {
@@ -907,7 +907,7 @@
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -916,7 +916,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -927,7 +927,7 @@
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -936,7 +936,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -947,9 +947,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
               }
             },
             "kind-of": {
@@ -966,14 +966,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "0.3.2",
-            "define-property": "1.0.0",
-            "expand-brackets": "2.1.4",
-            "extend-shallow": "2.0.1",
-            "fragment-cache": "0.2.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -982,7 +982,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "1.0.2"
+                "is-descriptor": "^1.0.0"
               }
             },
             "extend-shallow": {
@@ -991,7 +991,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -1002,10 +1002,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-number": "3.0.0",
-            "repeat-string": "1.6.1",
-            "to-regex-range": "2.1.1"
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
           },
           "dependencies": {
             "extend-shallow": {
@@ -1014,7 +1014,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -1025,7 +1025,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -1034,7 +1034,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -1043,9 +1043,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "is-number": {
@@ -1054,7 +1054,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -1063,7 +1063,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -1086,19 +1086,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "braces": "2.3.2",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "extglob": "2.0.4",
-            "fragment-cache": "0.2.1",
-            "kind-of": "6.0.2",
-            "nanomatch": "1.2.9",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
           }
         }
       }
@@ -1115,7 +1115,7 @@
       "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
       "dev": true,
       "requires": {
-        "default-require-extensions": "1.0.0"
+        "default-require-extensions": "^1.0.0"
       }
     },
     "aproba": {
@@ -1130,8 +1130,8 @@
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "dev": true,
       "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.3"
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
       }
     },
     "argparse": {
@@ -1140,7 +1140,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "aria-query": {
@@ -1150,7 +1150,7 @@
       "dev": true,
       "requires": {
         "ast-types-flow": "0.0.7",
-        "commander": "2.15.1"
+        "commander": "^2.11.0"
       }
     },
     "arr-diff": {
@@ -1159,7 +1159,7 @@
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0"
+        "arr-flatten": "^1.0.1"
       }
     },
     "arr-flatten": {
@@ -1216,8 +1216,8 @@
       "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.11.0"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.7.0"
       }
     },
     "array-map": {
@@ -1238,7 +1238,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -1259,9 +1259,9 @@
       "integrity": "sha512-i18e2APdsiezkcqDyZor78Pbfjfds3S94dG6dgIV2ZASJaUf1N0dz2tGdrmwrmlZuNUgxH+wz6Z0zYVH2c5xzQ==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.11.0",
-        "function-bind": "1.1.1"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.10.0",
+        "function-bind": "^1.1.1"
       }
     },
     "array.prototype.flatten": {
@@ -1270,9 +1270,9 @@
       "integrity": "sha512-3GhsA78XgK//wQKbhUe6L93kknekGlTRY0kvYcpuSi0aa9rVrMr/okeIIv/XSpN8fZ5iUM+bWifhf2/7CYKtIg==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.11.0",
-        "function-bind": "1.1.1"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.10.0",
+        "function-bind": "^1.1.1"
       }
     },
     "arrify": {
@@ -1298,9 +1298,9 @@
       "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1"
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "assert": {
@@ -1348,7 +1348,7 @@
       "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "^4.14.0"
       }
     },
     "async-each": {
@@ -1387,12 +1387,12 @@
       "integrity": "sha512-YqUclCBDXUT9Y7aQ8Xv+ja8yhTZYJoMsOD7WS++gZIJLCpCu+gPcKGDlhk6S3WxhLkTcNVdaMZAWys2nzZCH7g==",
       "dev": true,
       "requires": {
-        "browserslist": "3.2.6",
-        "caniuse-lite": "1.0.30000833",
-        "normalize-range": "0.1.2",
-        "num2fraction": "1.2.2",
-        "postcss": "6.0.22",
-        "postcss-value-parser": "3.3.0"
+        "browserslist": "^3.2.6",
+        "caniuse-lite": "^1.0.30000832",
+        "normalize-range": "^0.1.2",
+        "num2fraction": "^1.2.2",
+        "postcss": "^6.0.22",
+        "postcss-value-parser": "^3.2.3"
       },
       "dependencies": {
         "browserslist": {
@@ -1401,8 +1401,8 @@
           "integrity": "sha512-XCsMSg9V4S1VRdcp265dJ+8kBRjfuFXcavbisY7G6T9QI0H1Z24PP53vvs0WDYWqm38Mco1ILDtafcS8ZR4xiw==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "1.0.30000833",
-            "electron-to-chromium": "1.3.45"
+            "caniuse-lite": "^1.0.30000830",
+            "electron-to-chromium": "^1.3.42"
           }
         }
       }
@@ -1434,9 +1434,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -1451,11 +1451,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "supports-color": {
@@ -1472,25 +1472,25 @@
       "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-generator": "6.26.1",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "convert-source-map": "1.5.1",
-        "debug": "2.6.9",
-        "json5": "0.5.1",
-        "lodash": "4.17.10",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.8",
-        "slash": "1.0.0",
-        "source-map": "0.5.7"
+        "babel-code-frame": "^6.26.0",
+        "babel-generator": "^6.26.0",
+        "babel-helpers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "convert-source-map": "^1.5.1",
+        "debug": "^2.6.9",
+        "json5": "^0.5.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4",
+        "path-is-absolute": "^1.0.1",
+        "private": "^0.1.8",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.7"
       },
       "dependencies": {
         "source-map": {
@@ -1511,8 +1511,8 @@
         "@babel/traverse": "7.0.0-beta.44",
         "@babel/types": "7.0.0-beta.44",
         "babylon": "7.0.0-beta.44",
-        "eslint-scope": "3.7.1",
-        "eslint-visitor-keys": "1.0.0"
+        "eslint-scope": "~3.7.1",
+        "eslint-visitor-keys": "^1.0.0"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -1530,9 +1530,9 @@
           "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
           "dev": true,
           "requires": {
-            "chalk": "2.3.0",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.0"
           }
         },
         "babylon": {
@@ -1549,14 +1549,14 @@
       "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
       "dev": true,
       "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.10",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.17.4",
+        "source-map": "^0.5.7",
+        "trim-right": "^1.0.1"
       },
       "dependencies": {
         "source-map": {
@@ -1573,9 +1573,9 @@
       "integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
@@ -1584,9 +1584,9 @@
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
       "dev": true,
       "requires": {
-        "babel-helper-explode-assignable-expression": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-explode-assignable-expression": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-builder-react-jsx": {
@@ -1595,9 +1595,9 @@
       "integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "esutils": "2.0.2"
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "esutils": "^2.0.2"
       }
     },
     "babel-helper-call-delegate": {
@@ -1606,10 +1606,10 @@
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-define-map": {
@@ -1618,10 +1618,10 @@
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.10"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-evaluate-path": {
@@ -1636,9 +1636,9 @@
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-explode-class": {
@@ -1647,10 +1647,10 @@
       "integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
       "dev": true,
       "requires": {
-        "babel-helper-bindify-decorators": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-bindify-decorators": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-flip-expressions": {
@@ -1665,11 +1665,11 @@
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "dev": true,
       "requires": {
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-get-function-arity": {
@@ -1678,8 +1678,8 @@
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-hoist-variables": {
@@ -1688,8 +1688,8 @@
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-is-nodes-equiv": {
@@ -1716,8 +1716,8 @@
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-regex": {
@@ -1726,9 +1726,9 @@
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.10"
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-remap-async-to-generator": {
@@ -1737,11 +1737,11 @@
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-remove-or-void": {
@@ -1756,12 +1756,12 @@
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
       "dev": true,
       "requires": {
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-to-multiple-sequence-expressions": {
@@ -1776,8 +1776,8 @@
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-jest": {
@@ -1786,8 +1786,8 @@
       "integrity": "sha512-BgSjmtl3mW3i+VeVHEr9d2zFSAT66G++pJcHQiUjd00pkW+voYXFctIm/indcqOWWXw5a1nUpR1XWszD9fJ1qg==",
       "dev": true,
       "requires": {
-        "babel-plugin-istanbul": "4.1.6",
-        "babel-preset-jest": "22.4.3"
+        "babel-plugin-istanbul": "^4.1.5",
+        "babel-preset-jest": "^22.4.3"
       }
     },
     "babel-loader": {
@@ -1796,9 +1796,9 @@
       "integrity": "sha512-/hbyEvPzBJuGpk9o80R0ZyTej6heEOr59GoEUtn8qFKbnx4cJm9FWES6J/iv644sYgrtVw9JJQkjaLW/bqb5gw==",
       "dev": true,
       "requires": {
-        "find-cache-dir": "1.0.0",
-        "loader-utils": "1.1.0",
-        "mkdirp": "0.5.1"
+        "find-cache-dir": "^1.0.0",
+        "loader-utils": "^1.0.2",
+        "mkdirp": "^0.5.1"
       }
     },
     "babel-messages": {
@@ -1807,7 +1807,7 @@
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-check-es2015-constants": {
@@ -1816,7 +1816,7 @@
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-dynamic-import-node": {
@@ -1825,9 +1825,9 @@
       "integrity": "sha512-tTfZbM9Ecwj3GK50mnPrUpinTwA4xXmDiQGCk/aBYbvl1+X8YqldK86wZ1owVJ4u3mrKbRlXMma80J18qwiaTQ==",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-dynamic-import": "6.18.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-plugin-syntax-dynamic-import": "^6.18.0",
+        "babel-template": "^6.26.0",
+        "babel-types": "^6.26.0"
       }
     },
     "babel-plugin-istanbul": {
@@ -1836,10 +1836,10 @@
       "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-object-rest-spread": "6.13.0",
-        "find-up": "2.1.0",
-        "istanbul-lib-instrument": "1.10.1",
-        "test-exclude": "4.2.1"
+        "babel-plugin-syntax-object-rest-spread": "^6.13.0",
+        "find-up": "^2.1.0",
+        "istanbul-lib-instrument": "^1.10.1",
+        "test-exclude": "^4.2.1"
       }
     },
     "babel-plugin-jest-hoist": {
@@ -1854,7 +1854,7 @@
       "integrity": "sha512-HGdenPU9+WGhg++P65O+6aIdmXx99p58K7VtAtizC3eUHbO4FXfyfK9SCJubylcyKziEB3nMAUDFHeyDUj38eA==",
       "dev": true,
       "requires": {
-        "cosmiconfig": "4.0.0"
+        "cosmiconfig": "^4.0.0"
       },
       "dependencies": {
         "cosmiconfig": {
@@ -1863,10 +1863,10 @@
           "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
           "dev": true,
           "requires": {
-            "is-directory": "0.3.1",
-            "js-yaml": "3.11.0",
-            "parse-json": "4.0.0",
-            "require-from-string": "2.0.2"
+            "is-directory": "^0.3.1",
+            "js-yaml": "^3.9.0",
+            "parse-json": "^4.0.0",
+            "require-from-string": "^2.0.1"
           }
         },
         "parse-json": {
@@ -1875,8 +1875,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.1",
-            "json-parse-better-errors": "1.0.2"
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
           }
         },
         "require-from-string": {
@@ -1893,7 +1893,7 @@
       "integrity": "sha512-MqhSHlxkmgURqj3144qPksbZ/qof1JWdumcbucc4tysFcf3P3V3z3munTevQgKEFNMd8F5/ECGnwb63xogLjAg==",
       "dev": true,
       "requires": {
-        "babel-helper-evaluate-path": "0.3.0"
+        "babel-helper-evaluate-path": "^0.3.0"
       }
     },
     "babel-plugin-minify-constant-folding": {
@@ -1902,7 +1902,7 @@
       "integrity": "sha512-1XeRpx+aY1BuNY6QU/cm6P+FtEi3ar3XceYbmC+4q4W+2Ewq5pL7V68oHg1hKXkBIE0Z4/FjSoHz6vosZLOe/A==",
       "dev": true,
       "requires": {
-        "babel-helper-evaluate-path": "0.3.0"
+        "babel-helper-evaluate-path": "^0.3.0"
       }
     },
     "babel-plugin-minify-dead-code-elimination": {
@@ -1911,10 +1911,10 @@
       "integrity": "sha512-SjM2Fzg85YZz+q/PNJ/HU4O3W98FKFOiP9K5z3sfonlamGOzvZw3Eup2OTiEBsbbqTeY8yzNCAv3qpJRYCgGmw==",
       "dev": true,
       "requires": {
-        "babel-helper-evaluate-path": "0.3.0",
-        "babel-helper-mark-eval-scopes": "0.3.0",
-        "babel-helper-remove-or-void": "0.3.0",
-        "lodash.some": "4.6.0"
+        "babel-helper-evaluate-path": "^0.3.0",
+        "babel-helper-mark-eval-scopes": "^0.3.0",
+        "babel-helper-remove-or-void": "^0.3.0",
+        "lodash.some": "^4.6.0"
       }
     },
     "babel-plugin-minify-flip-comparisons": {
@@ -1923,7 +1923,7 @@
       "integrity": "sha512-B8lK+ekcpSNVH7PZpWDe5nC5zxjRiiT4nTsa6h3QkF3Kk6y9qooIFLemdGlqBq6j0zALEnebvCpw8v7gAdpgnw==",
       "dev": true,
       "requires": {
-        "babel-helper-is-void-0": "0.3.0"
+        "babel-helper-is-void-0": "^0.3.0"
       }
     },
     "babel-plugin-minify-guarded-expressions": {
@@ -1932,7 +1932,7 @@
       "integrity": "sha512-O+6CvF5/Ttsth3LMg4/BhyvVZ82GImeKMXGdVRQGK/8jFiP15EjRpdgFlxv3cnqRjqdYxLCS6r28VfLpb9C/kA==",
       "dev": true,
       "requires": {
-        "babel-helper-flip-expressions": "0.3.0"
+        "babel-helper-flip-expressions": "^0.3.0"
       }
     },
     "babel-plugin-minify-infinity": {
@@ -1947,7 +1947,7 @@
       "integrity": "sha512-PYTonhFWURsfAN8achDwvR5Xgy6EeTClLz+fSgGRqjAIXb0OyFm3/xfccbQviVi1qDXmlSnt6oJhBg8KE4Fn7Q==",
       "dev": true,
       "requires": {
-        "babel-helper-mark-eval-scopes": "0.3.0"
+        "babel-helper-mark-eval-scopes": "^0.3.0"
       }
     },
     "babel-plugin-minify-numeric-literals": {
@@ -1968,9 +1968,9 @@
       "integrity": "sha512-2M16ytQOCqBi7bYMu4DCWn8e6KyFCA108F6+tVrBJxOmm5u2sOmTFEa8s94tR9RHRRNYmcUf+rgidfnzL3ik9Q==",
       "dev": true,
       "requires": {
-        "babel-helper-flip-expressions": "0.3.0",
-        "babel-helper-is-nodes-equiv": "0.0.1",
-        "babel-helper-to-multiple-sequence-expressions": "0.3.0"
+        "babel-helper-flip-expressions": "^0.3.0",
+        "babel-helper-is-nodes-equiv": "^0.0.1",
+        "babel-helper-to-multiple-sequence-expressions": "^0.3.0"
       }
     },
     "babel-plugin-minify-type-constructors": {
@@ -1979,7 +1979,7 @@
       "integrity": "sha512-XRXpvsUCPeVw9YEUw+9vSiugcSZfow81oIJT0yR9s8H4W7yJ6FHbImi5DJHoL8KcDUjYnL9wYASXk/fOkbyR6Q==",
       "dev": true,
       "requires": {
-        "babel-helper-is-void-0": "0.3.0"
+        "babel-helper-is-void-0": "^0.3.0"
       }
     },
     "babel-plugin-react-docgen": {
@@ -1988,9 +1988,9 @@
       "integrity": "sha512-8lQ73p4BL+xcgba03NTiHrddl2X8J6PDMQHPpz73sesrRBf6JtAscQPLIjFWQR/abLokdv81HdshpjYGppOXgA==",
       "dev": true,
       "requires": {
-        "babel-types": "6.26.0",
-        "lodash": "4.17.10",
-        "react-docgen": "3.0.0-beta9"
+        "babel-types": "^6.24.1",
+        "lodash": "^4.17.0",
+        "react-docgen": "^3.0.0-beta11"
       }
     },
     "babel-plugin-syntax-async-functions": {
@@ -2083,9 +2083,9 @@
       "integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
       "dev": true,
       "requires": {
-        "babel-helper-remap-async-to-generator": "6.24.1",
-        "babel-plugin-syntax-async-generators": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-remap-async-to-generator": "^6.24.1",
+        "babel-plugin-syntax-async-generators": "^6.5.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-async-to-generator": {
@@ -2094,9 +2094,9 @@
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
       "dev": true,
       "requires": {
-        "babel-helper-remap-async-to-generator": "6.24.1",
-        "babel-plugin-syntax-async-functions": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-remap-async-to-generator": "^6.24.1",
+        "babel-plugin-syntax-async-functions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-class-constructor-call": {
@@ -2105,9 +2105,9 @@
       "integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-class-constructor-call": "6.18.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-syntax-class-constructor-call": "^6.18.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-class-properties": {
@@ -2116,10 +2116,10 @@
       "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-plugin-syntax-class-properties": "6.13.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-plugin-syntax-class-properties": "^6.8.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-decorators": {
@@ -2128,11 +2128,11 @@
       "integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
       "dev": true,
       "requires": {
-        "babel-helper-explode-class": "6.24.1",
-        "babel-plugin-syntax-decorators": "6.13.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-explode-class": "^6.24.1",
+        "babel-plugin-syntax-decorators": "^6.13.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-do-expressions": {
@@ -2141,8 +2141,8 @@
       "integrity": "sha1-KMyvkoEtlJws0SgfaQyP3EaK6bs=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-do-expressions": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-do-expressions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -2151,7 +2151,7 @@
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -2160,7 +2160,7 @@
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
@@ -2169,11 +2169,11 @@
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.10"
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -2182,15 +2182,15 @@
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
       "dev": true,
       "requires": {
-        "babel-helper-define-map": "6.26.0",
-        "babel-helper-function-name": "6.24.1",
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-define-map": "^6.24.1",
+        "babel-helper-function-name": "^6.24.1",
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
@@ -2199,8 +2199,8 @@
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -2209,7 +2209,7 @@
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
@@ -2218,8 +2218,8 @@
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-for-of": {
@@ -2228,7 +2228,7 @@
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
@@ -2237,9 +2237,9 @@
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-literals": {
@@ -2248,7 +2248,7 @@
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-modules-amd": {
@@ -2257,9 +2257,9 @@
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
@@ -2268,10 +2268,10 @@
       "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-plugin-transform-strict-mode": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-types": "^6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
@@ -2280,9 +2280,9 @@
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-umd": {
@@ -2291,9 +2291,9 @@
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-object-super": {
@@ -2302,8 +2302,8 @@
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
       "dev": true,
       "requires": {
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-runtime": "6.26.0"
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -2312,12 +2312,12 @@
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "dev": true,
       "requires": {
-        "babel-helper-call-delegate": "6.24.1",
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-call-delegate": "^6.24.1",
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
@@ -2326,8 +2326,8 @@
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -2336,7 +2336,7 @@
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
@@ -2345,9 +2345,9 @@
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-template-literals": {
@@ -2356,7 +2356,7 @@
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
@@ -2365,7 +2365,7 @@
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
@@ -2374,9 +2374,9 @@
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "regexpu-core": "2.0.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "regexpu-core": "^2.0.0"
       }
     },
     "babel-plugin-transform-exponentiation-operator": {
@@ -2385,9 +2385,9 @@
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "dev": true,
       "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-export-extensions": {
@@ -2396,8 +2396,8 @@
       "integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-export-extensions": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-export-extensions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-flow-strip-types": {
@@ -2406,8 +2406,8 @@
       "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-flow": "6.18.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-flow": "^6.18.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-function-bind": {
@@ -2416,8 +2416,8 @@
       "integrity": "sha1-xvuOlqwpajELjPjqQBRiQH3fapc=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-function-bind": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-function-bind": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-inline-consecutive-adds": {
@@ -2450,8 +2450,8 @@
       "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-object-rest-spread": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
+        "babel-runtime": "^6.26.0"
       }
     },
     "babel-plugin-transform-property-literals": {
@@ -2460,7 +2460,7 @@
       "integrity": "sha1-pY0Jls8q2vIk986EitHN5M2M8nU=",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2"
+        "esutils": "^2.0.2"
       }
     },
     "babel-plugin-transform-react-constant-elements": {
@@ -2469,7 +2469,7 @@
       "integrity": "sha1-LxGb9NLN1F65uqrldAU8YE9hR90=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-react-display-name": {
@@ -2478,7 +2478,7 @@
       "integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-react-jsx": {
@@ -2487,9 +2487,9 @@
       "integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
       "dev": true,
       "requires": {
-        "babel-helper-builder-react-jsx": "6.26.0",
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-builder-react-jsx": "^6.24.1",
+        "babel-plugin-syntax-jsx": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-react-jsx-self": {
@@ -2498,8 +2498,8 @@
       "integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-jsx": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-react-jsx-source": {
@@ -2508,8 +2508,8 @@
       "integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-jsx": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-regenerator": {
@@ -2518,7 +2518,7 @@
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "dev": true,
       "requires": {
-        "regenerator-transform": "0.10.1"
+        "regenerator-transform": "^0.10.0"
       }
     },
     "babel-plugin-transform-regexp-constructors": {
@@ -2545,7 +2545,7 @@
       "integrity": "sha512-TYGQucc8iP3LJwN3kDZLEz5aa/2KuFrqpT+s8f8NnHsBU1sAgR3y8Opns0xhC+smyDYWscqFCKM1gbkWQOhhnw==",
       "dev": true,
       "requires": {
-        "babel-helper-evaluate-path": "0.3.0"
+        "babel-helper-evaluate-path": "^0.3.0"
       }
     },
     "babel-plugin-transform-runtime": {
@@ -2554,7 +2554,7 @@
       "integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-simplify-comparison-operators": {
@@ -2569,8 +2569,8 @@
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-undefined-to-void": {
@@ -2585,36 +2585,36 @@
       "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
       "dev": true,
       "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-async-to-generator": "6.24.1",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.26.0",
-        "browserslist": "2.11.3",
-        "invariant": "2.2.4",
-        "semver": "5.4.1"
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+        "babel-plugin-transform-async-to-generator": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
+        "babel-plugin-transform-es2015-classes": "^6.23.0",
+        "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-destructuring": "^6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
+        "babel-plugin-transform-es2015-for-of": "^6.23.0",
+        "babel-plugin-transform-es2015-function-name": "^6.22.0",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
+        "babel-plugin-transform-es2015-object-super": "^6.22.0",
+        "babel-plugin-transform-es2015-parameters": "^6.23.0",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
+        "babel-plugin-transform-exponentiation-operator": "^6.22.0",
+        "babel-plugin-transform-regenerator": "^6.22.0",
+        "browserslist": "^2.1.2",
+        "invariant": "^2.2.2",
+        "semver": "^5.3.0"
       }
     },
     "babel-preset-es2015": {
@@ -2623,30 +2623,30 @@
       "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
       "dev": true,
       "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.26.0"
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
+        "babel-plugin-transform-es2015-classes": "^6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "^6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "^6.22.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
+        "babel-plugin-transform-es2015-for-of": "^6.22.0",
+        "babel-plugin-transform-es2015-function-name": "^6.24.1",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
+        "babel-plugin-transform-es2015-object-super": "^6.24.1",
+        "babel-plugin-transform-es2015-parameters": "^6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
+        "babel-plugin-transform-regenerator": "^6.24.1"
       }
     },
     "babel-preset-flow": {
@@ -2655,7 +2655,7 @@
       "integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-flow-strip-types": "6.22.0"
+        "babel-plugin-transform-flow-strip-types": "^6.22.0"
       }
     },
     "babel-preset-jest": {
@@ -2664,8 +2664,8 @@
       "integrity": "sha512-a+M3LTEXTq3gxv0uBN9Qm6ahUl7a8pj923nFbCUdqFUSsf3YrX8Uc+C3MEwji5Af3LiQjSC7w4ooYewlz8HRTA==",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "22.4.3",
-        "babel-plugin-syntax-object-rest-spread": "6.13.0"
+        "babel-plugin-jest-hoist": "^22.4.3",
+        "babel-plugin-syntax-object-rest-spread": "^6.13.0"
       }
     },
     "babel-preset-minify": {
@@ -2674,29 +2674,29 @@
       "integrity": "sha512-+VV2GWEyak3eDOmzT1DDMuqHrw3VbE9nBNkx2LLVs4pH/Me32ND8DRpVDd8IRvk1xX5p75nygyRPtkMh6GIAbQ==",
       "dev": true,
       "requires": {
-        "babel-plugin-minify-builtins": "0.3.0",
-        "babel-plugin-minify-constant-folding": "0.3.0",
-        "babel-plugin-minify-dead-code-elimination": "0.3.0",
-        "babel-plugin-minify-flip-comparisons": "0.3.0",
-        "babel-plugin-minify-guarded-expressions": "0.3.0",
-        "babel-plugin-minify-infinity": "0.3.0",
-        "babel-plugin-minify-mangle-names": "0.3.0",
-        "babel-plugin-minify-numeric-literals": "0.3.0",
-        "babel-plugin-minify-replace": "0.3.0",
-        "babel-plugin-minify-simplify": "0.3.0",
-        "babel-plugin-minify-type-constructors": "0.3.0",
-        "babel-plugin-transform-inline-consecutive-adds": "0.3.0",
-        "babel-plugin-transform-member-expression-literals": "6.9.2",
-        "babel-plugin-transform-merge-sibling-variables": "6.9.2",
-        "babel-plugin-transform-minify-booleans": "6.9.2",
-        "babel-plugin-transform-property-literals": "6.9.2",
-        "babel-plugin-transform-regexp-constructors": "0.3.0",
-        "babel-plugin-transform-remove-console": "6.9.2",
-        "babel-plugin-transform-remove-debugger": "6.9.2",
-        "babel-plugin-transform-remove-undefined": "0.3.0",
-        "babel-plugin-transform-simplify-comparison-operators": "6.9.2",
-        "babel-plugin-transform-undefined-to-void": "6.9.2",
-        "lodash.isplainobject": "4.0.6"
+        "babel-plugin-minify-builtins": "^0.3.0",
+        "babel-plugin-minify-constant-folding": "^0.3.0",
+        "babel-plugin-minify-dead-code-elimination": "^0.3.0",
+        "babel-plugin-minify-flip-comparisons": "^0.3.0",
+        "babel-plugin-minify-guarded-expressions": "^0.3.0",
+        "babel-plugin-minify-infinity": "^0.3.0",
+        "babel-plugin-minify-mangle-names": "^0.3.0",
+        "babel-plugin-minify-numeric-literals": "^0.3.0",
+        "babel-plugin-minify-replace": "^0.3.0",
+        "babel-plugin-minify-simplify": "^0.3.0",
+        "babel-plugin-minify-type-constructors": "^0.3.0",
+        "babel-plugin-transform-inline-consecutive-adds": "^0.3.0",
+        "babel-plugin-transform-member-expression-literals": "^6.9.0",
+        "babel-plugin-transform-merge-sibling-variables": "^6.9.0",
+        "babel-plugin-transform-minify-booleans": "^6.9.0",
+        "babel-plugin-transform-property-literals": "^6.9.0",
+        "babel-plugin-transform-regexp-constructors": "^0.3.0",
+        "babel-plugin-transform-remove-console": "^6.9.0",
+        "babel-plugin-transform-remove-debugger": "^6.9.0",
+        "babel-plugin-transform-remove-undefined": "^0.3.0",
+        "babel-plugin-transform-simplify-comparison-operators": "^6.9.0",
+        "babel-plugin-transform-undefined-to-void": "^6.9.0",
+        "lodash.isplainobject": "^4.0.6"
       }
     },
     "babel-preset-react": {
@@ -2705,12 +2705,12 @@
       "integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-plugin-transform-react-display-name": "6.25.0",
-        "babel-plugin-transform-react-jsx": "6.24.1",
-        "babel-plugin-transform-react-jsx-self": "6.22.0",
-        "babel-plugin-transform-react-jsx-source": "6.22.0",
-        "babel-preset-flow": "6.23.0"
+        "babel-plugin-syntax-jsx": "^6.3.13",
+        "babel-plugin-transform-react-display-name": "^6.23.0",
+        "babel-plugin-transform-react-jsx": "^6.24.1",
+        "babel-plugin-transform-react-jsx-self": "^6.22.0",
+        "babel-plugin-transform-react-jsx-source": "^6.22.0",
+        "babel-preset-flow": "^6.23.0"
       }
     },
     "babel-preset-react-app": {
@@ -2740,9 +2740,9 @@
       "integrity": "sha1-VkLRUEL5E4TX5a+LyIsduVsDnmo=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-do-expressions": "6.22.0",
-        "babel-plugin-transform-function-bind": "6.22.0",
-        "babel-preset-stage-1": "6.24.1"
+        "babel-plugin-transform-do-expressions": "^6.22.0",
+        "babel-plugin-transform-function-bind": "^6.22.0",
+        "babel-preset-stage-1": "^6.24.1"
       }
     },
     "babel-preset-stage-1": {
@@ -2751,9 +2751,9 @@
       "integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-class-constructor-call": "6.24.1",
-        "babel-plugin-transform-export-extensions": "6.22.0",
-        "babel-preset-stage-2": "6.24.1"
+        "babel-plugin-transform-class-constructor-call": "^6.24.1",
+        "babel-plugin-transform-export-extensions": "^6.22.0",
+        "babel-preset-stage-2": "^6.24.1"
       }
     },
     "babel-preset-stage-2": {
@@ -2762,10 +2762,10 @@
       "integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-dynamic-import": "6.18.0",
-        "babel-plugin-transform-class-properties": "6.24.1",
-        "babel-plugin-transform-decorators": "6.24.1",
-        "babel-preset-stage-3": "6.24.1"
+        "babel-plugin-syntax-dynamic-import": "^6.18.0",
+        "babel-plugin-transform-class-properties": "^6.24.1",
+        "babel-plugin-transform-decorators": "^6.24.1",
+        "babel-preset-stage-3": "^6.24.1"
       }
     },
     "babel-preset-stage-3": {
@@ -2774,11 +2774,11 @@
       "integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-async-generator-functions": "6.24.1",
-        "babel-plugin-transform-async-to-generator": "6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "6.24.1",
-        "babel-plugin-transform-object-rest-spread": "6.26.0"
+        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+        "babel-plugin-transform-async-generator-functions": "^6.24.1",
+        "babel-plugin-transform-async-to-generator": "^6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "^6.24.1",
+        "babel-plugin-transform-object-rest-spread": "^6.22.0"
       }
     },
     "babel-register": {
@@ -2787,13 +2787,13 @@
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.3",
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.6",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.10",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.18"
+        "babel-core": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "home-or-tmp": "^2.0.0",
+        "lodash": "^4.17.4",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.15"
       },
       "dependencies": {
         "core-js": {
@@ -2814,7 +2814,7 @@
           "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
           "dev": true,
           "requires": {
-            "source-map": "0.5.7"
+            "source-map": "^0.5.6"
           }
         }
       }
@@ -2825,8 +2825,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.5",
-        "regenerator-runtime": "0.11.1"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       },
       "dependencies": {
         "core-js": {
@@ -2849,11 +2849,11 @@
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "lodash": "4.17.10"
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-traverse": {
@@ -2862,15 +2862,15 @@
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.9",
-        "globals": "9.18.0",
-        "invariant": "2.2.4",
-        "lodash": "4.17.10"
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
       }
     },
     "babel-types": {
@@ -2879,10 +2879,10 @@
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.10",
-        "to-fast-properties": "1.0.3"
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
       }
     },
     "babylon": {
@@ -2903,13 +2903,13 @@
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
-        "cache-base": "1.0.1",
-        "class-utils": "0.3.6",
-        "component-emitter": "1.2.1",
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "mixin-deep": "1.3.1",
-        "pascalcase": "0.1.1"
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -2918,7 +2918,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -2927,7 +2927,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -2936,7 +2936,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -2945,9 +2945,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "isobject": {
@@ -2977,7 +2977,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "big.js": {
@@ -2998,7 +2998,7 @@
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "~2.0.0"
       }
     },
     "bluebird": {
@@ -3020,15 +3020,15 @@
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "http-errors": "1.6.3",
+        "depd": "~1.1.1",
+        "http-errors": "~1.6.2",
         "iconv-lite": "0.4.19",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "6.5.1",
         "raw-body": "2.3.2",
-        "type-is": "1.6.16"
+        "type-is": "~1.6.15"
       },
       "dependencies": {
         "qs": {
@@ -3051,7 +3051,7 @@
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "dev": true,
       "requires": {
-        "hoek": "4.2.1"
+        "hoek": "4.x.x"
       }
     },
     "bowser": {
@@ -3066,7 +3066,7 @@
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -3076,9 +3076,9 @@
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
       }
     },
     "brcast": {
@@ -3114,12 +3114,12 @@
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
-        "buffer-xor": "1.0.3",
-        "cipher-base": "1.0.4",
-        "create-hash": "1.2.0",
-        "evp_bytestokey": "1.0.3",
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "browserify-cipher": {
@@ -3128,9 +3128,9 @@
       "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "dev": true,
       "requires": {
-        "browserify-aes": "1.2.0",
-        "browserify-des": "1.0.1",
-        "evp_bytestokey": "1.0.3"
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
       }
     },
     "browserify-des": {
@@ -3139,9 +3139,9 @@
       "integrity": "sha512-zy0Cobe3hhgpiOM32Tj7KQ3Vl91m0njwsjzZQK1L+JDf11dzP9qIvjreVinsvXrgfjhStXwUWAEpB9D7Gwmayw==",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "des.js": "1.0.0",
-        "inherits": "2.0.3"
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "browserify-rsa": {
@@ -3150,8 +3150,8 @@
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "randombytes": "^2.0.1"
       }
     },
     "browserify-sign": {
@@ -3160,13 +3160,13 @@
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "elliptic": "6.4.0",
-        "inherits": "2.0.3",
-        "parse-asn1": "5.1.1"
+        "bn.js": "^4.1.1",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^6.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^5.0.0"
       }
     },
     "browserify-zlib": {
@@ -3175,7 +3175,7 @@
       "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "dev": true,
       "requires": {
-        "pako": "1.0.6"
+        "pako": "~1.0.5"
       }
     },
     "browserslist": {
@@ -3184,8 +3184,8 @@
       "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000833",
-        "electron-to-chromium": "1.3.45"
+        "caniuse-lite": "^1.0.30000792",
+        "electron-to-chromium": "^1.3.30"
       }
     },
     "bser": {
@@ -3194,7 +3194,7 @@
       "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
       "dev": true,
       "requires": {
-        "node-int64": "0.4.0"
+        "node-int64": "^0.4.0"
       }
     },
     "buffer": {
@@ -3203,9 +3203,9 @@
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
-        "base64-js": "1.3.0",
-        "ieee754": "1.1.11",
-        "isarray": "1.0.0"
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "buffer-from": {
@@ -3250,19 +3250,19 @@
       "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.1",
-        "chownr": "1.0.1",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "lru-cache": "4.1.1",
-        "mississippi": "2.0.0",
-        "mkdirp": "0.5.1",
-        "move-concurrently": "1.0.1",
-        "promise-inflight": "1.0.1",
-        "rimraf": "2.6.2",
-        "ssri": "5.3.0",
-        "unique-filename": "1.1.0",
-        "y18n": "4.0.0"
+        "bluebird": "^3.5.1",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.1.1",
+        "mississippi": "^2.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.2",
+        "ssri": "^5.2.4",
+        "unique-filename": "^1.1.0",
+        "y18n": "^4.0.0"
       },
       "dependencies": {
         "y18n": {
@@ -3279,15 +3279,15 @@
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
-        "collection-visit": "1.0.0",
-        "component-emitter": "1.2.1",
-        "get-value": "2.0.6",
-        "has-value": "1.0.0",
-        "isobject": "3.0.1",
-        "set-value": "2.0.0",
-        "to-object-path": "0.3.0",
-        "union-value": "1.0.0",
-        "unset-value": "1.0.0"
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
       },
       "dependencies": {
         "isobject": {
@@ -3304,7 +3304,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "0.2.0"
+        "callsites": "^0.2.0"
       },
       "dependencies": {
         "callsites": {
@@ -3327,8 +3327,8 @@
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
       "dev": true,
       "requires": {
-        "no-case": "2.3.2",
-        "upper-case": "1.1.3"
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.1"
       }
     },
     "camelcase": {
@@ -3343,8 +3343,8 @@
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "2.1.1",
-        "map-obj": "1.0.1"
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -3361,10 +3361,10 @@
       "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
       "dev": true,
       "requires": {
-        "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000836",
-        "lodash.memoize": "4.1.2",
-        "lodash.uniq": "4.5.0"
+        "browserslist": "^1.3.6",
+        "caniuse-db": "^1.0.30000529",
+        "lodash.memoize": "^4.1.2",
+        "lodash.uniq": "^4.5.0"
       },
       "dependencies": {
         "browserslist": {
@@ -3373,8 +3373,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000836",
-            "electron-to-chromium": "1.3.45"
+            "caniuse-db": "^1.0.30000639",
+            "electron-to-chromium": "^1.2.7"
           }
         }
       }
@@ -3415,8 +3415,8 @@
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chalk": {
@@ -3425,9 +3425,9 @@
       "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.0",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "4.5.0"
+        "ansi-styles": "^3.1.0",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^4.0.0"
       }
     },
     "chardet": {
@@ -3442,12 +3442,12 @@
       "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
       "dev": true,
       "requires": {
-        "css-select": "1.2.0",
-        "dom-serializer": "0.1.0",
-        "entities": "1.1.1",
-        "htmlparser2": "3.9.2",
-        "lodash": "4.17.10",
-        "parse5": "3.0.3"
+        "css-select": "~1.2.0",
+        "dom-serializer": "~0.1.0",
+        "entities": "~1.1.1",
+        "htmlparser2": "^3.9.1",
+        "lodash": "^4.15.0",
+        "parse5": "^3.0.1"
       }
     },
     "chokidar": {
@@ -3456,18 +3456,18 @@
       "integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
       "dev": true,
       "requires": {
-        "anymatch": "2.0.0",
-        "async-each": "1.0.1",
-        "braces": "2.3.2",
-        "fsevents": "1.2.3",
-        "glob-parent": "3.1.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "4.0.0",
-        "normalize-path": "2.1.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0",
-        "upath": "1.0.5"
+        "anymatch": "^2.0.0",
+        "async-each": "^1.0.0",
+        "braces": "^2.3.0",
+        "fsevents": "^1.1.2",
+        "glob-parent": "^3.1.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "normalize-path": "^2.1.1",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0",
+        "upath": "^1.0.0"
       },
       "dependencies": {
         "array-unique": {
@@ -3482,16 +3482,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0",
-            "array-unique": "0.3.2",
-            "extend-shallow": "2.0.1",
-            "fill-range": "4.0.0",
-            "isobject": "3.0.1",
-            "repeat-element": "1.1.2",
-            "snapdragon": "0.8.2",
-            "snapdragon-node": "2.1.1",
-            "split-string": "3.1.0",
-            "to-regex": "3.0.2"
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
           }
         },
         "extend-shallow": {
@@ -3500,7 +3500,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "fill-range": {
@@ -3509,10 +3509,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-number": "3.0.0",
-            "repeat-string": "1.6.1",
-            "to-regex-range": "2.1.1"
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
           }
         },
         "glob-parent": {
@@ -3521,8 +3521,8 @@
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
-            "is-glob": "3.1.0",
-            "path-dirname": "1.0.2"
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
           },
           "dependencies": {
             "is-glob": {
@@ -3531,7 +3531,7 @@
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "dev": true,
               "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.0"
               }
             }
           }
@@ -3548,7 +3548,7 @@
           "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
           "dev": true,
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.1"
           }
         },
         "is-number": {
@@ -3557,7 +3557,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "isobject": {
@@ -3586,8 +3586,8 @@
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "circular-json": {
@@ -3608,7 +3608,7 @@
       "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3"
+        "chalk": "^1.1.3"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3623,11 +3623,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "supports-color": {
@@ -3644,10 +3644,10 @@
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "static-extend": "0.1.2"
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -3656,7 +3656,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "isobject": {
@@ -3679,7 +3679,7 @@
       "integrity": "sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "0.5.x"
       },
       "dependencies": {
         "source-map": {
@@ -3696,7 +3696,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "2.0.0"
+        "restore-cursor": "^2.0.0"
       }
     },
     "cli-spinners": {
@@ -3712,7 +3712,7 @@
       "dev": true,
       "requires": {
         "slice-ansi": "0.0.4",
-        "string-width": "1.0.2"
+        "string-width": "^1.0.1"
       },
       "dependencies": {
         "slice-ansi": {
@@ -3727,9 +3727,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         }
       }
@@ -3746,8 +3746,8 @@
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "dev": true,
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
       }
     },
@@ -3763,10 +3763,10 @@
       "integrity": "sha512-SZegPTKjCgpQH63E+eN6mVEEPdQBOUzjyJm5Pora4lrwWRFS8I0QAxV/KD6vV/i0WuijHZWQC1fMsPEdxfdVCQ==",
       "dev": true,
       "requires": {
-        "for-own": "1.0.0",
-        "is-plain-object": "2.0.4",
-        "kind-of": "6.0.2",
-        "shallow-clone": "1.0.0"
+        "for-own": "^1.0.0",
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.0",
+        "shallow-clone": "^1.0.0"
       },
       "dependencies": {
         "for-own": {
@@ -3792,8 +3792,8 @@
       "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1"
+        "graceful-fs": "^4.1.2",
+        "mkdirp": "~0.5.0"
       }
     },
     "co": {
@@ -3808,7 +3808,7 @@
       "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
       "dev": true,
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.1.2"
       }
     },
     "code-point-at": {
@@ -3823,8 +3823,8 @@
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "map-visit": "1.0.0",
-        "object-visit": "1.0.1"
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
       }
     },
     "color": {
@@ -3833,9 +3833,9 @@
       "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
       "dev": true,
       "requires": {
-        "clone": "1.0.2",
-        "color-convert": "1.9.0",
-        "color-string": "0.3.0"
+        "clone": "^1.0.2",
+        "color-convert": "^1.3.0",
+        "color-string": "^0.3.0"
       }
     },
     "color-convert": {
@@ -3844,7 +3844,7 @@
       "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
       "dev": true,
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.1.1"
       }
     },
     "color-name": {
@@ -3859,7 +3859,7 @@
       "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
       "dev": true,
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.0.0"
       }
     },
     "colormin": {
@@ -3868,9 +3868,9 @@
       "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
       "dev": true,
       "requires": {
-        "color": "0.11.4",
+        "color": "^0.11.0",
         "css-color-names": "0.0.4",
-        "has": "1.0.1"
+        "has": "^1.0.1"
       }
     },
     "colors": {
@@ -3885,8 +3885,8 @@
       "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
       "dev": true,
       "requires": {
-        "strip-ansi": "3.0.1",
-        "wcwidth": "1.0.1"
+        "strip-ansi": "^3.0.0",
+        "wcwidth": "^1.0.0"
       }
     },
     "combined-stream": {
@@ -3895,7 +3895,7 @@
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "dev": true,
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "command-join": {
@@ -3916,7 +3916,7 @@
       "integrity": "sha512-joj9ZlUOjCrwdbmiLqafeUSgkUM74NqhLsZtSqDmhKudaIY197zTrb8JMl31fMnCUuxwFT23eC/oWvrZzDLRJQ==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.26.0"
       }
     },
     "commondir": {
@@ -3931,8 +3931,8 @@
       "integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
       "dev": true,
       "requires": {
-        "array-ify": "1.0.0",
-        "dot-prop": "3.0.0"
+        "array-ify": "^1.0.0",
+        "dot-prop": "^3.0.0"
       },
       "dependencies": {
         "dot-prop": {
@@ -3941,7 +3941,7 @@
           "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
           "dev": true,
           "requires": {
-            "is-obj": "1.0.1"
+            "is-obj": "^1.0.0"
           }
         }
       }
@@ -3970,9 +3970,9 @@
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "typedarray": "0.0.6"
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "console-browserify": {
@@ -3981,7 +3981,7 @@
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
-        "date-now": "0.1.4"
+        "date-now": "^0.1.4"
       }
     },
     "console-control-strings": {
@@ -4020,17 +4020,17 @@
       "integrity": "sha512-2WcSUst4Y3Z4hHvoMTWXMJr/DmgVdLiMOVY1Kak2LfFz+GIz2KDp5naqbFesYbfXPmaZ5p491dO0FWZIJoJw1Q==",
       "dev": true,
       "requires": {
-        "conventional-changelog-angular": "1.6.6",
-        "conventional-changelog-atom": "0.2.8",
-        "conventional-changelog-codemirror": "0.3.8",
-        "conventional-changelog-core": "2.0.11",
-        "conventional-changelog-ember": "0.3.12",
-        "conventional-changelog-eslint": "1.0.9",
-        "conventional-changelog-express": "0.3.6",
-        "conventional-changelog-jquery": "0.1.0",
-        "conventional-changelog-jscs": "0.1.0",
-        "conventional-changelog-jshint": "0.3.8",
-        "conventional-changelog-preset-loader": "1.1.8"
+        "conventional-changelog-angular": "^1.6.6",
+        "conventional-changelog-atom": "^0.2.8",
+        "conventional-changelog-codemirror": "^0.3.8",
+        "conventional-changelog-core": "^2.0.11",
+        "conventional-changelog-ember": "^0.3.12",
+        "conventional-changelog-eslint": "^1.0.9",
+        "conventional-changelog-express": "^0.3.6",
+        "conventional-changelog-jquery": "^0.1.0",
+        "conventional-changelog-jscs": "^0.1.0",
+        "conventional-changelog-jshint": "^0.3.8",
+        "conventional-changelog-preset-loader": "^1.1.8"
       }
     },
     "conventional-changelog-angular": {
@@ -4039,8 +4039,8 @@
       "integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
       "dev": true,
       "requires": {
-        "compare-func": "1.3.2",
-        "q": "1.5.1"
+        "compare-func": "^1.3.1",
+        "q": "^1.5.1"
       }
     },
     "conventional-changelog-atom": {
@@ -4049,7 +4049,7 @@
       "integrity": "sha512-8pPZqhMbrnltNBizjoDCb/Sz85KyUXNDQxuAEYAU5V/eHn0okMBVjqc8aHWYpHrytyZWvMGbayOlDv7i8kEf6g==",
       "dev": true,
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.5.1"
       }
     },
     "conventional-changelog-cli": {
@@ -4058,11 +4058,11 @@
       "integrity": "sha512-pnjdIJbxjkZ5VdAX/H1wndr1G10CY8MuZgnXuJhIHglOXfIrXygb7KZC836GW9uo1u8PjEIvIw/bKX0lOmOzZg==",
       "dev": true,
       "requires": {
-        "add-stream": "1.0.0",
-        "conventional-changelog": "1.1.24",
-        "lodash": "4.17.10",
-        "meow": "4.0.1",
-        "tempfile": "1.1.1"
+        "add-stream": "^1.0.0",
+        "conventional-changelog": "^1.1.24",
+        "lodash": "^4.2.1",
+        "meow": "^4.0.0",
+        "tempfile": "^1.1.1"
       },
       "dependencies": {
         "camelcase": {
@@ -4077,9 +4077,9 @@
           "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0",
-            "map-obj": "2.0.0",
-            "quick-lru": "1.1.0"
+            "camelcase": "^4.1.0",
+            "map-obj": "^2.0.0",
+            "quick-lru": "^1.0.0"
           }
         },
         "indent-string": {
@@ -4094,10 +4094,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "4.0.0",
-            "pify": "3.0.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "lodash": {
@@ -4118,15 +4118,15 @@
           "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
           "dev": true,
           "requires": {
-            "camelcase-keys": "4.2.0",
-            "decamelize-keys": "1.1.0",
-            "loud-rejection": "1.6.0",
-            "minimist": "1.2.0",
-            "minimist-options": "3.0.2",
-            "normalize-package-data": "2.4.0",
-            "read-pkg-up": "3.0.0",
-            "redent": "2.0.0",
-            "trim-newlines": "2.0.0"
+            "camelcase-keys": "^4.0.0",
+            "decamelize-keys": "^1.0.0",
+            "loud-rejection": "^1.0.0",
+            "minimist": "^1.1.3",
+            "minimist-options": "^3.0.1",
+            "normalize-package-data": "^2.3.4",
+            "read-pkg-up": "^3.0.0",
+            "redent": "^2.0.0",
+            "trim-newlines": "^2.0.0"
           }
         },
         "minimist": {
@@ -4141,8 +4141,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.1",
-            "json-parse-better-errors": "1.0.2"
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
           }
         },
         "path-type": {
@@ -4151,7 +4151,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "3.0.0"
+            "pify": "^3.0.0"
           }
         },
         "read-pkg": {
@@ -4160,9 +4160,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "4.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "3.0.0"
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
           }
         },
         "read-pkg-up": {
@@ -4171,8 +4171,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "3.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
           }
         },
         "redent": {
@@ -4181,8 +4181,8 @@
           "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
           "dev": true,
           "requires": {
-            "indent-string": "3.2.0",
-            "strip-indent": "2.0.0"
+            "indent-string": "^3.0.0",
+            "strip-indent": "^2.0.0"
           }
         },
         "strip-indent": {
@@ -4205,7 +4205,7 @@
       "integrity": "sha512-3HFZKtBXTaUCHvz7ai6nk2+psRIkldDoNzCsom0egDtVmPsvvHZkzjynhdQyULfacRSsBTaiQ0ol6nBOL4dDiQ==",
       "dev": true,
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.5.1"
       }
     },
     "conventional-changelog-core": {
@@ -4214,19 +4214,19 @@
       "integrity": "sha512-HvTE6RlqeEZ/NFPtQeFLsIDOLrGP3bXYr7lFLMhCVsbduF1MXIe8OODkwMFyo1i9ku9NWBwVnVn0jDmIFXjDRg==",
       "dev": true,
       "requires": {
-        "conventional-changelog-writer": "3.0.9",
-        "conventional-commits-parser": "2.1.7",
-        "dateformat": "3.0.3",
-        "get-pkg-repo": "1.4.0",
-        "git-raw-commits": "1.3.6",
-        "git-remote-origin-url": "2.0.0",
-        "git-semver-tags": "1.3.6",
-        "lodash": "4.17.10",
-        "normalize-package-data": "2.4.0",
-        "q": "1.5.1",
-        "read-pkg": "1.1.0",
-        "read-pkg-up": "1.0.1",
-        "through2": "2.0.3"
+        "conventional-changelog-writer": "^3.0.9",
+        "conventional-commits-parser": "^2.1.7",
+        "dateformat": "^3.0.0",
+        "get-pkg-repo": "^1.0.0",
+        "git-raw-commits": "^1.3.6",
+        "git-remote-origin-url": "^2.0.0",
+        "git-semver-tags": "^1.3.6",
+        "lodash": "^4.2.1",
+        "normalize-package-data": "^2.3.5",
+        "q": "^1.5.1",
+        "read-pkg": "^1.1.0",
+        "read-pkg-up": "^1.0.1",
+        "through2": "^2.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -4235,8 +4235,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "load-json-file": {
@@ -4245,11 +4245,11 @@
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "lodash": {
@@ -4264,7 +4264,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-type": {
@@ -4273,9 +4273,9 @@
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pify": {
@@ -4290,9 +4290,9 @@
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -4301,8 +4301,8 @@
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         },
         "strip-bom": {
@@ -4311,7 +4311,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         }
       }
@@ -4322,7 +4322,7 @@
       "integrity": "sha512-mmJzA7uzbrOqeF89dMMi6z17O07ORTXlTMArnLG9ZTX4oLaKNolUlxFUFlFm9JUoVWajVpaHQWjxH1EOQ+ARoQ==",
       "dev": true,
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.5.1"
       }
     },
     "conventional-changelog-eslint": {
@@ -4331,7 +4331,7 @@
       "integrity": "sha512-h87nfVh2fdk9fJIvz26wCBsbDC/KxqCc5wSlNMZbXcARtbgNbNDIF7Y7ctokFdnxkzVdaHsbINkh548T9eBA7Q==",
       "dev": true,
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.5.1"
       }
     },
     "conventional-changelog-express": {
@@ -4340,7 +4340,7 @@
       "integrity": "sha512-3iWVtBJZ9RnRnZveNDzOD8QRn6g6vUif0qVTWWyi5nUIAbuN1FfPVyKdAlJJfp5Im+dE8Kiy/d2SpaX/0X678Q==",
       "dev": true,
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.5.1"
       }
     },
     "conventional-changelog-jquery": {
@@ -4349,7 +4349,7 @@
       "integrity": "sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=",
       "dev": true,
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.4.1"
       }
     },
     "conventional-changelog-jscs": {
@@ -4358,7 +4358,7 @@
       "integrity": "sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=",
       "dev": true,
       "requires": {
-        "q": "1.5.1"
+        "q": "^1.4.1"
       }
     },
     "conventional-changelog-jshint": {
@@ -4367,8 +4367,8 @@
       "integrity": "sha512-hn9QU4ZI/5V50wKPJNPGT4gEWgiBFpV6adieILW4MaUFynuDYOvQ71EMSj3EznJyKi/KzuXpc9dGmX8njZMjig==",
       "dev": true,
       "requires": {
-        "compare-func": "1.3.2",
-        "q": "1.5.1"
+        "compare-func": "^1.3.1",
+        "q": "^1.5.1"
       }
     },
     "conventional-changelog-preset-loader": {
@@ -4383,16 +4383,16 @@
       "integrity": "sha512-n9KbsxlJxRQsUnK6wIBRnARacvNnN4C/nxnxCkH+B/R1JS2Fa+DiP1dU4I59mEDEjgnFaN2+9wr1P1s7GYB5/Q==",
       "dev": true,
       "requires": {
-        "compare-func": "1.3.2",
-        "conventional-commits-filter": "1.1.6",
-        "dateformat": "3.0.3",
-        "handlebars": "4.0.11",
-        "json-stringify-safe": "5.0.1",
-        "lodash": "4.17.10",
-        "meow": "4.0.1",
-        "semver": "5.5.0",
-        "split": "1.0.1",
-        "through2": "2.0.3"
+        "compare-func": "^1.3.1",
+        "conventional-commits-filter": "^1.1.6",
+        "dateformat": "^3.0.0",
+        "handlebars": "^4.0.2",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.2.1",
+        "meow": "^4.0.0",
+        "semver": "^5.5.0",
+        "split": "^1.0.0",
+        "through2": "^2.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -4407,9 +4407,9 @@
           "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0",
-            "map-obj": "2.0.0",
-            "quick-lru": "1.1.0"
+            "camelcase": "^4.1.0",
+            "map-obj": "^2.0.0",
+            "quick-lru": "^1.0.0"
           }
         },
         "indent-string": {
@@ -4424,10 +4424,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "4.0.0",
-            "pify": "3.0.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "lodash": {
@@ -4448,15 +4448,15 @@
           "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
           "dev": true,
           "requires": {
-            "camelcase-keys": "4.2.0",
-            "decamelize-keys": "1.1.0",
-            "loud-rejection": "1.6.0",
-            "minimist": "1.2.0",
-            "minimist-options": "3.0.2",
-            "normalize-package-data": "2.4.0",
-            "read-pkg-up": "3.0.0",
-            "redent": "2.0.0",
-            "trim-newlines": "2.0.0"
+            "camelcase-keys": "^4.0.0",
+            "decamelize-keys": "^1.0.0",
+            "loud-rejection": "^1.0.0",
+            "minimist": "^1.1.3",
+            "minimist-options": "^3.0.1",
+            "normalize-package-data": "^2.3.4",
+            "read-pkg-up": "^3.0.0",
+            "redent": "^2.0.0",
+            "trim-newlines": "^2.0.0"
           }
         },
         "minimist": {
@@ -4471,8 +4471,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.1",
-            "json-parse-better-errors": "1.0.2"
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
           }
         },
         "path-type": {
@@ -4481,7 +4481,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "3.0.0"
+            "pify": "^3.0.0"
           }
         },
         "read-pkg": {
@@ -4490,9 +4490,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "4.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "3.0.0"
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
           }
         },
         "read-pkg-up": {
@@ -4501,8 +4501,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "3.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
           }
         },
         "redent": {
@@ -4511,8 +4511,8 @@
           "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
           "dev": true,
           "requires": {
-            "indent-string": "3.2.0",
-            "strip-indent": "2.0.0"
+            "indent-string": "^3.0.0",
+            "strip-indent": "^2.0.0"
           }
         },
         "semver": {
@@ -4541,8 +4541,8 @@
       "integrity": "sha512-KcDgtCRKJCQhyk6VLT7zR+ZOyCnerfemE/CsR3iQpzRRFbLEs0Y6rwk3mpDvtOh04X223z+1xyJ582Stfct/0Q==",
       "dev": true,
       "requires": {
-        "is-subset": "0.1.1",
-        "modify-values": "1.0.1"
+        "is-subset": "^0.1.1",
+        "modify-values": "^1.0.0"
       }
     },
     "conventional-commits-parser": {
@@ -4551,13 +4551,13 @@
       "integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.2",
-        "is-text-path": "1.0.1",
-        "lodash": "4.17.10",
-        "meow": "4.0.1",
-        "split2": "2.2.0",
-        "through2": "2.0.3",
-        "trim-off-newlines": "1.0.1"
+        "JSONStream": "^1.0.4",
+        "is-text-path": "^1.0.0",
+        "lodash": "^4.2.1",
+        "meow": "^4.0.0",
+        "split2": "^2.0.0",
+        "through2": "^2.0.0",
+        "trim-off-newlines": "^1.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -4572,9 +4572,9 @@
           "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0",
-            "map-obj": "2.0.0",
-            "quick-lru": "1.1.0"
+            "camelcase": "^4.1.0",
+            "map-obj": "^2.0.0",
+            "quick-lru": "^1.0.0"
           }
         },
         "indent-string": {
@@ -4589,10 +4589,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "4.0.0",
-            "pify": "3.0.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "lodash": {
@@ -4613,15 +4613,15 @@
           "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
           "dev": true,
           "requires": {
-            "camelcase-keys": "4.2.0",
-            "decamelize-keys": "1.1.0",
-            "loud-rejection": "1.6.0",
-            "minimist": "1.2.0",
-            "minimist-options": "3.0.2",
-            "normalize-package-data": "2.4.0",
-            "read-pkg-up": "3.0.0",
-            "redent": "2.0.0",
-            "trim-newlines": "2.0.0"
+            "camelcase-keys": "^4.0.0",
+            "decamelize-keys": "^1.0.0",
+            "loud-rejection": "^1.0.0",
+            "minimist": "^1.1.3",
+            "minimist-options": "^3.0.1",
+            "normalize-package-data": "^2.3.4",
+            "read-pkg-up": "^3.0.0",
+            "redent": "^2.0.0",
+            "trim-newlines": "^2.0.0"
           }
         },
         "minimist": {
@@ -4636,8 +4636,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.1",
-            "json-parse-better-errors": "1.0.2"
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
           }
         },
         "path-type": {
@@ -4646,7 +4646,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "3.0.0"
+            "pify": "^3.0.0"
           }
         },
         "read-pkg": {
@@ -4655,9 +4655,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "4.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "3.0.0"
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
           }
         },
         "read-pkg-up": {
@@ -4666,8 +4666,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "3.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
           }
         },
         "redent": {
@@ -4676,8 +4676,8 @@
           "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
           "dev": true,
           "requires": {
-            "indent-string": "3.2.0",
-            "strip-indent": "2.0.0"
+            "indent-string": "^3.0.0",
+            "strip-indent": "^2.0.0"
           }
         },
         "strip-indent": {
@@ -4700,13 +4700,13 @@
       "integrity": "sha512-oJjG6DkRgtnr/t/VrPdzmf4XZv8c4xKVJrVT4zrSHd92KEL+EYxSbYoKq8lQ7U5yLMw7130wrcQTLRjM/T+d4w==",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.0",
-        "conventional-commits-filter": "1.1.6",
-        "conventional-commits-parser": "2.1.7",
-        "git-raw-commits": "1.3.6",
-        "git-semver-tags": "1.3.6",
-        "meow": "3.7.0",
-        "object-assign": "4.1.1"
+        "concat-stream": "^1.4.10",
+        "conventional-commits-filter": "^1.1.1",
+        "conventional-commits-parser": "^2.1.1",
+        "git-raw-commits": "^1.3.0",
+        "git-semver-tags": "^1.3.0",
+        "meow": "^3.3.0",
+        "object-assign": "^4.0.1"
       }
     },
     "convert-source-map": {
@@ -4733,12 +4733,12 @@
       "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
       "dev": true,
       "requires": {
-        "aproba": "1.2.0",
-        "fs-write-stream-atomic": "1.0.10",
-        "iferr": "0.1.5",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
-        "run-queue": "1.0.3"
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "iferr": "^0.1.5",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.0"
       }
     },
     "copy-descriptor": {
@@ -4764,13 +4764,13 @@
       "integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
       "dev": true,
       "requires": {
-        "is-directory": "0.3.1",
-        "js-yaml": "3.11.0",
-        "minimist": "1.2.0",
-        "object-assign": "4.1.1",
-        "os-homedir": "1.0.2",
-        "parse-json": "2.2.0",
-        "require-from-string": "1.2.1"
+        "is-directory": "^0.3.1",
+        "js-yaml": "^3.4.3",
+        "minimist": "^1.2.0",
+        "object-assign": "^4.1.0",
+        "os-homedir": "^1.0.1",
+        "parse-json": "^2.2.0",
+        "require-from-string": "^1.1.0"
       },
       "dependencies": {
         "minimist": {
@@ -4787,11 +4787,11 @@
       "integrity": "sha512-FAzXwiDOYLGDWH+zgoIA+8GbWv50hlx+kpEJyvzLKOdnIBv9uWoVl4DhqGgyUHpiRjAlF8KYZSipWXYtllWH6Q==",
       "dev": true,
       "requires": {
-        "js-yaml": "3.11.0",
-        "lcov-parse": "0.0.10",
-        "log-driver": "1.2.7",
-        "minimist": "1.2.0",
-        "request": "2.85.0"
+        "js-yaml": "^3.6.1",
+        "lcov-parse": "^0.0.10",
+        "log-driver": "^1.2.5",
+        "minimist": "^1.2.0",
+        "request": "^2.79.0"
       },
       "dependencies": {
         "minimist": {
@@ -4808,8 +4808,8 @@
       "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "elliptic": "6.4.0"
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.0.0"
       }
     },
     "create-error-class": {
@@ -4818,7 +4818,7 @@
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true,
       "requires": {
-        "capture-stack-trace": "1.0.0"
+        "capture-stack-trace": "^1.0.0"
       }
     },
     "create-hash": {
@@ -4827,11 +4827,11 @@
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "inherits": "2.0.3",
-        "md5.js": "1.3.4",
-        "ripemd160": "2.0.2",
-        "sha.js": "2.4.11"
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
       }
     },
     "create-hmac": {
@@ -4840,12 +4840,12 @@
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "create-hash": "1.2.0",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.2",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.11"
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "create-react-class": {
@@ -4854,9 +4854,9 @@
       "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
       "dev": true,
       "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
+        "fbjs": "^0.8.9",
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
       }
     },
     "cross-spawn": {
@@ -4865,9 +4865,9 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.1",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "cryptiles": {
@@ -4876,7 +4876,7 @@
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "dev": true,
       "requires": {
-        "boom": "5.2.0"
+        "boom": "5.x.x"
       },
       "dependencies": {
         "boom": {
@@ -4885,7 +4885,7 @@
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "dev": true,
           "requires": {
-            "hoek": "4.2.1"
+            "hoek": "4.x.x"
           }
         }
       }
@@ -4896,17 +4896,17 @@
       "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "dev": true,
       "requires": {
-        "browserify-cipher": "1.0.1",
-        "browserify-sign": "4.0.4",
-        "create-ecdh": "4.0.3",
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "diffie-hellman": "5.0.3",
-        "inherits": "2.0.3",
-        "pbkdf2": "3.0.16",
-        "public-encrypt": "4.0.2",
-        "randombytes": "2.0.6",
-        "randomfill": "1.0.4"
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
       }
     },
     "css-color-names": {
@@ -4921,8 +4921,8 @@
       "integrity": "sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==",
       "dev": true,
       "requires": {
-        "hyphenate-style-name": "1.0.2",
-        "isobject": "3.0.1"
+        "hyphenate-style-name": "^1.0.2",
+        "isobject": "^3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -4939,20 +4939,20 @@
       "integrity": "sha512-wovHgjAx8ZIMGSL8pTys7edA1ClmzxHeY6n/d97gg5odgsxEgKjULPR0viqyC+FWMCL9sfqoC/QCUBo62tLvPg==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "css-selector-tokenizer": "0.7.0",
-        "cssnano": "3.10.0",
-        "icss-utils": "2.1.0",
-        "loader-utils": "1.1.0",
-        "lodash.camelcase": "4.3.0",
-        "object-assign": "4.1.1",
-        "postcss": "5.2.18",
-        "postcss-modules-extract-imports": "1.2.0",
-        "postcss-modules-local-by-default": "1.2.0",
-        "postcss-modules-scope": "1.1.0",
-        "postcss-modules-values": "1.3.0",
-        "postcss-value-parser": "3.3.0",
-        "source-list-map": "2.0.0"
+        "babel-code-frame": "^6.26.0",
+        "css-selector-tokenizer": "^0.7.0",
+        "cssnano": "^3.10.0",
+        "icss-utils": "^2.1.0",
+        "loader-utils": "^1.0.2",
+        "lodash.camelcase": "^4.3.0",
+        "object-assign": "^4.1.1",
+        "postcss": "^5.0.6",
+        "postcss-modules-extract-imports": "^1.2.0",
+        "postcss-modules-local-by-default": "^1.2.0",
+        "postcss-modules-scope": "^1.1.0",
+        "postcss-modules-values": "^1.3.0",
+        "postcss-value-parser": "^3.3.0",
+        "source-list-map": "^2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5023,10 +5023,10 @@
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "dev": true,
       "requires": {
-        "boolbase": "1.0.0",
-        "css-what": "2.1.0",
+        "boolbase": "~1.0.0",
+        "css-what": "2.1",
         "domutils": "1.5.1",
-        "nth-check": "1.0.1"
+        "nth-check": "~1.0.1"
       }
     },
     "css-selector-tokenizer": {
@@ -5035,9 +5035,9 @@
       "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
       "dev": true,
       "requires": {
-        "cssesc": "0.1.0",
-        "fastparse": "1.1.1",
-        "regexpu-core": "1.0.0"
+        "cssesc": "^0.1.0",
+        "fastparse": "^1.1.1",
+        "regexpu-core": "^1.0.0"
       },
       "dependencies": {
         "regexpu-core": {
@@ -5046,9 +5046,9 @@
           "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
           "dev": true,
           "requires": {
-            "regenerate": "1.3.3",
-            "regjsgen": "0.2.0",
-            "regjsparser": "0.1.5"
+            "regenerate": "^1.2.1",
+            "regjsgen": "^0.2.0",
+            "regjsparser": "^0.1.4"
           }
         }
       }
@@ -5071,38 +5071,38 @@
       "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
       "dev": true,
       "requires": {
-        "autoprefixer": "6.7.7",
-        "decamelize": "1.2.0",
-        "defined": "1.0.0",
-        "has": "1.0.1",
-        "object-assign": "4.1.1",
-        "postcss": "5.2.18",
-        "postcss-calc": "5.3.1",
-        "postcss-colormin": "2.2.2",
-        "postcss-convert-values": "2.6.1",
-        "postcss-discard-comments": "2.0.4",
-        "postcss-discard-duplicates": "2.1.0",
-        "postcss-discard-empty": "2.1.0",
-        "postcss-discard-overridden": "0.1.1",
-        "postcss-discard-unused": "2.2.3",
-        "postcss-filter-plugins": "2.0.2",
-        "postcss-merge-idents": "2.1.7",
-        "postcss-merge-longhand": "2.0.2",
-        "postcss-merge-rules": "2.1.2",
-        "postcss-minify-font-values": "1.0.5",
-        "postcss-minify-gradients": "1.0.5",
-        "postcss-minify-params": "1.2.2",
-        "postcss-minify-selectors": "2.1.1",
-        "postcss-normalize-charset": "1.1.1",
-        "postcss-normalize-url": "3.0.8",
-        "postcss-ordered-values": "2.2.3",
-        "postcss-reduce-idents": "2.4.0",
-        "postcss-reduce-initial": "1.0.1",
-        "postcss-reduce-transforms": "1.0.4",
-        "postcss-svgo": "2.1.6",
-        "postcss-unique-selectors": "2.0.2",
-        "postcss-value-parser": "3.3.0",
-        "postcss-zindex": "2.2.0"
+        "autoprefixer": "^6.3.1",
+        "decamelize": "^1.1.2",
+        "defined": "^1.0.0",
+        "has": "^1.0.1",
+        "object-assign": "^4.0.1",
+        "postcss": "^5.0.14",
+        "postcss-calc": "^5.2.0",
+        "postcss-colormin": "^2.1.8",
+        "postcss-convert-values": "^2.3.4",
+        "postcss-discard-comments": "^2.0.4",
+        "postcss-discard-duplicates": "^2.0.1",
+        "postcss-discard-empty": "^2.0.1",
+        "postcss-discard-overridden": "^0.1.1",
+        "postcss-discard-unused": "^2.2.1",
+        "postcss-filter-plugins": "^2.0.0",
+        "postcss-merge-idents": "^2.1.5",
+        "postcss-merge-longhand": "^2.0.1",
+        "postcss-merge-rules": "^2.0.3",
+        "postcss-minify-font-values": "^1.0.2",
+        "postcss-minify-gradients": "^1.0.1",
+        "postcss-minify-params": "^1.0.4",
+        "postcss-minify-selectors": "^2.0.4",
+        "postcss-normalize-charset": "^1.1.0",
+        "postcss-normalize-url": "^3.0.7",
+        "postcss-ordered-values": "^2.1.0",
+        "postcss-reduce-idents": "^2.2.2",
+        "postcss-reduce-initial": "^1.0.0",
+        "postcss-reduce-transforms": "^1.0.3",
+        "postcss-svgo": "^2.1.1",
+        "postcss-unique-selectors": "^2.0.2",
+        "postcss-value-parser": "^3.2.3",
+        "postcss-zindex": "^2.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5117,12 +5117,12 @@
           "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
           "dev": true,
           "requires": {
-            "browserslist": "1.7.7",
-            "caniuse-db": "1.0.30000836",
-            "normalize-range": "0.1.2",
-            "num2fraction": "1.2.2",
-            "postcss": "5.2.18",
-            "postcss-value-parser": "3.3.0"
+            "browserslist": "^1.7.6",
+            "caniuse-db": "^1.0.30000634",
+            "normalize-range": "^0.1.2",
+            "num2fraction": "^1.2.2",
+            "postcss": "^5.2.16",
+            "postcss-value-parser": "^3.2.3"
           }
         },
         "browserslist": {
@@ -5131,8 +5131,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000836",
-            "electron-to-chromium": "1.3.45"
+            "caniuse-db": "^1.0.30000639",
+            "electron-to-chromium": "^1.2.7"
           }
         },
         "chalk": {
@@ -5141,11 +5141,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -5168,10 +5168,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.3",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -5186,7 +5186,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -5197,8 +5197,8 @@
       "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
       "dev": true,
       "requires": {
-        "clap": "1.2.3",
-        "source-map": "0.5.7"
+        "clap": "^1.0.9",
+        "source-map": "^0.5.3"
       },
       "dependencies": {
         "source-map": {
@@ -5221,7 +5221,7 @@
       "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
       "dev": true,
       "requires": {
-        "cssom": "0.3.2"
+        "cssom": "0.3.x"
       }
     },
     "csstype": {
@@ -5236,7 +5236,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "1.0.2"
+        "array-find-index": "^1.0.1"
       }
     },
     "cyclist": {
@@ -5251,7 +5251,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.42"
+        "es5-ext": "^0.10.9"
       }
     },
     "damerau-levenshtein": {
@@ -5266,7 +5266,7 @@
       "integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "dashdash": {
@@ -5275,7 +5275,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "data-urls": {
@@ -5284,9 +5284,9 @@
       "integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
       "dev": true,
       "requires": {
-        "abab": "1.0.4",
-        "whatwg-mimetype": "2.1.0",
-        "whatwg-url": "6.4.1"
+        "abab": "^1.0.4",
+        "whatwg-mimetype": "^2.0.0",
+        "whatwg-url": "^6.4.0"
       }
     },
     "date-fns": {
@@ -5328,8 +5328,8 @@
       "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
       "dev": true,
       "requires": {
-        "decamelize": "1.2.0",
-        "map-obj": "1.0.1"
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
       }
     },
     "decode-uri-component": {
@@ -5356,7 +5356,7 @@
       "integrity": "sha1-BvS4nlNxDNbOpKd4HHqVZkLejck=",
       "dev": true,
       "requires": {
-        "lodash.isequal": "3.0.4"
+        "lodash.isequal": "^3.0"
       }
     },
     "deep-extend": {
@@ -5377,7 +5377,7 @@
       "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
       "dev": true,
       "requires": {
-        "strip-bom": "2.0.0"
+        "strip-bom": "^2.0.0"
       },
       "dependencies": {
         "strip-bom": {
@@ -5386,7 +5386,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         }
       }
@@ -5397,7 +5397,7 @@
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "requires": {
-        "clone": "1.0.2"
+        "clone": "^1.0.2"
       }
     },
     "define-properties": {
@@ -5406,8 +5406,8 @@
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "dev": true,
       "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
+        "foreach": "^2.0.5",
+        "object-keys": "^1.0.8"
       }
     },
     "define-property": {
@@ -5416,8 +5416,8 @@
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
       "requires": {
-        "is-descriptor": "1.0.2",
-        "isobject": "3.0.1"
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -5426,7 +5426,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -5435,7 +5435,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -5444,9 +5444,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "isobject": {
@@ -5475,13 +5475,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.1",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
       },
       "dependencies": {
         "pify": {
@@ -5516,8 +5516,8 @@
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1"
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "destroy": {
@@ -5532,7 +5532,7 @@
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "detect-newline": {
@@ -5547,8 +5547,8 @@
       "integrity": "sha512-5tQykt+LqfJFBEYaDITx7S7cR7mJ/zQmLXZ2qt5w04ainYZw6tBf9dBunMjVeVOdYVRUzUOE4HkY5J7+uttb5Q==",
       "dev": true,
       "requires": {
-        "address": "1.0.3",
-        "debug": "2.6.9"
+        "address": "^1.0.1",
+        "debug": "^2.6.0"
       }
     },
     "diff": {
@@ -5563,9 +5563,9 @@
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "miller-rabin": "4.0.1",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
       }
     },
     "discontinuous-range": {
@@ -5580,7 +5580,7 @@
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2"
+        "esutils": "^2.0.2"
       }
     },
     "dom-converter": {
@@ -5589,7 +5589,7 @@
       "integrity": "sha1-pF71cnuJDJv/5tfIduexnLDhfzs=",
       "dev": true,
       "requires": {
-        "utila": "0.3.3"
+        "utila": "~0.3"
       },
       "dependencies": {
         "utila": {
@@ -5612,8 +5612,8 @@
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.1.3",
-        "entities": "1.1.1"
+        "domelementtype": "~1.1.1",
+        "entities": "~1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -5648,7 +5648,7 @@
       "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
       "dev": true,
       "requires": {
-        "webidl-conversions": "4.0.2"
+        "webidl-conversions": "^4.0.2"
       }
     },
     "domhandler": {
@@ -5657,7 +5657,7 @@
       "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0"
+        "domelementtype": "1"
       }
     },
     "domutils": {
@@ -5666,8 +5666,8 @@
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "dev": true,
       "requires": {
-        "dom-serializer": "0.1.0",
-        "domelementtype": "1.3.0"
+        "dom-serializer": "0",
+        "domelementtype": "1"
       }
     },
     "dotenv": {
@@ -5682,7 +5682,7 @@
       "integrity": "sha1-NEEJTwTTBLYRnmtyUk5i+zJS9fI=",
       "dev": true,
       "requires": {
-        "dotenv": "5.0.1"
+        "dotenv": "^5.0.1"
       }
     },
     "duplexer": {
@@ -5703,10 +5703,10 @@
       "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "stream-shift": "1.0.0"
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
       }
     },
     "ecc-jsbn": {
@@ -5716,7 +5716,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "ee-first": {
@@ -5743,13 +5743,13 @@
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0",
-        "hash.js": "1.1.3",
-        "hmac-drbg": "1.0.1",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1",
-        "minimalistic-crypto-utils": "1.0.1"
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
       }
     },
     "emoji-regex": {
@@ -5775,7 +5775,7 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
-        "iconv-lite": "0.4.19"
+        "iconv-lite": "~0.4.13"
       }
     },
     "end-of-stream": {
@@ -5784,7 +5784,7 @@
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "enhanced-resolve": {
@@ -5793,10 +5793,10 @@
       "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "memory-fs": "0.4.1",
-        "object-assign": "4.1.1",
-        "tapable": "0.2.8"
+        "graceful-fs": "^4.1.2",
+        "memory-fs": "^0.4.0",
+        "object-assign": "^4.0.1",
+        "tapable": "^0.2.7"
       }
     },
     "entities": {
@@ -5811,22 +5811,22 @@
       "integrity": "sha512-l8csyPyLmtxskTz6pX9W8eDOyH1ckEtDttXk/vlFWCjv00SkjTjtoUrogqp4yEvMyneU9dUJoOLnqFoiHb8IHA==",
       "dev": true,
       "requires": {
-        "cheerio": "1.0.0-rc.2",
-        "function.prototype.name": "1.1.0",
-        "has": "1.0.1",
-        "is-boolean-object": "1.0.0",
-        "is-callable": "1.1.3",
-        "is-number-object": "1.0.3",
-        "is-string": "1.0.4",
-        "is-subset": "0.1.1",
-        "lodash": "4.17.10",
-        "object-inspect": "1.6.0",
-        "object-is": "1.0.1",
-        "object.assign": "4.1.0",
-        "object.entries": "1.0.4",
-        "object.values": "1.0.4",
-        "raf": "3.4.0",
-        "rst-selector-parser": "2.2.3"
+        "cheerio": "^1.0.0-rc.2",
+        "function.prototype.name": "^1.0.3",
+        "has": "^1.0.1",
+        "is-boolean-object": "^1.0.0",
+        "is-callable": "^1.1.3",
+        "is-number-object": "^1.0.3",
+        "is-string": "^1.0.4",
+        "is-subset": "^0.1.1",
+        "lodash": "^4.17.4",
+        "object-inspect": "^1.5.0",
+        "object-is": "^1.0.1",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.0.4",
+        "object.values": "^1.0.4",
+        "raf": "^3.4.0",
+        "rst-selector-parser": "^2.2.3"
       }
     },
     "enzyme-adapter-react-16": {
@@ -5835,13 +5835,13 @@
       "integrity": "sha512-kC8pAtU2Jk3OJ0EG8Y2813dg9Ol0TXi7UNxHzHiWs30Jo/hj7alc//G1YpKUsPP1oKl9X+Lkx+WlGJpPYA+nvw==",
       "dev": true,
       "requires": {
-        "enzyme-adapter-utils": "1.3.0",
-        "lodash": "4.17.10",
-        "object.assign": "4.1.0",
-        "object.values": "1.0.4",
-        "prop-types": "15.6.1",
-        "react-reconciler": "0.7.0",
-        "react-test-renderer": "16.3.2"
+        "enzyme-adapter-utils": "^1.3.0",
+        "lodash": "^4.17.4",
+        "object.assign": "^4.0.4",
+        "object.values": "^1.0.4",
+        "prop-types": "^15.6.0",
+        "react-reconciler": "^0.7.0",
+        "react-test-renderer": "^16.0.0-0"
       }
     },
     "enzyme-adapter-utils": {
@@ -5850,9 +5850,9 @@
       "integrity": "sha512-vVXSt6uDv230DIv+ebCG66T1Pm36Kv+m74L1TrF4kaE7e1V7Q/LcxO0QRkajk5cA6R3uu9wJf5h13wOTezTbjA==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.10",
-        "object.assign": "4.1.0",
-        "prop-types": "15.6.1"
+        "lodash": "^4.17.4",
+        "object.assign": "^4.0.4",
+        "prop-types": "^15.6.0"
       }
     },
     "enzyme-matchers": {
@@ -5861,8 +5861,8 @@
       "integrity": "sha1-uIooq61C7GncG6x8ZxUtui4VeVA=",
       "dev": true,
       "requires": {
-        "circular-json-es6": "2.0.2",
-        "deep-equal-ident": "1.1.1"
+        "circular-json-es6": "^2.0.1",
+        "deep-equal-ident": "^1.1.1"
       }
     },
     "enzyme-to-json": {
@@ -5871,7 +5871,7 @@
       "integrity": "sha1-7eRZOPswnNh+vUOG9gx1RSVRWgc=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "^4.17.4"
       }
     },
     "errno": {
@@ -5880,7 +5880,7 @@
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "dev": true,
       "requires": {
-        "prr": "1.0.1"
+        "prr": "~1.0.1"
       }
     },
     "error-ex": {
@@ -5889,7 +5889,7 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es-abstract": {
@@ -5898,11 +5898,11 @@
       "integrity": "sha512-ZnQrE/lXTTQ39ulXZ+J1DTFazV9qBy61x2bY071B+qGco8Z8q1QddsLdt/EF8Ai9hcWH72dWS0kFqXLxOxqslA==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.1",
-        "is-callable": "1.1.3",
-        "is-regex": "1.0.4"
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
       }
     },
     "es-to-primitive": {
@@ -5911,9 +5911,9 @@
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "dev": true,
       "requires": {
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
+        "is-callable": "^1.1.1",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.1"
       }
     },
     "es5-ext": {
@@ -5922,9 +5922,9 @@
       "integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
       "dev": true,
       "requires": {
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1",
-        "next-tick": "1.0.0"
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1",
+        "next-tick": "1"
       }
     },
     "es5-shim": {
@@ -5939,9 +5939,9 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.42",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
       }
     },
     "es6-map": {
@@ -5950,12 +5950,12 @@
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.42",
-        "es6-iterator": "2.0.3",
-        "es6-set": "0.1.5",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-set": "~0.1.5",
+        "es6-symbol": "~3.1.1",
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-set": {
@@ -5964,11 +5964,11 @@
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.42",
-        "es6-iterator": "2.0.3",
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
         "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-shim": {
@@ -5983,8 +5983,8 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.42"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "es6-templates": {
@@ -5993,8 +5993,8 @@
       "integrity": "sha1-XLmsn7He1usSOTQrgdeSu7QHjuQ=",
       "dev": true,
       "requires": {
-        "recast": "0.11.23",
-        "through": "2.3.8"
+        "recast": "~0.11.12",
+        "through": "~2.3.6"
       },
       "dependencies": {
         "ast-types": {
@@ -6016,9 +6016,9 @@
           "dev": true,
           "requires": {
             "ast-types": "0.9.6",
-            "esprima": "3.1.3",
-            "private": "0.1.8",
-            "source-map": "0.5.7"
+            "esprima": "~3.1.0",
+            "private": "~0.1.5",
+            "source-map": "~0.5.0"
           }
         },
         "source-map": {
@@ -6035,10 +6035,10 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.42",
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.14",
+        "es6-iterator": "^2.0.1",
+        "es6-symbol": "^3.1.1"
       }
     },
     "escape-html": {
@@ -6059,11 +6059,11 @@
       "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
       "dev": true,
       "requires": {
-        "esprima": "3.1.3",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.6.1"
+        "esprima": "^3.1.3",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "esprima": {
@@ -6080,10 +6080,10 @@
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
       "requires": {
-        "es6-map": "0.1.5",
-        "es6-weak-map": "2.0.2",
-        "esrecurse": "4.2.1",
-        "estraverse": "4.2.0"
+        "es6-map": "^0.1.3",
+        "es6-weak-map": "^2.0.1",
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "eslint": {
@@ -6092,44 +6092,44 @@
       "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "babel-code-frame": "6.26.0",
-        "chalk": "2.3.0",
-        "concat-stream": "1.6.0",
-        "cross-spawn": "5.1.0",
-        "debug": "3.1.0",
-        "doctrine": "2.1.0",
-        "eslint-scope": "3.7.1",
-        "eslint-visitor-keys": "1.0.0",
-        "espree": "3.5.4",
-        "esquery": "1.0.1",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "functional-red-black-tree": "1.0.1",
-        "glob": "7.1.2",
-        "globals": "11.5.0",
-        "ignore": "3.3.8",
-        "imurmurhash": "0.1.4",
-        "inquirer": "3.3.0",
-        "is-resolvable": "1.1.0",
-        "js-yaml": "3.11.0",
-        "json-stable-stringify-without-jsonify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.10",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "7.0.0",
-        "progress": "2.0.0",
-        "regexpp": "1.1.0",
-        "require-uncached": "1.0.3",
-        "semver": "5.4.1",
-        "strip-ansi": "4.0.0",
-        "strip-json-comments": "2.0.1",
+        "ajv": "^5.3.0",
+        "babel-code-frame": "^6.22.0",
+        "chalk": "^2.1.0",
+        "concat-stream": "^1.6.0",
+        "cross-spawn": "^5.1.0",
+        "debug": "^3.1.0",
+        "doctrine": "^2.1.0",
+        "eslint-scope": "^3.7.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^3.5.4",
+        "esquery": "^1.0.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.0.1",
+        "ignore": "^3.3.3",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^3.0.6",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.9.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "regexpp": "^1.0.1",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.3.0",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "~2.0.1",
         "table": "4.0.2",
-        "text-table": "0.2.0"
+        "text-table": "~0.2.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -6159,7 +6159,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -6182,8 +6182,8 @@
       "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "resolve": "1.7.1"
+        "debug": "^2.6.9",
+        "resolve": "^1.5.0"
       },
       "dependencies": {
         "resolve": {
@@ -6192,7 +6192,7 @@
           "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
           "dev": true,
           "requires": {
-            "path-parse": "1.0.5"
+            "path-parse": "^1.0.5"
           }
         }
       }
@@ -6203,8 +6203,8 @@
       "integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "pkg-dir": "1.0.0"
+        "debug": "^2.6.8",
+        "pkg-dir": "^1.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -6243,7 +6243,7 @@
       "integrity": "sha512-VpnNeC4E6t2E2NCw8Oveda91p8CPEaujZURC1KhHe4lBRZJla3o0DVvZu1QGXQZO1ZJ4vUmy3TCp95PqGvIZgQ==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "^4.15.0"
       }
     },
     "eslint-plugin-import": {
@@ -6252,16 +6252,16 @@
       "integrity": "sha1-Fa7qN6Z0mdhI6OmBgG1GJ7VQOBY=",
       "dev": true,
       "requires": {
-        "contains-path": "0.1.0",
-        "debug": "2.6.9",
+        "contains-path": "^0.1.0",
+        "debug": "^2.6.8",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "0.3.2",
-        "eslint-module-utils": "2.2.0",
-        "has": "1.0.1",
-        "lodash": "4.17.10",
-        "minimatch": "3.0.4",
-        "read-pkg-up": "2.0.0",
-        "resolve": "1.7.1"
+        "eslint-import-resolver-node": "^0.3.1",
+        "eslint-module-utils": "^2.2.0",
+        "has": "^1.0.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.3",
+        "read-pkg-up": "^2.0.0",
+        "resolve": "^1.6.0"
       },
       "dependencies": {
         "doctrine": {
@@ -6280,7 +6280,7 @@
           "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
           "dev": true,
           "requires": {
-            "path-parse": "1.0.5"
+            "path-parse": "^1.0.5"
           }
         }
       }
@@ -6297,13 +6297,13 @@
       "integrity": "sha512-5I9SpoP7gT4wBFOtXT8/tXNPYohHBVfyVfO17vkbC7r9kEIxYJF12D3pKqhk8+xnk12rfxKClS3WCFpVckFTPQ==",
       "dev": true,
       "requires": {
-        "aria-query": "0.7.1",
-        "array-includes": "3.0.3",
+        "aria-query": "^0.7.0",
+        "array-includes": "^3.0.3",
         "ast-types-flow": "0.0.7",
-        "axobject-query": "0.1.0",
-        "damerau-levenshtein": "1.0.4",
-        "emoji-regex": "6.5.1",
-        "jsx-ast-utils": "1.4.1"
+        "axobject-query": "^0.1.0",
+        "damerau-levenshtein": "^1.0.0",
+        "emoji-regex": "^6.1.0",
+        "jsx-ast-utils": "^1.4.0"
       },
       "dependencies": {
         "jsx-ast-utils": {
@@ -6320,7 +6320,7 @@
       "integrity": "sha512-sIEzx85Sy+Higf4W+oLCIyh7ym0OEcmJCzY8ukptlGfkcyVagzYBjhUt1JfkcpT4qZC68+7TzceJSqLu+qwYMg==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "~4.17.0"
       }
     },
     "eslint-plugin-react": {
@@ -6329,10 +6329,10 @@
       "integrity": "sha512-H3ne8ob4Bn6NXSN9N9twsn7t8dyHT5bF/ibQepxIHi6JiPIdC2gXlfYvZYucbdrWio4FxBq7Z4mSauQP+qmMkQ==",
       "dev": true,
       "requires": {
-        "doctrine": "2.1.0",
-        "has": "1.0.1",
-        "jsx-ast-utils": "2.0.1",
-        "prop-types": "15.6.1"
+        "doctrine": "^2.0.2",
+        "has": "^1.0.1",
+        "jsx-ast-utils": "^2.0.1",
+        "prop-types": "^15.6.0"
       }
     },
     "eslint-scope": {
@@ -6341,8 +6341,8 @@
       "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
       "dev": true,
       "requires": {
-        "esrecurse": "4.2.1",
-        "estraverse": "4.2.0"
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "eslint-visitor-keys": {
@@ -6357,8 +6357,8 @@
       "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
       "requires": {
-        "acorn": "5.5.3",
-        "acorn-jsx": "3.0.1"
+        "acorn": "^5.5.0",
+        "acorn-jsx": "^3.0.0"
       }
     },
     "esprima": {
@@ -6373,7 +6373,7 @@
       "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.0.0"
       }
     },
     "esrecurse": {
@@ -6382,7 +6382,7 @@
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.1.0"
       }
     },
     "estraverse": {
@@ -6409,8 +6409,8 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.42"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "events": {
@@ -6425,7 +6425,7 @@
       "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
       "dev": true,
       "requires": {
-        "original": "1.0.0"
+        "original": ">=0.0.5"
       }
     },
     "evp_bytestokey": {
@@ -6434,8 +6434,8 @@
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
       "requires": {
-        "md5.js": "1.3.4",
-        "safe-buffer": "5.1.1"
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
       }
     },
     "exec-sh": {
@@ -6444,7 +6444,7 @@
       "integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
       "dev": true,
       "requires": {
-        "merge": "1.2.0"
+        "merge": "^1.1.3"
       }
     },
     "execa": {
@@ -6453,13 +6453,13 @@
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       }
     },
     "exenv": {
@@ -6486,7 +6486,7 @@
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
-        "is-posix-bracket": "0.1.1"
+        "is-posix-bracket": "^0.1.0"
       }
     },
     "expand-range": {
@@ -6495,7 +6495,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "2.2.3"
+        "fill-range": "^2.1.0"
       }
     },
     "expand-tilde": {
@@ -6504,7 +6504,7 @@
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "1.0.1"
+        "homedir-polyfill": "^1.0.1"
       }
     },
     "expect": {
@@ -6513,12 +6513,12 @@
       "integrity": "sha512-XcNXEPehqn8b/jm8FYotdX0YrXn36qp4HWlrVT4ktwQas1l1LPxiVWncYnnL2eyMtKAmVIaG0XAp0QlrqJaxaA==",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.0",
-        "jest-diff": "22.4.3",
-        "jest-get-type": "22.4.3",
-        "jest-matcher-utils": "22.4.3",
-        "jest-message-util": "22.4.3",
-        "jest-regex-util": "22.4.3"
+        "ansi-styles": "^3.2.0",
+        "jest-diff": "^22.4.3",
+        "jest-get-type": "^22.4.3",
+        "jest-matcher-utils": "^22.4.3",
+        "jest-message-util": "^22.4.3",
+        "jest-regex-util": "^22.4.3"
       }
     },
     "express": {
@@ -6527,36 +6527,36 @@
       "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
       "dev": true,
       "requires": {
-        "accepts": "1.3.5",
+        "accepts": "~1.3.5",
         "array-flatten": "1.1.1",
         "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "finalhandler": "1.1.1",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "1.1.2",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "2.0.3",
+        "proxy-addr": "~2.0.3",
         "qs": "6.5.1",
-        "range-parser": "1.2.0",
+        "range-parser": "~1.2.0",
         "safe-buffer": "5.1.1",
         "send": "0.16.2",
         "serve-static": "1.13.2",
         "setprototypeof": "1.1.0",
-        "statuses": "1.4.0",
-        "type-is": "1.6.16",
+        "statuses": "~1.4.0",
+        "type-is": "~1.6.16",
         "utils-merge": "1.0.1",
-        "vary": "1.1.2"
+        "vary": "~1.1.2"
       },
       "dependencies": {
         "qs": {
@@ -6579,8 +6579,8 @@
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
-        "assign-symbols": "1.0.0",
-        "is-extendable": "1.0.1"
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -6589,7 +6589,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -6600,9 +6600,9 @@
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
-        "chardet": "0.4.2",
-        "iconv-lite": "0.4.19",
-        "tmp": "0.0.33"
+        "chardet": "^0.4.0",
+        "iconv-lite": "^0.4.17",
+        "tmp": "^0.0.33"
       }
     },
     "extglob": {
@@ -6611,7 +6611,7 @@
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "extsprintf": {
@@ -6656,7 +6656,7 @@
       "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
       "dev": true,
       "requires": {
-        "websocket-driver": "0.7.0"
+        "websocket-driver": ">=0.5.1"
       }
     },
     "fb-watchman": {
@@ -6665,7 +6665,7 @@
       "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
       "dev": true,
       "requires": {
-        "bser": "2.0.0"
+        "bser": "^2.0.0"
       }
     },
     "fbjs": {
@@ -6673,13 +6673,13 @@
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
       "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
       "requires": {
-        "core-js": "1.2.7",
-        "isomorphic-fetch": "2.2.1",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "promise": "7.3.1",
-        "setimmediate": "1.0.5",
-        "ua-parser-js": "0.7.18"
+        "core-js": "^1.0.0",
+        "isomorphic-fetch": "^2.1.1",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.9"
       }
     },
     "figures": {
@@ -6688,7 +6688,7 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-entry-cache": {
@@ -6697,8 +6697,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.3.0",
-        "object-assign": "4.1.1"
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
       }
     },
     "file-loader": {
@@ -6707,8 +6707,8 @@
       "integrity": "sha512-TGR4HU7HUsGg6GCOPJnFk06RhWgEWFLAGWiT6rcD+GRC2keU3s9RGJ+b3Z6/U73jwwNb2gKLJ7YCrp+jvU4ALg==",
       "dev": true,
       "requires": {
-        "loader-utils": "1.1.0",
-        "schema-utils": "0.4.5"
+        "loader-utils": "^1.0.2",
+        "schema-utils": "^0.4.5"
       }
     },
     "filename-regex": {
@@ -6723,8 +6723,8 @@
       "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "minimatch": "3.0.4"
+        "glob": "^7.0.3",
+        "minimatch": "^3.0.3"
       }
     },
     "filesize": {
@@ -6739,11 +6739,11 @@
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "dev": true,
       "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^1.1.3",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
       }
     },
     "finalhandler": {
@@ -6753,12 +6753,12 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
-        "statuses": "1.4.0",
-        "unpipe": "1.0.0"
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.4.0",
+        "unpipe": "~1.0.0"
       }
     },
     "find-cache-dir": {
@@ -6767,9 +6767,9 @@
       "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
       "dev": true,
       "requires": {
-        "commondir": "1.0.1",
-        "make-dir": "1.1.0",
-        "pkg-dir": "2.0.0"
+        "commondir": "^1.0.1",
+        "make-dir": "^1.0.0",
+        "pkg-dir": "^2.0.0"
       }
     },
     "find-parent-dir": {
@@ -6784,7 +6784,7 @@
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
-        "locate-path": "2.0.0"
+        "locate-path": "^2.0.0"
       }
     },
     "flat-cache": {
@@ -6793,10 +6793,10 @@
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
       }
     },
     "flatten": {
@@ -6811,8 +6811,8 @@
       "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.4"
       }
     },
     "for-in": {
@@ -6827,7 +6827,7 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "foreach": {
@@ -6848,9 +6848,9 @@
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "dev": true,
       "requires": {
-        "asynckit": "0.4.0",
+        "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "2.1.18"
+        "mime-types": "^2.1.12"
       }
     },
     "forwarded": {
@@ -6865,7 +6865,7 @@
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
-        "map-cache": "0.2.2"
+        "map-cache": "^0.2.2"
       }
     },
     "fresh": {
@@ -6880,8 +6880,8 @@
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
       }
     },
     "fs-write-stream-atomic": {
@@ -6890,10 +6890,10 @@
       "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "iferr": "0.1.5",
-        "imurmurhash": "0.1.4",
-        "readable-stream": "2.3.3"
+        "graceful-fs": "^4.1.2",
+        "iferr": "^0.1.5",
+        "imurmurhash": "^0.1.4",
+        "readable-stream": "1 || 2"
       }
     },
     "fs.realpath": {
@@ -6909,8 +6909,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.10.0",
-        "node-pre-gyp": "0.9.1"
+        "nan": "^2.9.2",
+        "node-pre-gyp": "^0.9.0"
       },
       "dependencies": {
         "abbrev": {
@@ -6936,8 +6936,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.6"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
         },
         "balanced-match": {
@@ -6950,7 +6950,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -7014,7 +7014,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "^2.2.1"
           }
         },
         "fs.realpath": {
@@ -7029,14 +7029,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "1.2.0",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "glob": {
@@ -7045,12 +7045,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-unicode": {
@@ -7065,7 +7065,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": "^2.1.0"
           }
         },
         "ignore-walk": {
@@ -7074,7 +7074,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimatch": "3.0.4"
+            "minimatch": "^3.0.4"
           }
         },
         "inflight": {
@@ -7083,8 +7083,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -7103,7 +7103,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
@@ -7117,7 +7117,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -7130,8 +7130,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.0"
           }
         },
         "minizlib": {
@@ -7140,7 +7140,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "^2.2.1"
           }
         },
         "mkdirp": {
@@ -7163,9 +7163,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "2.6.9",
-            "iconv-lite": "0.4.21",
-            "sax": "1.2.4"
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -7174,16 +7174,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "1.0.3",
-            "mkdirp": "0.5.1",
-            "needle": "2.2.0",
-            "nopt": "4.0.1",
-            "npm-packlist": "1.1.10",
-            "npmlog": "4.1.2",
-            "rc": "1.2.6",
-            "rimraf": "2.6.2",
-            "semver": "5.5.0",
-            "tar": "4.4.1"
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.0",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
           }
         },
         "nopt": {
@@ -7192,8 +7192,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.5"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "npm-bundled": {
@@ -7208,8 +7208,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "3.0.1",
-            "npm-bundled": "1.0.3"
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
           }
         },
         "npmlog": {
@@ -7218,10 +7218,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
@@ -7240,7 +7240,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-homedir": {
@@ -7261,8 +7261,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "path-is-absolute": {
@@ -7283,10 +7283,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "~0.4.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -7303,13 +7303,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "rimraf": {
@@ -7318,7 +7318,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "safe-buffer": {
@@ -7361,9 +7361,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string_decoder": {
@@ -7372,7 +7372,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "strip-ansi": {
@@ -7380,7 +7380,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
@@ -7395,13 +7395,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "1.0.1",
-            "fs-minipass": "1.2.5",
-            "minipass": "2.2.4",
-            "minizlib": "1.1.0",
-            "mkdirp": "0.5.1",
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
+            "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.2.4",
+            "minizlib": "^1.1.0",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.2"
           }
         },
         "util-deprecate": {
@@ -7416,7 +7416,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2"
           }
         },
         "wrappy": {
@@ -7437,10 +7437,10 @@
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "inherits": "2.0.3",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2"
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
       }
     },
     "function-bind": {
@@ -7455,9 +7455,9 @@
       "integrity": "sha512-Bs0VRrTz4ghD8pTmbJQD1mZ8A/mN0ur/jGz+A6FBxPDUPkm1tNfF6bhTYPA7i7aF4lZJVr+OXTNNrnnIl58Wfg==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "function-bind": "1.1.1",
-        "is-callable": "1.1.3"
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "is-callable": "^1.1.3"
       }
     },
     "functional-red-black-tree": {
@@ -7478,14 +7478,14 @@
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "requires": {
-        "aproba": "1.2.0",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.2"
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
       },
       "dependencies": {
         "string-width": {
@@ -7494,9 +7494,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         }
       }
@@ -7507,7 +7507,7 @@
       "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
       "dev": true,
       "requires": {
-        "globule": "1.2.0"
+        "globule": "^1.0.0"
       }
     },
     "generate-function": {
@@ -7522,7 +7522,7 @@
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "requires": {
-        "is-property": "1.0.2"
+        "is-property": "^1.0.0"
       }
     },
     "get-caller-file": {
@@ -7543,11 +7543,11 @@
       "integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.5.0",
-        "meow": "3.7.0",
-        "normalize-package-data": "2.4.0",
-        "parse-github-repo-url": "1.4.1",
-        "through2": "2.0.3"
+        "hosted-git-info": "^2.1.4",
+        "meow": "^3.3.0",
+        "normalize-package-data": "^2.3.0",
+        "parse-github-repo-url": "^1.3.0",
+        "through2": "^2.0.0"
       }
     },
     "get-port": {
@@ -7580,7 +7580,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "git-raw-commits": {
@@ -7589,11 +7589,11 @@
       "integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
       "dev": true,
       "requires": {
-        "dargs": "4.1.0",
-        "lodash.template": "4.4.0",
-        "meow": "4.0.1",
-        "split2": "2.2.0",
-        "through2": "2.0.3"
+        "dargs": "^4.0.1",
+        "lodash.template": "^4.0.2",
+        "meow": "^4.0.0",
+        "split2": "^2.0.0",
+        "through2": "^2.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -7608,9 +7608,9 @@
           "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0",
-            "map-obj": "2.0.0",
-            "quick-lru": "1.1.0"
+            "camelcase": "^4.1.0",
+            "map-obj": "^2.0.0",
+            "quick-lru": "^1.0.0"
           }
         },
         "indent-string": {
@@ -7625,10 +7625,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "4.0.0",
-            "pify": "3.0.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "map-obj": {
@@ -7643,15 +7643,15 @@
           "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
           "dev": true,
           "requires": {
-            "camelcase-keys": "4.2.0",
-            "decamelize-keys": "1.1.0",
-            "loud-rejection": "1.6.0",
-            "minimist": "1.2.0",
-            "minimist-options": "3.0.2",
-            "normalize-package-data": "2.4.0",
-            "read-pkg-up": "3.0.0",
-            "redent": "2.0.0",
-            "trim-newlines": "2.0.0"
+            "camelcase-keys": "^4.0.0",
+            "decamelize-keys": "^1.0.0",
+            "loud-rejection": "^1.0.0",
+            "minimist": "^1.1.3",
+            "minimist-options": "^3.0.1",
+            "normalize-package-data": "^2.3.4",
+            "read-pkg-up": "^3.0.0",
+            "redent": "^2.0.0",
+            "trim-newlines": "^2.0.0"
           }
         },
         "minimist": {
@@ -7666,8 +7666,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.1",
-            "json-parse-better-errors": "1.0.2"
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
           }
         },
         "path-type": {
@@ -7676,7 +7676,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "3.0.0"
+            "pify": "^3.0.0"
           }
         },
         "read-pkg": {
@@ -7685,9 +7685,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "4.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "3.0.0"
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
           }
         },
         "read-pkg-up": {
@@ -7696,8 +7696,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "3.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
           }
         },
         "redent": {
@@ -7706,8 +7706,8 @@
           "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
           "dev": true,
           "requires": {
-            "indent-string": "3.2.0",
-            "strip-indent": "2.0.0"
+            "indent-string": "^3.0.0",
+            "strip-indent": "^2.0.0"
           }
         },
         "strip-indent": {
@@ -7730,8 +7730,8 @@
       "integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
       "dev": true,
       "requires": {
-        "gitconfiglocal": "1.0.0",
-        "pify": "2.3.0"
+        "gitconfiglocal": "^1.0.0",
+        "pify": "^2.3.0"
       },
       "dependencies": {
         "pify": {
@@ -7748,8 +7748,8 @@
       "integrity": "sha512-2jHlJnln4D/ECk9FxGEBh3k44wgYdWjWDtMmJPaecjoRmxKo3Y1Lh8GMYuOPu04CHw86NTAODchYjC5pnpMQig==",
       "dev": true,
       "requires": {
-        "meow": "4.0.1",
-        "semver": "5.5.0"
+        "meow": "^4.0.0",
+        "semver": "^5.5.0"
       },
       "dependencies": {
         "camelcase": {
@@ -7764,9 +7764,9 @@
           "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0",
-            "map-obj": "2.0.0",
-            "quick-lru": "1.1.0"
+            "camelcase": "^4.1.0",
+            "map-obj": "^2.0.0",
+            "quick-lru": "^1.0.0"
           }
         },
         "indent-string": {
@@ -7781,10 +7781,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "4.0.0",
-            "pify": "3.0.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "map-obj": {
@@ -7799,15 +7799,15 @@
           "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
           "dev": true,
           "requires": {
-            "camelcase-keys": "4.2.0",
-            "decamelize-keys": "1.1.0",
-            "loud-rejection": "1.6.0",
-            "minimist": "1.2.0",
-            "minimist-options": "3.0.2",
-            "normalize-package-data": "2.4.0",
-            "read-pkg-up": "3.0.0",
-            "redent": "2.0.0",
-            "trim-newlines": "2.0.0"
+            "camelcase-keys": "^4.0.0",
+            "decamelize-keys": "^1.0.0",
+            "loud-rejection": "^1.0.0",
+            "minimist": "^1.1.3",
+            "minimist-options": "^3.0.1",
+            "normalize-package-data": "^2.3.4",
+            "read-pkg-up": "^3.0.0",
+            "redent": "^2.0.0",
+            "trim-newlines": "^2.0.0"
           }
         },
         "minimist": {
@@ -7822,8 +7822,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.1",
-            "json-parse-better-errors": "1.0.2"
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
           }
         },
         "path-type": {
@@ -7832,7 +7832,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "3.0.0"
+            "pify": "^3.0.0"
           }
         },
         "read-pkg": {
@@ -7841,9 +7841,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "4.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "3.0.0"
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
           }
         },
         "read-pkg-up": {
@@ -7852,8 +7852,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "3.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
           }
         },
         "redent": {
@@ -7862,8 +7862,8 @@
           "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
           "dev": true,
           "requires": {
-            "indent-string": "3.2.0",
-            "strip-indent": "2.0.0"
+            "indent-string": "^3.0.0",
+            "strip-indent": "^2.0.0"
           }
         },
         "semver": {
@@ -7892,8 +7892,8 @@
       "integrity": "sha512-2v4UN3qV2RGypD9QpmUjpk+4+RlYpW8GFuiZqQnKmvei08HsFPd0RfbDvEhnE4wBvnYs8ORVtYpOFuuCEmBVBw==",
       "dev": true,
       "requires": {
-        "is-ssh": "1.3.0",
-        "parse-url": "1.3.11"
+        "is-ssh": "^1.3.0",
+        "parse-url": "^1.3.0"
       }
     },
     "git-url-parse": {
@@ -7902,8 +7902,8 @@
       "integrity": "sha512-r/FxXIdfgdSO+V2zl4ZK1JGYkHT9nqVRSzom5WsYPLg3XzeBeKPl3R/6X9E9ZJRx/sE/dXwXtfl+Zp7YL8ktWQ==",
       "dev": true,
       "requires": {
-        "git-up": "2.0.10",
-        "parse-domain": "2.0.0"
+        "git-up": "^2.0.0",
+        "parse-domain": "^2.0.0"
       }
     },
     "gitconfiglocal": {
@@ -7912,7 +7912,7 @@
       "integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
       "dev": true,
       "requires": {
-        "ini": "1.3.5"
+        "ini": "^1.3.2"
       }
     },
     "glamor": {
@@ -7921,11 +7921,11 @@
       "integrity": "sha512-DNXCd+c14N9QF8aAKrfl4xakPk5FdcFwmH7sD0qnC0Pr7xoZ5W9yovhUrY/dJc3psfGGXC58vqQyRtuskyUJxA==",
       "dev": true,
       "requires": {
-        "fbjs": "0.8.16",
-        "inline-style-prefixer": "3.0.8",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.1",
-        "through": "2.3.8"
+        "fbjs": "^0.8.12",
+        "inline-style-prefixer": "^3.0.6",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.5.10",
+        "through": "^2.3.8"
       }
     },
     "glamorous": {
@@ -7934,14 +7934,14 @@
       "integrity": "sha512-k3w5+7iHLyS1BRWOrGpXAXIAq8vIdK762gIePr+WT30wQ9rw7Ve+5bjxSspM4rcw5pt+/4/CJAbbJvYLWB4PGg==",
       "dev": true,
       "requires": {
-        "brcast": "3.0.1",
-        "csstype": "2.4.2",
-        "fast-memoize": "2.3.2",
-        "html-tag-names": "1.1.3",
-        "is-function": "1.0.1",
-        "is-plain-object": "2.0.4",
-        "react-html-attributes": "1.4.2",
-        "svg-tag-names": "1.1.1"
+        "brcast": "^3.0.0",
+        "csstype": "^2.2.0",
+        "fast-memoize": "^2.2.7",
+        "html-tag-names": "^1.1.1",
+        "is-function": "^1.0.1",
+        "is-plain-object": "^2.0.4",
+        "react-html-attributes": "^1.4.2",
+        "svg-tag-names": "^1.1.0"
       }
     },
     "glob": {
@@ -7950,12 +7950,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-base": {
@@ -7964,8 +7964,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "glob-parent": {
@@ -7974,7 +7974,7 @@
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
-        "is-glob": "2.0.1"
+        "is-glob": "^2.0.0"
       }
     },
     "global": {
@@ -7983,8 +7983,8 @@
       "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
       "dev": true,
       "requires": {
-        "min-document": "2.19.0",
-        "process": "0.5.2"
+        "min-document": "^2.19.0",
+        "process": "~0.5.1"
       }
     },
     "global-modules": {
@@ -7993,9 +7993,9 @@
       "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
       "dev": true,
       "requires": {
-        "global-prefix": "1.0.2",
-        "is-windows": "1.0.2",
-        "resolve-dir": "1.0.1"
+        "global-prefix": "^1.0.1",
+        "is-windows": "^1.0.1",
+        "resolve-dir": "^1.0.0"
       }
     },
     "global-prefix": {
@@ -8004,11 +8004,11 @@
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "dev": true,
       "requires": {
-        "expand-tilde": "2.0.2",
-        "homedir-polyfill": "1.0.1",
-        "ini": "1.3.5",
-        "is-windows": "1.0.2",
-        "which": "1.3.0"
+        "expand-tilde": "^2.0.2",
+        "homedir-polyfill": "^1.0.1",
+        "ini": "^1.3.4",
+        "is-windows": "^1.0.1",
+        "which": "^1.2.14"
       }
     },
     "globals": {
@@ -8023,12 +8023,12 @@
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       },
       "dependencies": {
         "pify": {
@@ -8045,9 +8045,9 @@
       "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "lodash": "4.17.10",
-        "minimatch": "3.0.4"
+        "glob": "~7.1.1",
+        "lodash": "~4.17.4",
+        "minimatch": "~3.0.2"
       }
     },
     "got": {
@@ -8056,17 +8056,17 @@
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true,
       "requires": {
-        "create-error-class": "3.0.2",
-        "duplexer3": "0.1.4",
-        "get-stream": "3.0.0",
-        "is-redirect": "1.0.0",
-        "is-retry-allowed": "1.1.0",
-        "is-stream": "1.1.0",
-        "lowercase-keys": "1.0.1",
-        "safe-buffer": "5.1.1",
-        "timed-out": "4.0.1",
-        "unzip-response": "2.0.1",
-        "url-parse-lax": "1.0.0"
+        "create-error-class": "^3.0.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "is-redirect": "^1.0.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "lowercase-keys": "^1.0.0",
+        "safe-buffer": "^5.0.1",
+        "timed-out": "^4.0.0",
+        "unzip-response": "^2.0.1",
+        "url-parse-lax": "^1.0.0"
       }
     },
     "graceful-fs": {
@@ -8087,7 +8087,7 @@
       "integrity": "sha1-VGGI6b3DN/Zzdy+BZgRks4nc5SA=",
       "dev": true,
       "requires": {
-        "duplexer": "0.1.1"
+        "duplexer": "^0.1.1"
       }
     },
     "handlebars": {
@@ -8096,10 +8096,10 @@
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
+        "async": "^1.4.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.4.4",
+        "uglify-js": "^2.6"
       },
       "dependencies": {
         "async": {
@@ -8114,7 +8114,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -8131,8 +8131,8 @@
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
       }
     },
     "harmony-reflect": {
@@ -8147,7 +8147,7 @@
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.0.2"
       }
     },
     "has-ansi": {
@@ -8156,7 +8156,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -8183,9 +8183,9 @@
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
-        "get-value": "2.0.6",
-        "has-values": "1.0.0",
-        "isobject": "3.0.1"
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "isobject": {
@@ -8202,8 +8202,8 @@
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -8212,7 +8212,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -8221,7 +8221,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -8232,7 +8232,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -8243,8 +8243,8 @@
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "hash.js": {
@@ -8253,8 +8253,8 @@
       "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1"
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "hawk": {
@@ -8263,10 +8263,10 @@
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "dev": true,
       "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.1",
-        "sntp": "2.1.0"
+        "boom": "4.x.x",
+        "cryptiles": "3.x.x",
+        "hoek": "4.x.x",
+        "sntp": "2.x.x"
       }
     },
     "he": {
@@ -8281,9 +8281,9 @@
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
-        "hash.js": "1.1.3",
-        "minimalistic-assert": "1.0.1",
-        "minimalistic-crypto-utils": "1.0.1"
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "hoek": {
@@ -8304,8 +8304,8 @@
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
       }
     },
     "homedir-polyfill": {
@@ -8314,7 +8314,7 @@
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "dev": true,
       "requires": {
-        "parse-passwd": "1.0.0"
+        "parse-passwd": "^1.0.0"
       }
     },
     "hosted-git-info": {
@@ -8341,7 +8341,7 @@
       "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
       "dev": true,
       "requires": {
-        "whatwg-encoding": "1.0.3"
+        "whatwg-encoding": "^1.0.1"
       }
     },
     "html-entities": {
@@ -8356,11 +8356,11 @@
       "integrity": "sha512-7hIW7YinOYUpo//kSYcPB6dCKoceKLmOwjEMmhIobHuWGDVl0Nwe4l68mdG/Ru0wcUxQjVMEoZpkalZ/SE7zog==",
       "dev": true,
       "requires": {
-        "es6-templates": "0.2.3",
-        "fastparse": "1.1.1",
-        "html-minifier": "3.5.15",
-        "loader-utils": "1.1.0",
-        "object-assign": "4.1.1"
+        "es6-templates": "^0.2.3",
+        "fastparse": "^1.1.1",
+        "html-minifier": "^3.5.8",
+        "loader-utils": "^1.1.0",
+        "object-assign": "^4.1.1"
       }
     },
     "html-minifier": {
@@ -8369,13 +8369,13 @@
       "integrity": "sha512-OZa4rfb6tZOZ3Z8Xf0jKxXkiDcFWldQePGYFDcgKqES2sXeWaEv9y6QQvWUtX3ySI3feApQi5uCsHLINQ6NoAw==",
       "dev": true,
       "requires": {
-        "camel-case": "3.0.0",
-        "clean-css": "4.1.11",
-        "commander": "2.15.1",
-        "he": "1.1.1",
-        "param-case": "2.1.1",
-        "relateurl": "0.2.7",
-        "uglify-js": "3.3.24"
+        "camel-case": "3.0.x",
+        "clean-css": "4.1.x",
+        "commander": "2.15.x",
+        "he": "1.1.x",
+        "param-case": "2.1.x",
+        "relateurl": "0.2.x",
+        "uglify-js": "3.3.x"
       },
       "dependencies": {
         "uglify-js": {
@@ -8384,8 +8384,8 @@
           "integrity": "sha512-hS7+TDiqIqvWScCcKRybCQzmMnEzJ4ryl9ErRmW4GFyG48p0/dKZiy/5mVLbsFzU8CCnCgQdxMiJzZythvLzCg==",
           "dev": true,
           "requires": {
-            "commander": "2.15.1",
-            "source-map": "0.6.1"
+            "commander": "~2.15.0",
+            "source-map": "~0.6.1"
           }
         }
       }
@@ -8402,12 +8402,12 @@
       "integrity": "sha1-f5xCG36pHsRg9WUn1430hO51N9U=",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.1",
-        "html-minifier": "3.5.15",
-        "loader-utils": "0.2.17",
-        "lodash": "4.17.10",
-        "pretty-error": "2.1.1",
-        "toposort": "1.0.7"
+        "bluebird": "^3.4.7",
+        "html-minifier": "^3.2.3",
+        "loader-utils": "^0.2.16",
+        "lodash": "^4.17.3",
+        "pretty-error": "^2.0.2",
+        "toposort": "^1.0.0"
       },
       "dependencies": {
         "loader-utils": {
@@ -8416,10 +8416,10 @@
           "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
           "dev": true,
           "requires": {
-            "big.js": "3.2.0",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1",
-            "object-assign": "4.1.1"
+            "big.js": "^3.1.3",
+            "emojis-list": "^2.0.0",
+            "json5": "^0.5.0",
+            "object-assign": "^4.0.1"
           }
         }
       }
@@ -8430,12 +8430,12 @@
       "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0",
-        "domhandler": "2.4.1",
-        "domutils": "1.5.1",
-        "entities": "1.1.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
+        "domelementtype": "^1.3.0",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "http-errors": {
@@ -8444,10 +8444,10 @@
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
-        "depd": "1.1.2",
+        "depd": "~1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": "1.4.0"
+        "statuses": ">= 1.4.0 < 2"
       }
     },
     "http-parser-js": {
@@ -8462,9 +8462,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.1"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "https-browserify": {
@@ -8479,9 +8479,9 @@
       "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
       "dev": true,
       "requires": {
-        "is-ci": "1.0.10",
-        "normalize-path": "1.0.0",
-        "strip-indent": "2.0.0"
+        "is-ci": "^1.0.10",
+        "normalize-path": "^1.0.0",
+        "strip-indent": "^2.0.0"
       },
       "dependencies": {
         "normalize-path": {
@@ -8521,7 +8521,7 @@
       "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.22"
+        "postcss": "^6.0.1"
       }
     },
     "identity-obj-proxy": {
@@ -8530,7 +8530,7 @@
       "integrity": "sha1-lNK9qWCERT7zb7xarsN+D3nx/BQ=",
       "dev": true,
       "requires": {
-        "harmony-reflect": "1.6.0"
+        "harmony-reflect": "^1.4.6"
       }
     },
     "ieee754": {
@@ -8563,8 +8563,8 @@
       "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
       "dev": true,
       "requires": {
-        "pkg-dir": "2.0.0",
-        "resolve-cwd": "2.0.0"
+        "pkg-dir": "^2.0.0",
+        "resolve-cwd": "^2.0.0"
       }
     },
     "imurmurhash": {
@@ -8585,7 +8585,7 @@
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "indexes-of": {
@@ -8606,8 +8606,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -8628,8 +8628,8 @@
       "integrity": "sha1-hVG45bTVcyROZqNLBPfTIHaitTQ=",
       "dev": true,
       "requires": {
-        "bowser": "1.9.3",
-        "css-in-js-utils": "2.0.1"
+        "bowser": "^1.7.3",
+        "css-in-js-utils": "^2.0.0"
       }
     },
     "inquirer": {
@@ -8638,20 +8638,20 @@
       "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "3.1.0",
-        "chalk": "2.3.0",
-        "cli-cursor": "2.1.0",
-        "cli-width": "2.2.0",
-        "external-editor": "2.2.0",
-        "figures": "2.0.0",
-        "lodash": "4.17.10",
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^2.0.4",
+        "figures": "^2.0.0",
+        "lodash": "^4.3.0",
         "mute-stream": "0.0.7",
-        "run-async": "2.3.0",
-        "rx-lite": "4.0.8",
-        "rx-lite-aggregates": "4.0.8",
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
-        "through": "2.3.8"
+        "run-async": "^2.2.0",
+        "rx-lite": "^4.0.8",
+        "rx-lite-aggregates": "^4.0.8",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^4.0.0",
+        "through": "^2.3.6"
       },
       "dependencies": {
         "ansi-regex": {
@@ -8672,7 +8672,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -8689,7 +8689,7 @@
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
-        "loose-envify": "1.3.1"
+        "loose-envify": "^1.0.0"
       }
     },
     "invert-kv": {
@@ -8716,7 +8716,7 @@
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-arrayish": {
@@ -8731,7 +8731,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.11.0"
+        "binary-extensions": "^1.0.0"
       }
     },
     "is-boolean-object": {
@@ -8752,7 +8752,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-callable": {
@@ -8767,7 +8767,7 @@
       "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
       "dev": true,
       "requires": {
-        "ci-info": "1.1.1"
+        "ci-info": "^1.0.0"
       }
     },
     "is-data-descriptor": {
@@ -8776,7 +8776,7 @@
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-date-object": {
@@ -8791,9 +8791,9 @@
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "0.1.6",
-        "is-data-descriptor": "0.1.4",
-        "kind-of": "5.1.0"
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -8828,7 +8828,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "2.0.0"
+        "is-primitive": "^2.0.0"
       }
     },
     "is-extendable": {
@@ -8849,7 +8849,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -8858,7 +8858,7 @@
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-function": {
@@ -8879,7 +8879,7 @@
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "is-my-ip-valid": {
@@ -8894,11 +8894,11 @@
       "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
       "dev": true,
       "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "is-my-ip-valid": "1.0.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "is-my-ip-valid": "^1.0.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "is-number": {
@@ -8907,7 +8907,7 @@
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-number-object": {
@@ -8928,7 +8928,7 @@
       "integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
       "dev": true,
       "requires": {
-        "symbol-observable": "0.2.4"
+        "symbol-observable": "^0.2.2"
       },
       "dependencies": {
         "symbol-observable": {
@@ -8945,7 +8945,7 @@
       "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
       "dev": true,
       "requires": {
-        "is-number": "4.0.0"
+        "is-number": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -8968,7 +8968,7 @@
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.1"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
@@ -8977,7 +8977,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-plain-obj": {
@@ -8992,7 +8992,7 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -9039,7 +9039,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "1.0.1"
+        "has": "^1.0.1"
       }
     },
     "is-regexp": {
@@ -9072,7 +9072,7 @@
       "integrity": "sha1-6+oRaaJhTaOSpjdANmw84EnY3/Y=",
       "dev": true,
       "requires": {
-        "protocols": "1.4.6"
+        "protocols": "^1.1.0"
       }
     },
     "is-stream": {
@@ -9098,7 +9098,7 @@
       "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
       "dev": true,
       "requires": {
-        "html-comment-regex": "1.1.1"
+        "html-comment-regex": "^1.1.0"
       }
     },
     "is-symbol": {
@@ -9113,7 +9113,7 @@
       "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
       "dev": true,
       "requires": {
-        "text-extensions": "1.7.0"
+        "text-extensions": "^1.0.0"
       }
     },
     "is-typedarray": {
@@ -9166,8 +9166,8 @@
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
-        "node-fetch": "1.7.3",
-        "whatwg-fetch": "2.0.4"
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
       }
     },
     "isstream": {
@@ -9182,18 +9182,18 @@
       "integrity": "sha512-duj6AlLcsWNwUpfyfHt0nWIeRiZpuShnP40YTxOGQgtaN8fd6JYSxsvxUphTDy8V5MfDXo4s/xVCIIvVCO808g==",
       "dev": true,
       "requires": {
-        "async": "2.6.0",
-        "compare-versions": "3.1.0",
-        "fileset": "2.0.3",
-        "istanbul-lib-coverage": "1.2.0",
-        "istanbul-lib-hook": "1.2.0",
-        "istanbul-lib-instrument": "1.10.1",
-        "istanbul-lib-report": "1.1.4",
-        "istanbul-lib-source-maps": "1.2.4",
-        "istanbul-reports": "1.3.0",
-        "js-yaml": "3.11.0",
-        "mkdirp": "0.5.1",
-        "once": "1.4.0"
+        "async": "^2.1.4",
+        "compare-versions": "^3.1.0",
+        "fileset": "^2.0.2",
+        "istanbul-lib-coverage": "^1.2.0",
+        "istanbul-lib-hook": "^1.2.0",
+        "istanbul-lib-instrument": "^1.10.1",
+        "istanbul-lib-report": "^1.1.4",
+        "istanbul-lib-source-maps": "^1.2.4",
+        "istanbul-reports": "^1.3.0",
+        "js-yaml": "^3.7.0",
+        "mkdirp": "^0.5.1",
+        "once": "^1.4.0"
       },
       "dependencies": {
         "debug": {
@@ -9211,11 +9211,11 @@
           "integrity": "sha512-UzuK0g1wyQijiaYQxj/CdNycFhAd2TLtO2obKQMTZrZ1jzEMRY3rvpASEKkaxbRR6brvdovfA03znPa/pXcejg==",
           "dev": true,
           "requires": {
-            "debug": "3.1.0",
-            "istanbul-lib-coverage": "1.2.0",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.2",
-            "source-map": "0.5.7"
+            "debug": "^3.1.0",
+            "istanbul-lib-coverage": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.6.1",
+            "source-map": "^0.5.3"
           }
         },
         "source-map": {
@@ -9238,7 +9238,7 @@
       "integrity": "sha512-p3En6/oGkFQV55Up8ZPC2oLxvgSxD8CzA0yBrhRZSh3pfv3OFj9aSGVC0yoerAi/O4u7jUVnOGVX1eVFM+0tmQ==",
       "dev": true,
       "requires": {
-        "append-transform": "0.4.0"
+        "append-transform": "^0.4.0"
       }
     },
     "istanbul-lib-instrument": {
@@ -9247,13 +9247,13 @@
       "integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
       "dev": true,
       "requires": {
-        "babel-generator": "6.26.1",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "istanbul-lib-coverage": "1.2.0",
-        "semver": "5.4.1"
+        "babel-generator": "^6.18.0",
+        "babel-template": "^6.16.0",
+        "babel-traverse": "^6.18.0",
+        "babel-types": "^6.18.0",
+        "babylon": "^6.18.0",
+        "istanbul-lib-coverage": "^1.2.0",
+        "semver": "^5.3.0"
       }
     },
     "istanbul-lib-report": {
@@ -9262,10 +9262,10 @@
       "integrity": "sha512-Azqvq5tT0U09nrncK3q82e/Zjkxa4tkFZv7E6VcqP0QCPn6oNljDPfrZEC/umNXds2t7b8sRJfs6Kmpzt8m2kA==",
       "dev": true,
       "requires": {
-        "istanbul-lib-coverage": "1.2.0",
-        "mkdirp": "0.5.1",
-        "path-parse": "1.0.5",
-        "supports-color": "3.2.3"
+        "istanbul-lib-coverage": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "path-parse": "^1.0.5",
+        "supports-color": "^3.1.2"
       },
       "dependencies": {
         "has-flag": {
@@ -9291,11 +9291,11 @@
       "integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
       "dev": true,
       "requires": {
-        "debug": "3.1.0",
-        "istanbul-lib-coverage": "1.2.0",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
-        "source-map": "0.5.7"
+        "debug": "^3.1.0",
+        "istanbul-lib-coverage": "^1.1.2",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.6.1",
+        "source-map": "^0.5.3"
       },
       "dependencies": {
         "debug": {
@@ -9321,7 +9321,7 @@
       "integrity": "sha512-y2Z2IMqE1gefWUaVjrBm0mSKvUkaBy9Vqz8iwr/r40Y9hBbIteH5wqHG/9DLTfJ9xUnUT2j7A3+VVJ6EaYBllA==",
       "dev": true,
       "requires": {
-        "handlebars": "4.0.11"
+        "handlebars": "^4.0.3"
       }
     },
     "jest": {
@@ -9330,8 +9330,8 @@
       "integrity": "sha512-FFCdU/pXOEASfHxFDOWUysI/+FFoqiXJADEIXgDKuZyqSmBD3tZ4BEGH7+M79v7czj7bbkhwtd2LaEDcJiM/GQ==",
       "dev": true,
       "requires": {
-        "import-local": "1.0.0",
-        "jest-cli": "22.4.3"
+        "import-local": "^1.0.0",
+        "jest-cli": "^22.4.3"
       },
       "dependencies": {
         "ansi-regex": {
@@ -9352,9 +9352,9 @@
           "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "dev": true,
           "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "jest-cli": {
@@ -9363,40 +9363,40 @@
           "integrity": "sha512-IiHybF0DJNqZPsbjn4Cy4vcqcmImpoFwNFnkehzVw8lTUSl4axZh5DHewu5bdpZF2Y5gUqFKYzH0FH4Qx2k+UA==",
           "dev": true,
           "requires": {
-            "ansi-escapes": "3.1.0",
-            "chalk": "2.3.0",
-            "exit": "0.1.2",
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "import-local": "1.0.0",
-            "is-ci": "1.0.10",
-            "istanbul-api": "1.3.1",
-            "istanbul-lib-coverage": "1.2.0",
-            "istanbul-lib-instrument": "1.10.1",
-            "istanbul-lib-source-maps": "1.2.3",
-            "jest-changed-files": "22.4.3",
-            "jest-config": "22.4.3",
-            "jest-environment-jsdom": "22.4.3",
-            "jest-get-type": "22.4.3",
-            "jest-haste-map": "22.4.3",
-            "jest-message-util": "22.4.3",
-            "jest-regex-util": "22.4.3",
-            "jest-resolve-dependencies": "22.4.3",
-            "jest-runner": "22.4.3",
-            "jest-runtime": "22.4.3",
-            "jest-snapshot": "22.4.3",
-            "jest-util": "22.4.3",
-            "jest-validate": "22.4.3",
-            "jest-worker": "22.4.3",
-            "micromatch": "2.3.11",
-            "node-notifier": "5.2.1",
-            "realpath-native": "1.0.0",
-            "rimraf": "2.6.2",
-            "slash": "1.0.0",
-            "string-length": "2.0.0",
-            "strip-ansi": "4.0.0",
-            "which": "1.3.0",
-            "yargs": "10.1.2"
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.1",
+            "exit": "^0.1.2",
+            "glob": "^7.1.2",
+            "graceful-fs": "^4.1.11",
+            "import-local": "^1.0.0",
+            "is-ci": "^1.0.10",
+            "istanbul-api": "^1.1.14",
+            "istanbul-lib-coverage": "^1.1.1",
+            "istanbul-lib-instrument": "^1.8.0",
+            "istanbul-lib-source-maps": "^1.2.1",
+            "jest-changed-files": "^22.4.3",
+            "jest-config": "^22.4.3",
+            "jest-environment-jsdom": "^22.4.3",
+            "jest-get-type": "^22.4.3",
+            "jest-haste-map": "^22.4.3",
+            "jest-message-util": "^22.4.3",
+            "jest-regex-util": "^22.4.3",
+            "jest-resolve-dependencies": "^22.4.3",
+            "jest-runner": "^22.4.3",
+            "jest-runtime": "^22.4.3",
+            "jest-snapshot": "^22.4.3",
+            "jest-util": "^22.4.3",
+            "jest-validate": "^22.4.3",
+            "jest-worker": "^22.4.3",
+            "micromatch": "^2.3.11",
+            "node-notifier": "^5.2.1",
+            "realpath-native": "^1.0.0",
+            "rimraf": "^2.5.4",
+            "slash": "^1.0.0",
+            "string-length": "^2.0.0",
+            "strip-ansi": "^4.0.0",
+            "which": "^1.2.12",
+            "yargs": "^10.0.3"
           }
         },
         "strip-ansi": {
@@ -9405,7 +9405,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "yargs": {
@@ -9414,18 +9414,18 @@
           "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
           "dev": true,
           "requires": {
-            "cliui": "4.1.0",
-            "decamelize": "1.2.0",
-            "find-up": "2.1.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "8.1.0"
+            "cliui": "^4.0.0",
+            "decamelize": "^1.1.1",
+            "find-up": "^2.1.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^8.1.0"
           }
         },
         "yargs-parser": {
@@ -9434,7 +9434,7 @@
           "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0"
+            "camelcase": "^4.1.0"
           }
         }
       }
@@ -9445,7 +9445,7 @@
       "integrity": "sha512-83Dh0w1aSkUNFhy5d2dvqWxi/y6weDwVVLU6vmK0cV9VpRxPzhTeGimbsbRDSnEoszhF937M4sDLLeS7Cu/Tmw==",
       "dev": true,
       "requires": {
-        "throat": "4.1.0"
+        "throat": "^4.0.0"
       }
     },
     "jest-config": {
@@ -9454,17 +9454,17 @@
       "integrity": "sha512-KSg3EOToCgkX+lIvenKY7J8s426h6ahXxaUFJxvGoEk0562Z6inWj1TnKoGycTASwiLD+6kSYFALcjdosq9KIQ==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
-        "glob": "7.1.2",
-        "jest-environment-jsdom": "22.4.3",
-        "jest-environment-node": "22.4.3",
-        "jest-get-type": "22.4.3",
-        "jest-jasmine2": "22.4.3",
-        "jest-regex-util": "22.4.3",
-        "jest-resolve": "22.4.3",
-        "jest-util": "22.4.3",
-        "jest-validate": "22.4.3",
-        "pretty-format": "22.4.3"
+        "chalk": "^2.0.1",
+        "glob": "^7.1.1",
+        "jest-environment-jsdom": "^22.4.3",
+        "jest-environment-node": "^22.4.3",
+        "jest-get-type": "^22.4.3",
+        "jest-jasmine2": "^22.4.3",
+        "jest-regex-util": "^22.4.3",
+        "jest-resolve": "^22.4.3",
+        "jest-util": "^22.4.3",
+        "jest-validate": "^22.4.3",
+        "pretty-format": "^22.4.3"
       }
     },
     "jest-diff": {
@@ -9473,10 +9473,10 @@
       "integrity": "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
-        "diff": "3.5.0",
-        "jest-get-type": "22.4.3",
-        "pretty-format": "22.4.3"
+        "chalk": "^2.0.1",
+        "diff": "^3.2.0",
+        "jest-get-type": "^22.4.3",
+        "pretty-format": "^22.4.3"
       }
     },
     "jest-docblock": {
@@ -9485,7 +9485,7 @@
       "integrity": "sha512-uPKBEAw7YrEMcXueMKZXn/rbMxBiSv48fSqy3uEnmgOlQhSX+lthBqHb1fKWNVmFqAp9E/RsSdBfiV31LbzaOg==",
       "dev": true,
       "requires": {
-        "detect-newline": "2.1.0"
+        "detect-newline": "^2.1.0"
       }
     },
     "jest-environment-enzyme": {
@@ -9494,7 +9494,7 @@
       "integrity": "sha1-RpzqoKIVea+GywElXwWRo6XZX0A=",
       "dev": true,
       "requires": {
-        "jest-environment-jsdom": "22.4.3"
+        "jest-environment-jsdom": "^22.4.1"
       }
     },
     "jest-environment-jsdom": {
@@ -9503,9 +9503,9 @@
       "integrity": "sha512-FviwfR+VyT3Datf13+ULjIMO5CSeajlayhhYQwpzgunswoaLIPutdbrnfUHEMyJCwvqQFaVtTmn9+Y8WCt6n1w==",
       "dev": true,
       "requires": {
-        "jest-mock": "22.4.3",
-        "jest-util": "22.4.3",
-        "jsdom": "11.10.0"
+        "jest-mock": "^22.4.3",
+        "jest-util": "^22.4.3",
+        "jsdom": "^11.5.1"
       }
     },
     "jest-environment-node": {
@@ -9514,8 +9514,8 @@
       "integrity": "sha512-reZl8XF6t/lMEuPWwo9OLfttyC26A5AMgDyEQ6DBgZuyfyeNUzYT8BFo6uxCCP/Av/b7eb9fTi3sIHFPBzmlRA==",
       "dev": true,
       "requires": {
-        "jest-mock": "22.4.3",
-        "jest-util": "22.4.3"
+        "jest-mock": "^22.4.3",
+        "jest-util": "^22.4.3"
       }
     },
     "jest-enzyme": {
@@ -9524,9 +9524,9 @@
       "integrity": "sha1-UY1OzF4yyMFWS0G3vIPqOGZ+hmE=",
       "dev": true,
       "requires": {
-        "enzyme-matchers": "6.0.0",
-        "enzyme-to-json": "3.3.3",
-        "jest-environment-enzyme": "6.0.0"
+        "enzyme-matchers": "^6.0.0",
+        "enzyme-to-json": "^3.3.0",
+        "jest-environment-enzyme": "^6.0.0"
       }
     },
     "jest-get-type": {
@@ -9541,13 +9541,13 @@
       "integrity": "sha512-4Q9fjzuPVwnaqGKDpIsCSoTSnG3cteyk2oNVjBX12HHOaF1oxql+uUiqZb5Ndu7g/vTZfdNwwy4WwYogLh29DQ==",
       "dev": true,
       "requires": {
-        "fb-watchman": "2.0.0",
-        "graceful-fs": "4.1.11",
-        "jest-docblock": "22.4.3",
-        "jest-serializer": "22.4.3",
-        "jest-worker": "22.4.3",
-        "micromatch": "2.3.11",
-        "sane": "2.5.1"
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.1.11",
+        "jest-docblock": "^22.4.3",
+        "jest-serializer": "^22.4.3",
+        "jest-worker": "^22.4.3",
+        "micromatch": "^2.3.11",
+        "sane": "^2.0.0"
       }
     },
     "jest-jasmine2": {
@@ -9556,17 +9556,17 @@
       "integrity": "sha512-yZCPCJUcEY6R5KJB/VReo1AYI2b+5Ky+C+JA1v34jndJsRcLpU4IZX4rFJn7yDTtdNbO/nNqg+3SDIPNH2ecnw==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
-        "co": "4.6.0",
-        "expect": "22.4.3",
-        "graceful-fs": "4.1.11",
-        "is-generator-fn": "1.0.0",
-        "jest-diff": "22.4.3",
-        "jest-matcher-utils": "22.4.3",
-        "jest-message-util": "22.4.3",
-        "jest-snapshot": "22.4.3",
-        "jest-util": "22.4.3",
-        "source-map-support": "0.5.5"
+        "chalk": "^2.0.1",
+        "co": "^4.6.0",
+        "expect": "^22.4.3",
+        "graceful-fs": "^4.1.11",
+        "is-generator-fn": "^1.0.0",
+        "jest-diff": "^22.4.3",
+        "jest-matcher-utils": "^22.4.3",
+        "jest-message-util": "^22.4.3",
+        "jest-snapshot": "^22.4.3",
+        "jest-util": "^22.4.3",
+        "source-map-support": "^0.5.0"
       }
     },
     "jest-leak-detector": {
@@ -9575,7 +9575,7 @@
       "integrity": "sha512-NZpR/Ls7+ndO57LuXROdgCGz2RmUdC541tTImL9bdUtU3WadgFGm0yV+Ok4Fuia/1rLAn5KaJ+i76L6e3zGJYQ==",
       "dev": true,
       "requires": {
-        "pretty-format": "22.4.3"
+        "pretty-format": "^22.4.3"
       }
     },
     "jest-matcher-utils": {
@@ -9584,9 +9584,9 @@
       "integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
-        "jest-get-type": "22.4.3",
-        "pretty-format": "22.4.3"
+        "chalk": "^2.0.1",
+        "jest-get-type": "^22.4.3",
+        "pretty-format": "^22.4.3"
       }
     },
     "jest-message-util": {
@@ -9595,11 +9595,11 @@
       "integrity": "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.46",
-        "chalk": "2.3.0",
-        "micromatch": "2.3.11",
-        "slash": "1.0.0",
-        "stack-utils": "1.0.1"
+        "@babel/code-frame": "^7.0.0-beta.35",
+        "chalk": "^2.0.1",
+        "micromatch": "^2.3.11",
+        "slash": "^1.0.0",
+        "stack-utils": "^1.0.1"
       }
     },
     "jest-mock": {
@@ -9620,8 +9620,8 @@
       "integrity": "sha512-u3BkD/MQBmwrOJDzDIaxpyqTxYH+XqAXzVJP51gt29H8jpj3QgKof5GGO2uPGKGeA1yTMlpbMs1gIQ6U4vcRhw==",
       "dev": true,
       "requires": {
-        "browser-resolve": "1.11.2",
-        "chalk": "2.3.0"
+        "browser-resolve": "^1.11.2",
+        "chalk": "^2.0.1"
       }
     },
     "jest-resolve-dependencies": {
@@ -9630,7 +9630,7 @@
       "integrity": "sha512-06czCMVToSN8F2U4EvgSB1Bv/56gc7MpCftZ9z9fBgUQM7dzHGCMBsyfVA6dZTx8v0FDcnALf7hupeQxaBCvpA==",
       "dev": true,
       "requires": {
-        "jest-regex-util": "22.4.3"
+        "jest-regex-util": "^22.4.3"
       }
     },
     "jest-runner": {
@@ -9639,17 +9639,17 @@
       "integrity": "sha512-U7PLlQPRlWNbvOHWOrrVay9sqhBJmiKeAdKIkvX4n1G2tsvzLlf77nBD28GL1N6tGv4RmuTfI8R8JrkvCa+IBg==",
       "dev": true,
       "requires": {
-        "exit": "0.1.2",
-        "jest-config": "22.4.3",
-        "jest-docblock": "22.4.3",
-        "jest-haste-map": "22.4.3",
-        "jest-jasmine2": "22.4.3",
-        "jest-leak-detector": "22.4.3",
-        "jest-message-util": "22.4.3",
-        "jest-runtime": "22.4.3",
-        "jest-util": "22.4.3",
-        "jest-worker": "22.4.3",
-        "throat": "4.1.0"
+        "exit": "^0.1.2",
+        "jest-config": "^22.4.3",
+        "jest-docblock": "^22.4.3",
+        "jest-haste-map": "^22.4.3",
+        "jest-jasmine2": "^22.4.3",
+        "jest-leak-detector": "^22.4.3",
+        "jest-message-util": "^22.4.3",
+        "jest-runtime": "^22.4.3",
+        "jest-util": "^22.4.3",
+        "jest-worker": "^22.4.3",
+        "throat": "^4.0.0"
       }
     },
     "jest-runtime": {
@@ -9658,26 +9658,26 @@
       "integrity": "sha512-Eat/esQjevhx9BgJEC8udye+FfoJ2qvxAZfOAWshYGS22HydHn5BgsvPdTtt9cp0fSl5LxYOFA1Pja9Iz2Zt8g==",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.3",
-        "babel-jest": "22.4.3",
-        "babel-plugin-istanbul": "4.1.6",
-        "chalk": "2.3.0",
-        "convert-source-map": "1.5.1",
-        "exit": "0.1.2",
-        "graceful-fs": "4.1.11",
-        "jest-config": "22.4.3",
-        "jest-haste-map": "22.4.3",
-        "jest-regex-util": "22.4.3",
-        "jest-resolve": "22.4.3",
-        "jest-util": "22.4.3",
-        "jest-validate": "22.4.3",
-        "json-stable-stringify": "1.0.1",
-        "micromatch": "2.3.11",
-        "realpath-native": "1.0.0",
-        "slash": "1.0.0",
+        "babel-core": "^6.0.0",
+        "babel-jest": "^22.4.3",
+        "babel-plugin-istanbul": "^4.1.5",
+        "chalk": "^2.0.1",
+        "convert-source-map": "^1.4.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.1.11",
+        "jest-config": "^22.4.3",
+        "jest-haste-map": "^22.4.3",
+        "jest-regex-util": "^22.4.3",
+        "jest-resolve": "^22.4.3",
+        "jest-util": "^22.4.3",
+        "jest-validate": "^22.4.3",
+        "json-stable-stringify": "^1.0.1",
+        "micromatch": "^2.3.11",
+        "realpath-native": "^1.0.0",
+        "slash": "^1.0.0",
         "strip-bom": "3.0.0",
-        "write-file-atomic": "2.3.0",
-        "yargs": "10.1.2"
+        "write-file-atomic": "^2.1.0",
+        "yargs": "^10.0.3"
       },
       "dependencies": {
         "ansi-regex": {
@@ -9698,9 +9698,9 @@
           "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "dev": true,
           "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "strip-ansi": {
@@ -9709,7 +9709,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "yargs": {
@@ -9718,18 +9718,18 @@
           "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
           "dev": true,
           "requires": {
-            "cliui": "4.1.0",
-            "decamelize": "1.2.0",
-            "find-up": "2.1.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "8.1.0"
+            "cliui": "^4.0.0",
+            "decamelize": "^1.1.1",
+            "find-up": "^2.1.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^8.1.0"
           }
         },
         "yargs-parser": {
@@ -9738,7 +9738,7 @@
           "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0"
+            "camelcase": "^4.1.0"
           }
         }
       }
@@ -9755,12 +9755,12 @@
       "integrity": "sha512-JXA0gVs5YL0HtLDCGa9YxcmmV2LZbwJ+0MfyXBBc5qpgkEYITQFJP7XNhcHFbUvRiniRpRbGVfJrOoYhhGE0RQ==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
-        "jest-diff": "22.4.3",
-        "jest-matcher-utils": "22.4.3",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "pretty-format": "22.4.3"
+        "chalk": "^2.0.1",
+        "jest-diff": "^22.4.3",
+        "jest-matcher-utils": "^22.4.3",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^22.4.3"
       }
     },
     "jest-util": {
@@ -9769,13 +9769,13 @@
       "integrity": "sha512-rfDfG8wyC5pDPNdcnAlZgwKnzHvZDu8Td2NJI/jAGKEGxJPYiE4F0ss/gSAkG4778Y23Hvbz+0GMrDJTeo7RjQ==",
       "dev": true,
       "requires": {
-        "callsites": "2.0.0",
-        "chalk": "2.3.0",
-        "graceful-fs": "4.1.11",
-        "is-ci": "1.0.10",
-        "jest-message-util": "22.4.3",
-        "mkdirp": "0.5.1",
-        "source-map": "0.6.1"
+        "callsites": "^2.0.0",
+        "chalk": "^2.0.1",
+        "graceful-fs": "^4.1.11",
+        "is-ci": "^1.0.10",
+        "jest-message-util": "^22.4.3",
+        "mkdirp": "^0.5.1",
+        "source-map": "^0.6.0"
       }
     },
     "jest-validate": {
@@ -9784,11 +9784,11 @@
       "integrity": "sha512-CfFM18W3GSP/xgmA4UouIx0ljdtfD2mjeBC6c89Gg17E44D4tQhAcTrZmf9djvipwU30kSTnk6CzcxdCCeSXfA==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
-        "jest-config": "22.4.3",
-        "jest-get-type": "22.4.3",
-        "leven": "2.1.0",
-        "pretty-format": "22.4.3"
+        "chalk": "^2.0.1",
+        "jest-config": "^22.4.3",
+        "jest-get-type": "^22.4.3",
+        "leven": "^2.1.0",
+        "pretty-format": "^22.4.3"
       }
     },
     "jest-worker": {
@@ -9797,7 +9797,7 @@
       "integrity": "sha512-B1ucW4fI8qVAuZmicFxI1R3kr2fNeYJyvIQ1rKcuLYnenFV5K5aMbxFj6J0i00Ju83S8jP2d7Dz14+AvbIHRYQ==",
       "dev": true,
       "requires": {
-        "merge-stream": "1.0.1"
+        "merge-stream": "^1.0.1"
       }
     },
     "js-base64": {
@@ -9817,8 +9817,8 @@
       "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsbn": {
@@ -9834,32 +9834,32 @@
       "integrity": "sha512-x5No5FpJgBg3j5aBwA8ka6eGuS5IxbC8FOkmyccKvObtFT0bDMict/LOxINZsZGZSfGdNomLZ/qRV9Bpq/GIBA==",
       "dev": true,
       "requires": {
-        "abab": "1.0.4",
-        "acorn": "5.5.3",
-        "acorn-globals": "4.1.0",
-        "array-equal": "1.0.0",
-        "cssom": "0.3.2",
-        "cssstyle": "0.2.37",
-        "data-urls": "1.0.0",
-        "domexception": "1.0.1",
-        "escodegen": "1.9.1",
-        "html-encoding-sniffer": "1.0.2",
-        "left-pad": "1.3.0",
-        "nwmatcher": "1.4.4",
+        "abab": "^1.0.4",
+        "acorn": "^5.3.0",
+        "acorn-globals": "^4.1.0",
+        "array-equal": "^1.0.0",
+        "cssom": ">= 0.3.2 < 0.4.0",
+        "cssstyle": ">= 0.2.37 < 0.3.0",
+        "data-urls": "^1.0.0",
+        "domexception": "^1.0.0",
+        "escodegen": "^1.9.0",
+        "html-encoding-sniffer": "^1.0.2",
+        "left-pad": "^1.2.0",
+        "nwmatcher": "^1.4.3",
         "parse5": "4.0.0",
-        "pn": "1.1.0",
-        "request": "2.85.0",
-        "request-promise-native": "1.0.5",
-        "sax": "1.2.4",
-        "symbol-tree": "3.2.2",
-        "tough-cookie": "2.3.4",
-        "w3c-hr-time": "1.0.1",
-        "webidl-conversions": "4.0.2",
-        "whatwg-encoding": "1.0.3",
-        "whatwg-mimetype": "2.1.0",
-        "whatwg-url": "6.4.1",
-        "ws": "4.1.0",
-        "xml-name-validator": "3.0.0"
+        "pn": "^1.1.0",
+        "request": "^2.83.0",
+        "request-promise-native": "^1.0.5",
+        "sax": "^1.2.4",
+        "symbol-tree": "^3.2.2",
+        "tough-cookie": "^2.3.3",
+        "w3c-hr-time": "^1.0.1",
+        "webidl-conversions": "^4.0.2",
+        "whatwg-encoding": "^1.0.3",
+        "whatwg-mimetype": "^2.1.0",
+        "whatwg-url": "^6.4.0",
+        "ws": "^4.0.0",
+        "xml-name-validator": "^3.0.0"
       },
       "dependencies": {
         "parse5": {
@@ -9906,7 +9906,7 @@
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json-stable-stringify-without-jsonify": {
@@ -9969,7 +9969,7 @@
       "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
       "dev": true,
       "requires": {
-        "array-includes": "3.0.3"
+        "array-includes": "^3.0.3"
       }
     },
     "keycode": {
@@ -9984,7 +9984,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "lazy-cache": {
@@ -9999,7 +9999,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "^1.0.0"
       }
     },
     "lcov-parse": {
@@ -10020,45 +10020,45 @@
       "integrity": "sha512-kgM6zwe2P2tR30MYvgiLLW+9buFCm6E7o8HnRlhTgm70WVBvXVhydqv+q/MF2HrVZkCawfVtCfetyQmtd4oHhQ==",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "chalk": "2.3.0",
-        "cmd-shim": "2.0.2",
-        "columnify": "1.5.4",
-        "command-join": "2.0.0",
-        "conventional-changelog-cli": "1.3.22",
-        "conventional-recommended-bump": "1.2.1",
-        "dedent": "0.7.0",
-        "execa": "0.8.0",
-        "find-up": "2.1.0",
-        "fs-extra": "4.0.3",
-        "get-port": "3.2.0",
-        "glob": "7.1.2",
-        "glob-parent": "3.1.0",
-        "globby": "6.1.0",
-        "graceful-fs": "4.1.11",
-        "hosted-git-info": "2.5.0",
-        "inquirer": "3.3.0",
-        "is-ci": "1.0.10",
-        "load-json-file": "4.0.0",
-        "lodash": "4.17.10",
-        "minimatch": "3.0.4",
-        "npmlog": "4.1.2",
-        "p-finally": "1.0.0",
-        "package-json": "4.0.1",
-        "path-exists": "3.0.0",
-        "read-cmd-shim": "1.0.1",
-        "read-pkg": "3.0.0",
-        "rimraf": "2.6.2",
-        "safe-buffer": "5.1.1",
-        "semver": "5.4.1",
-        "signal-exit": "3.0.2",
-        "slash": "1.0.0",
-        "strong-log-transformer": "1.0.6",
-        "temp-write": "3.4.0",
-        "write-file-atomic": "2.3.0",
-        "write-json-file": "2.3.0",
-        "write-pkg": "3.1.0",
-        "yargs": "8.0.2"
+        "async": "^1.5.0",
+        "chalk": "^2.1.0",
+        "cmd-shim": "^2.0.2",
+        "columnify": "^1.5.4",
+        "command-join": "^2.0.0",
+        "conventional-changelog-cli": "^1.3.13",
+        "conventional-recommended-bump": "^1.2.1",
+        "dedent": "^0.7.0",
+        "execa": "^0.8.0",
+        "find-up": "^2.1.0",
+        "fs-extra": "^4.0.1",
+        "get-port": "^3.2.0",
+        "glob": "^7.1.2",
+        "glob-parent": "^3.1.0",
+        "globby": "^6.1.0",
+        "graceful-fs": "^4.1.11",
+        "hosted-git-info": "^2.5.0",
+        "inquirer": "^3.2.2",
+        "is-ci": "^1.0.10",
+        "load-json-file": "^4.0.0",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4",
+        "npmlog": "^4.1.2",
+        "p-finally": "^1.0.0",
+        "package-json": "^4.0.1",
+        "path-exists": "^3.0.0",
+        "read-cmd-shim": "^1.0.1",
+        "read-pkg": "^3.0.0",
+        "rimraf": "^2.6.1",
+        "safe-buffer": "^5.1.1",
+        "semver": "^5.4.1",
+        "signal-exit": "^3.0.2",
+        "slash": "^1.0.0",
+        "strong-log-transformer": "^1.0.6",
+        "temp-write": "^3.3.0",
+        "write-file-atomic": "^2.3.0",
+        "write-json-file": "^2.2.0",
+        "write-pkg": "^3.1.0",
+        "yargs": "^8.0.2"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -10085,7 +10085,7 @@
           "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
           "dev": true,
           "requires": {
-            "restore-cursor": "2.0.0"
+            "restore-cursor": "^2.0.0"
           }
         },
         "execa": {
@@ -10094,13 +10094,13 @@
           "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
           "dev": true,
           "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
           }
         },
         "figures": {
@@ -10109,7 +10109,7 @@
           "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "1.0.5"
+            "escape-string-regexp": "^1.0.5"
           }
         },
         "fs-extra": {
@@ -10118,9 +10118,9 @@
           "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "4.0.0",
-            "universalify": "0.1.1"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
           }
         },
         "glob-parent": {
@@ -10129,8 +10129,8 @@
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
-            "is-glob": "3.1.0",
-            "path-dirname": "1.0.2"
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
           }
         },
         "globby": {
@@ -10139,11 +10139,11 @@
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "dev": true,
           "requires": {
-            "array-union": "1.0.2",
-            "glob": "7.1.2",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "array-union": "^1.0.1",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "inquirer": {
@@ -10152,20 +10152,20 @@
           "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
           "dev": true,
           "requires": {
-            "ansi-escapes": "3.1.0",
-            "chalk": "2.3.0",
-            "cli-cursor": "2.1.0",
-            "cli-width": "2.2.0",
-            "external-editor": "2.2.0",
-            "figures": "2.0.0",
-            "lodash": "4.17.10",
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.0.4",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
             "mute-stream": "0.0.7",
-            "run-async": "2.3.0",
-            "rx-lite": "4.0.8",
-            "rx-lite-aggregates": "4.0.8",
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "through": "2.3.8"
+            "run-async": "^2.2.0",
+            "rx-lite": "^4.0.8",
+            "rx-lite-aggregates": "^4.0.8",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
           }
         },
         "is-extglob": {
@@ -10180,7 +10180,7 @@
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.0"
           }
         },
         "jsonfile": {
@@ -10189,7 +10189,7 @@
           "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11"
+            "graceful-fs": "^4.1.6"
           }
         },
         "load-json-file": {
@@ -10198,10 +10198,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "4.0.0",
-            "pify": "3.0.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
           },
           "dependencies": {
             "pify": {
@@ -10230,7 +10230,7 @@
           "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
           "dev": true,
           "requires": {
-            "mimic-fn": "1.1.0"
+            "mimic-fn": "^1.0.0"
           }
         },
         "parse-json": {
@@ -10239,8 +10239,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.1",
-            "json-parse-better-errors": "1.0.2"
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
           }
         },
         "path-type": {
@@ -10249,7 +10249,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "3.0.0"
+            "pify": "^3.0.0"
           },
           "dependencies": {
             "pify": {
@@ -10272,9 +10272,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "4.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "3.0.0"
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
           }
         },
         "restore-cursor": {
@@ -10283,8 +10283,8 @@
           "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
           "dev": true,
           "requires": {
-            "onetime": "2.0.1",
-            "signal-exit": "3.0.2"
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
           }
         },
         "run-async": {
@@ -10293,7 +10293,7 @@
           "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
           "dev": true,
           "requires": {
-            "is-promise": "2.1.0"
+            "is-promise": "^2.1.0"
           }
         },
         "rx-lite": {
@@ -10308,7 +10308,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -10325,8 +10325,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "lint-staged": {
@@ -10335,29 +10335,29 @@
       "integrity": "sha512-0l+PRD21v2zBRcfEIxjFMo2DiQ94wykRXH/aEw3aTMYUmnpTRPS1rc3DryPWf+qtK1Pjd51pLigHGopxgDMK5A==",
       "dev": true,
       "requires": {
-        "app-root-path": "2.0.1",
-        "chalk": "2.4.1",
-        "commander": "2.15.1",
-        "cosmiconfig": "4.0.0",
-        "debug": "3.1.0",
-        "dedent": "0.7.0",
-        "execa": "0.9.0",
-        "find-parent-dir": "0.3.0",
-        "is-glob": "4.0.0",
-        "is-windows": "1.0.2",
-        "jest-validate": "22.4.3",
-        "listr": "0.13.0",
-        "lodash": "4.17.10",
-        "log-symbols": "2.2.0",
-        "micromatch": "3.1.10",
-        "npm-which": "3.0.1",
-        "p-map": "1.2.0",
-        "path-is-inside": "1.0.2",
-        "pify": "3.0.0",
-        "please-upgrade-node": "3.0.2",
+        "app-root-path": "^2.0.1",
+        "chalk": "^2.3.1",
+        "commander": "^2.14.1",
+        "cosmiconfig": "^4.0.0",
+        "debug": "^3.1.0",
+        "dedent": "^0.7.0",
+        "execa": "^0.9.0",
+        "find-parent-dir": "^0.3.0",
+        "is-glob": "^4.0.0",
+        "is-windows": "^1.0.2",
+        "jest-validate": "^22.4.0",
+        "listr": "^0.13.0",
+        "lodash": "^4.17.5",
+        "log-symbols": "^2.2.0",
+        "micromatch": "^3.1.8",
+        "npm-which": "^3.0.1",
+        "p-map": "^1.1.1",
+        "path-is-inside": "^1.0.2",
+        "pify": "^3.0.0",
+        "please-upgrade-node": "^3.0.2",
         "staged-git-files": "1.1.1",
-        "string-argv": "0.0.2",
-        "stringify-object": "3.2.2"
+        "string-argv": "^0.0.2",
+        "stringify-object": "^3.2.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -10366,7 +10366,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "^1.9.0"
           }
         },
         "arr-diff": {
@@ -10387,16 +10387,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0",
-            "array-unique": "0.3.2",
-            "extend-shallow": "2.0.1",
-            "fill-range": "4.0.0",
-            "isobject": "3.0.1",
-            "repeat-element": "1.1.2",
-            "snapdragon": "0.8.2",
-            "snapdragon-node": "2.1.1",
-            "split-string": "3.1.0",
-            "to-regex": "3.0.2"
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -10405,7 +10405,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -10416,9 +10416,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "cosmiconfig": {
@@ -10427,10 +10427,10 @@
           "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
           "dev": true,
           "requires": {
-            "is-directory": "0.3.1",
-            "js-yaml": "3.11.0",
-            "parse-json": "4.0.0",
-            "require-from-string": "2.0.2"
+            "is-directory": "^0.3.1",
+            "js-yaml": "^3.9.0",
+            "parse-json": "^4.0.0",
+            "require-from-string": "^2.0.1"
           }
         },
         "debug": {
@@ -10448,13 +10448,13 @@
           "integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
           "dev": true,
           "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
           }
         },
         "expand-brackets": {
@@ -10463,13 +10463,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "posix-character-classes": "0.1.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "debug": {
@@ -10487,7 +10487,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             },
             "extend-shallow": {
@@ -10496,7 +10496,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             },
             "is-accessor-descriptor": {
@@ -10505,7 +10505,7 @@
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -10514,7 +10514,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -10525,7 +10525,7 @@
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -10534,7 +10534,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -10545,9 +10545,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
               }
             },
             "kind-of": {
@@ -10564,14 +10564,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "0.3.2",
-            "define-property": "1.0.0",
-            "expand-brackets": "2.1.4",
-            "extend-shallow": "2.0.1",
-            "fragment-cache": "0.2.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -10580,7 +10580,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "1.0.2"
+                "is-descriptor": "^1.0.0"
               }
             },
             "extend-shallow": {
@@ -10589,7 +10589,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -10600,10 +10600,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-number": "3.0.0",
-            "repeat-string": "1.6.1",
-            "to-regex-range": "2.1.1"
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
           },
           "dependencies": {
             "extend-shallow": {
@@ -10612,7 +10612,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -10629,7 +10629,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -10638,7 +10638,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -10647,9 +10647,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "is-extglob": {
@@ -10664,7 +10664,7 @@
           "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
           "dev": true,
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.1"
           }
         },
         "is-number": {
@@ -10673,7 +10673,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -10682,7 +10682,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -10705,19 +10705,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "braces": "2.3.2",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "extglob": "2.0.4",
-            "fragment-cache": "0.2.1",
-            "kind-of": "6.0.2",
-            "nanomatch": "1.2.9",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
           }
         },
         "parse-json": {
@@ -10726,8 +10726,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.1",
-            "json-parse-better-errors": "1.0.2"
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
           }
         },
         "require-from-string": {
@@ -10742,7 +10742,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -10753,23 +10753,23 @@
       "integrity": "sha1-ILsLowuuZg7oTMBQPfS+PVYjiH0=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "cli-truncate": "0.2.1",
-        "figures": "1.7.0",
-        "indent-string": "2.1.0",
-        "is-observable": "0.2.0",
-        "is-promise": "2.1.0",
-        "is-stream": "1.1.0",
-        "listr-silent-renderer": "1.1.1",
-        "listr-update-renderer": "0.4.0",
-        "listr-verbose-renderer": "0.4.1",
-        "log-symbols": "1.0.2",
-        "log-update": "1.0.2",
-        "ora": "0.2.3",
-        "p-map": "1.2.0",
-        "rxjs": "5.5.10",
-        "stream-to-observable": "0.2.0",
-        "strip-ansi": "3.0.1"
+        "chalk": "^1.1.3",
+        "cli-truncate": "^0.2.1",
+        "figures": "^1.7.0",
+        "indent-string": "^2.1.0",
+        "is-observable": "^0.2.0",
+        "is-promise": "^2.1.0",
+        "is-stream": "^1.1.0",
+        "listr-silent-renderer": "^1.1.1",
+        "listr-update-renderer": "^0.4.0",
+        "listr-verbose-renderer": "^0.4.0",
+        "log-symbols": "^1.0.2",
+        "log-update": "^1.0.2",
+        "ora": "^0.2.3",
+        "p-map": "^1.1.1",
+        "rxjs": "^5.4.2",
+        "stream-to-observable": "^0.2.0",
+        "strip-ansi": "^3.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -10784,11 +10784,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "figures": {
@@ -10797,8 +10797,8 @@
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.1"
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
           }
         },
         "log-symbols": {
@@ -10807,7 +10807,7 @@
           "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3"
+            "chalk": "^1.0.0"
           }
         },
         "supports-color": {
@@ -10830,14 +10830,14 @@
       "integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "cli-truncate": "0.2.1",
-        "elegant-spinner": "1.0.1",
-        "figures": "1.7.0",
-        "indent-string": "3.2.0",
-        "log-symbols": "1.0.2",
-        "log-update": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "chalk": "^1.1.3",
+        "cli-truncate": "^0.2.1",
+        "elegant-spinner": "^1.0.1",
+        "figures": "^1.7.0",
+        "indent-string": "^3.0.0",
+        "log-symbols": "^1.0.2",
+        "log-update": "^1.0.2",
+        "strip-ansi": "^3.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -10852,11 +10852,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "figures": {
@@ -10865,8 +10865,8 @@
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.1"
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
           }
         },
         "indent-string": {
@@ -10881,7 +10881,7 @@
           "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3"
+            "chalk": "^1.0.0"
           }
         },
         "supports-color": {
@@ -10898,10 +10898,10 @@
       "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "date-fns": "1.29.0",
-        "figures": "1.7.0"
+        "chalk": "^1.1.3",
+        "cli-cursor": "^1.0.2",
+        "date-fns": "^1.27.2",
+        "figures": "^1.7.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -10916,11 +10916,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "cli-cursor": {
@@ -10929,7 +10929,7 @@
           "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
           "dev": true,
           "requires": {
-            "restore-cursor": "1.0.1"
+            "restore-cursor": "^1.0.1"
           }
         },
         "figures": {
@@ -10938,8 +10938,8 @@
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.1"
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
           }
         },
         "onetime": {
@@ -10954,8 +10954,8 @@
           "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
           "dev": true,
           "requires": {
-            "exit-hook": "1.1.1",
-            "onetime": "1.1.0"
+            "exit-hook": "^1.0.0",
+            "onetime": "^1.0.0"
           }
         },
         "supports-color": {
@@ -10972,10 +10972,10 @@
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "strip-bom": "3.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "strip-bom": "^3.0.0"
       },
       "dependencies": {
         "pify": {
@@ -10998,9 +10998,9 @@
       "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
       "dev": true,
       "requires": {
-        "big.js": "3.2.0",
-        "emojis-list": "2.1.0",
-        "json5": "0.5.1"
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0"
       }
     },
     "locate-path": {
@@ -11009,8 +11009,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
@@ -11031,9 +11031,9 @@
       "integrity": "sha1-2AJfdjOdKTQnZ9zIh85cuVpbUfE=",
       "dev": true,
       "requires": {
-        "lodash.isarray": "3.0.4",
-        "lodash.istypedarray": "3.0.6",
-        "lodash.keys": "3.1.2"
+        "lodash.isarray": "^3.0.0",
+        "lodash.istypedarray": "^3.0.0",
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash._bindcallback": {
@@ -11102,8 +11102,8 @@
       "integrity": "sha1-HDXrO27wzR/1F0Pj6jz3/f/ay2Q=",
       "dev": true,
       "requires": {
-        "lodash._baseisequal": "3.0.7",
-        "lodash._bindcallback": "3.0.1"
+        "lodash._baseisequal": "^3.0.0",
+        "lodash._bindcallback": "^3.0.0"
       }
     },
     "lodash.isplainobject": {
@@ -11124,9 +11124,9 @@
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
       }
     },
     "lodash.memoize": {
@@ -11171,8 +11171,8 @@
       "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.templatesettings": "4.1.0"
+        "lodash._reinterpolate": "~3.0.0",
+        "lodash.templatesettings": "^4.0.0"
       }
     },
     "lodash.templatesettings": {
@@ -11181,7 +11181,7 @@
       "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "3.0.0"
+        "lodash._reinterpolate": "~3.0.0"
       }
     },
     "lodash.throttle": {
@@ -11208,7 +11208,7 @@
       "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0"
+        "chalk": "^2.0.1"
       }
     },
     "log-update": {
@@ -11217,8 +11217,8 @@
       "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "1.4.0",
-        "cli-cursor": "1.0.2"
+        "ansi-escapes": "^1.0.0",
+        "cli-cursor": "^1.0.2"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -11233,7 +11233,7 @@
           "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
           "dev": true,
           "requires": {
-            "restore-cursor": "1.0.1"
+            "restore-cursor": "^1.0.1"
           }
         },
         "onetime": {
@@ -11248,8 +11248,8 @@
           "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
           "dev": true,
           "requires": {
-            "exit-hook": "1.1.1",
-            "onetime": "1.1.0"
+            "exit-hook": "^1.0.0",
+            "onetime": "^1.0.0"
           }
         }
       }
@@ -11265,7 +11265,7 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "requires": {
-        "js-tokens": "3.0.2"
+        "js-tokens": "^3.0.0"
       }
     },
     "loud-rejection": {
@@ -11274,8 +11274,8 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
       }
     },
     "lower-case": {
@@ -11296,8 +11296,8 @@
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "dev": true,
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "macaddress": {
@@ -11312,7 +11312,7 @@
       "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
       "dev": true,
       "requires": {
-        "pify": "3.0.0"
+        "pify": "^3.0.0"
       }
     },
     "make-error": {
@@ -11327,7 +11327,7 @@
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
       "dev": true,
       "requires": {
-        "tmpl": "1.0.4"
+        "tmpl": "1.0.x"
       }
     },
     "map-cache": {
@@ -11348,7 +11348,7 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "object-visit": "1.0.1"
+        "object-visit": "^1.0.0"
       }
     },
     "markdown-loader": {
@@ -11357,8 +11357,8 @@
       "integrity": "sha512-v/ej7DflZbb6t//3Yu9vg0T+sun+Q9EoqggifeyABKfvFROqPwwwpv+hd1NKT2QxTRg6VCFk10IIJcMI13yCoQ==",
       "dev": true,
       "requires": {
-        "loader-utils": "1.1.0",
-        "marked": "0.3.19"
+        "loader-utils": "^1.1.0",
+        "marked": "^0.3.9"
       }
     },
     "marked": {
@@ -11373,9 +11373,9 @@
       "integrity": "sha512-k9r4HIpKlreInh6IVDGxhRs0veCr6WfLwP6lr2HXG8so+N6m6rfFKSpik9ZbvnTfKvdPhehwBWT5W+Fli29Ebg==",
       "dev": true,
       "requires": {
-        "babel-standalone": "6.26.0",
-        "he": "1.1.1",
-        "marked": "0.3.19"
+        "babel-standalone": "^6.26.0",
+        "he": "^1.1.1",
+        "marked": "^0.3.9"
       }
     },
     "math-expression-evaluator": {
@@ -11390,8 +11390,8 @@
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
       "dev": true,
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.3"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "media-typer": {
@@ -11406,7 +11406,7 @@
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.1.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "memory-fs": {
@@ -11415,8 +11415,8 @@
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "dev": true,
       "requires": {
-        "errno": "0.1.7",
-        "readable-stream": "2.3.3"
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
       }
     },
     "meow": {
@@ -11425,16 +11425,16 @@
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "2.1.0",
-        "decamelize": "1.2.0",
-        "loud-rejection": "1.6.0",
-        "map-obj": "1.0.1",
-        "minimist": "1.2.0",
-        "normalize-package-data": "2.4.0",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "redent": "1.0.0",
-        "trim-newlines": "1.0.0"
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -11443,8 +11443,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "load-json-file": {
@@ -11453,11 +11453,11 @@
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "minimist": {
@@ -11472,7 +11472,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-type": {
@@ -11481,9 +11481,9 @@
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pify": {
@@ -11498,9 +11498,9 @@
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -11509,8 +11509,8 @@
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         },
         "strip-bom": {
@@ -11519,7 +11519,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         }
       }
@@ -11542,7 +11542,7 @@
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "^2.0.1"
       }
     },
     "methods": {
@@ -11557,19 +11557,19 @@
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.4"
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
       }
     },
     "miller-rabin": {
@@ -11578,8 +11578,8 @@
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0"
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
       }
     },
     "mime": {
@@ -11600,7 +11600,7 @@
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "dev": true,
       "requires": {
-        "mime-db": "1.33.0"
+        "mime-db": "~1.33.0"
       }
     },
     "mimic-fn": {
@@ -11615,7 +11615,7 @@
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
       "dev": true,
       "requires": {
-        "dom-walk": "0.1.1"
+        "dom-walk": "^0.1.0"
       }
     },
     "minimalistic-assert": {
@@ -11636,7 +11636,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -11651,8 +11651,8 @@
       "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
       "dev": true,
       "requires": {
-        "arrify": "1.0.1",
-        "is-plain-obj": "1.1.0"
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0"
       }
     },
     "mississippi": {
@@ -11661,16 +11661,16 @@
       "integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.0",
-        "duplexify": "3.6.0",
-        "end-of-stream": "1.4.1",
-        "flush-write-stream": "1.0.3",
-        "from2": "2.3.0",
-        "parallel-transform": "1.1.0",
-        "pump": "2.0.1",
-        "pumpify": "1.5.0",
-        "stream-each": "1.2.2",
-        "through2": "2.0.3"
+        "concat-stream": "^1.5.0",
+        "duplexify": "^3.4.2",
+        "end-of-stream": "^1.1.0",
+        "flush-write-stream": "^1.0.0",
+        "from2": "^2.1.0",
+        "parallel-transform": "^1.1.0",
+        "pump": "^2.0.1",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^2.0.0"
       }
     },
     "mixin-deep": {
@@ -11679,8 +11679,8 @@
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2",
-        "is-extendable": "1.0.1"
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -11689,7 +11689,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -11700,8 +11700,8 @@
       "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
       "dev": true,
       "requires": {
-        "for-in": "0.1.8",
-        "is-extendable": "0.1.1"
+        "for-in": "^0.1.3",
+        "is-extendable": "^0.1.1"
       },
       "dependencies": {
         "for-in": {
@@ -11739,12 +11739,12 @@
       "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
       "dev": true,
       "requires": {
-        "aproba": "1.2.0",
-        "copy-concurrently": "1.0.5",
-        "fs-write-stream-atomic": "1.0.10",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
-        "run-queue": "1.0.3"
+        "aproba": "^1.1.1",
+        "copy-concurrently": "^1.0.0",
+        "fs-write-stream-atomic": "^1.0.8",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.3"
       }
     },
     "ms": {
@@ -11771,18 +11771,18 @@
       "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
       "dev": true,
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "fragment-cache": "0.2.1",
-        "is-odd": "2.0.0",
-        "is-windows": "1.0.2",
-        "kind-of": "6.0.2",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-odd": "^2.0.0",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -11817,10 +11817,10 @@
       "integrity": "sha512-ioYYogSaZhFlCpRizQgY3UT3G1qFXmHGY/5ozoFE3dMfiCRAeJfh+IPE3/eh9gCZvqLhPCWb4bLt7Bqzo+1mLQ==",
       "dev": true,
       "requires": {
-        "nomnom": "1.6.2",
-        "railroad-diagrams": "1.0.0",
+        "nomnom": "~1.6.2",
+        "railroad-diagrams": "^1.0.0",
         "randexp": "0.4.6",
-        "semver": "5.4.1"
+        "semver": "^5.4.1"
       }
     },
     "negotiator": {
@@ -11853,7 +11853,7 @@
       "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
       "dev": true,
       "requires": {
-        "lower-case": "1.1.4"
+        "lower-case": "^1.1.1"
       }
     },
     "node-dir": {
@@ -11862,7 +11862,7 @@
       "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
       "dev": true,
       "requires": {
-        "minimatch": "3.0.4"
+        "minimatch": "^3.0.2"
       }
     },
     "node-fetch": {
@@ -11870,8 +11870,8 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
       }
     },
     "node-gyp": {
@@ -11880,19 +11880,19 @@
       "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
       "dev": true,
       "requires": {
-        "fstream": "1.0.11",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "npmlog": "4.1.2",
-        "osenv": "0.1.5",
-        "request": "2.85.0",
-        "rimraf": "2.6.2",
-        "semver": "5.3.0",
-        "tar": "2.2.1",
-        "which": "1.3.0"
+        "fstream": "^1.0.0",
+        "glob": "^7.0.3",
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.0",
+        "nopt": "2 || 3",
+        "npmlog": "0 || 1 || 2 || 3 || 4",
+        "osenv": "0",
+        "request": "2",
+        "rimraf": "2",
+        "semver": "~5.3.0",
+        "tar": "^2.0.0",
+        "which": "1"
       },
       "dependencies": {
         "semver": {
@@ -11915,28 +11915,28 @@
       "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
       "dev": true,
       "requires": {
-        "assert": "1.4.1",
-        "browserify-zlib": "0.2.0",
-        "buffer": "4.9.1",
-        "console-browserify": "1.1.0",
-        "constants-browserify": "1.0.0",
-        "crypto-browserify": "3.12.0",
-        "domain-browser": "1.2.0",
-        "events": "1.1.1",
-        "https-browserify": "1.0.0",
-        "os-browserify": "0.3.0",
+        "assert": "^1.1.1",
+        "browserify-zlib": "^0.2.0",
+        "buffer": "^4.3.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.11.0",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "https-browserify": "^1.0.0",
+        "os-browserify": "^0.3.0",
         "path-browserify": "0.0.0",
-        "process": "0.11.10",
-        "punycode": "1.4.1",
-        "querystring-es3": "0.2.1",
-        "readable-stream": "2.3.3",
-        "stream-browserify": "2.0.1",
-        "stream-http": "2.8.1",
-        "string_decoder": "1.0.3",
-        "timers-browserify": "2.0.10",
+        "process": "^0.11.10",
+        "punycode": "^1.2.4",
+        "querystring-es3": "^0.2.0",
+        "readable-stream": "^2.3.3",
+        "stream-browserify": "^2.0.1",
+        "stream-http": "^2.7.2",
+        "string_decoder": "^1.0.0",
+        "timers-browserify": "^2.0.4",
         "tty-browserify": "0.0.0",
-        "url": "0.11.0",
-        "util": "0.10.3",
+        "url": "^0.11.0",
+        "util": "^0.10.3",
         "vm-browserify": "0.0.4"
       },
       "dependencies": {
@@ -11960,10 +11960,10 @@
       "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
       "dev": true,
       "requires": {
-        "growly": "1.3.0",
-        "semver": "5.4.1",
-        "shellwords": "0.1.1",
-        "which": "1.3.0"
+        "growly": "^1.3.0",
+        "semver": "^5.4.1",
+        "shellwords": "^0.1.1",
+        "which": "^1.3.0"
       }
     },
     "node-sass": {
@@ -11972,25 +11972,25 @@
       "integrity": "sha512-QFHfrZl6lqRU3csypwviz2XLgGNOoWQbo2GOvtsfQqOfL4cy1BtWnhx/XUeAO9LT3ahBzSRXcEO6DdvAH9DzSg==",
       "dev": true,
       "requires": {
-        "async-foreach": "0.1.3",
-        "chalk": "1.1.3",
-        "cross-spawn": "3.0.1",
-        "gaze": "1.1.2",
-        "get-stdin": "4.0.1",
-        "glob": "7.1.2",
-        "in-publish": "2.0.0",
-        "lodash.assign": "4.2.0",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.mergewith": "4.6.1",
-        "meow": "3.7.0",
-        "mkdirp": "0.5.1",
-        "nan": "2.10.0",
-        "node-gyp": "3.6.2",
-        "npmlog": "4.1.2",
-        "request": "2.79.0",
-        "sass-graph": "2.2.4",
-        "stdout-stream": "1.4.0",
-        "true-case-path": "1.0.2"
+        "async-foreach": "^0.1.3",
+        "chalk": "^1.1.1",
+        "cross-spawn": "^3.0.0",
+        "gaze": "^1.0.0",
+        "get-stdin": "^4.0.1",
+        "glob": "^7.0.3",
+        "in-publish": "^2.0.0",
+        "lodash.assign": "^4.2.0",
+        "lodash.clonedeep": "^4.3.2",
+        "lodash.mergewith": "^4.6.0",
+        "meow": "^3.7.0",
+        "mkdirp": "^0.5.1",
+        "nan": "^2.10.0",
+        "node-gyp": "^3.3.1",
+        "npmlog": "^4.0.0",
+        "request": "~2.79.0",
+        "sass-graph": "^2.2.4",
+        "stdout-stream": "^1.4.0",
+        "true-case-path": "^1.0.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -12017,7 +12017,7 @@
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "caseless": {
@@ -12055,7 +12055,7 @@
           "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
           "dev": true,
           "requires": {
-            "boom": "2.10.1"
+            "boom": "2.x.x"
           }
         },
         "form-data": {
@@ -12064,9 +12064,9 @@
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "dev": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.6",
-            "mime-types": "2.1.18"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           }
         },
         "har-validator": {
@@ -12075,10 +12075,10 @@
           "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "commander": "2.15.1",
-            "is-my-json-valid": "2.17.2",
-            "pinkie-promise": "2.0.1"
+            "chalk": "^1.1.1",
+            "commander": "^2.9.0",
+            "is-my-json-valid": "^2.12.4",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "hawk": {
@@ -12087,10 +12087,10 @@
           "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
           "dev": true,
           "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
+            "boom": "2.x.x",
+            "cryptiles": "2.x.x",
+            "hoek": "2.x.x",
+            "sntp": "1.x.x"
           }
         },
         "hoek": {
@@ -12105,9 +12105,9 @@
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
           "dev": true,
           "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.14.1"
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "qs": {
@@ -12122,26 +12122,26 @@
           "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
           "dev": true,
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.7.0",
-            "caseless": "0.11.0",
-            "combined-stream": "1.0.6",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "2.0.6",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.18",
-            "oauth-sign": "0.8.2",
-            "qs": "6.3.2",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.4",
-            "tunnel-agent": "0.4.3",
-            "uuid": "3.1.0"
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "caseless": "~0.11.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.1.1",
+            "har-validator": "~2.0.6",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "oauth-sign": "~0.8.1",
+            "qs": "~6.3.0",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "~0.4.1",
+            "uuid": "^3.0.0"
           }
         },
         "sntp": {
@@ -12150,7 +12150,7 @@
           "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
           "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "supports-color": {
@@ -12173,8 +12173,8 @@
       "integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
       "dev": true,
       "requires": {
-        "colors": "0.5.1",
-        "underscore": "1.4.4"
+        "colors": "0.5.x",
+        "underscore": "~1.4.4"
       }
     },
     "nopt": {
@@ -12183,7 +12183,7 @@
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1.1.1"
+        "abbrev": "1"
       }
     },
     "normalize-package-data": {
@@ -12192,10 +12192,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.5.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.4.1",
-        "validate-npm-package-license": "3.0.1"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -12204,7 +12204,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "normalize-range": {
@@ -12219,10 +12219,10 @@
       "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
       "dev": true,
       "requires": {
-        "object-assign": "4.1.1",
-        "prepend-http": "1.0.4",
-        "query-string": "4.3.4",
-        "sort-keys": "1.1.2"
+        "object-assign": "^4.0.1",
+        "prepend-http": "^1.0.0",
+        "query-string": "^4.1.0",
+        "sort-keys": "^1.0.0"
       }
     },
     "npm-path": {
@@ -12231,7 +12231,7 @@
       "integrity": "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
       "dev": true,
       "requires": {
-        "which": "1.3.0"
+        "which": "^1.2.10"
       }
     },
     "npm-run-path": {
@@ -12240,7 +12240,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "npm-which": {
@@ -12249,9 +12249,9 @@
       "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
       "dev": true,
       "requires": {
-        "commander": "2.15.1",
-        "npm-path": "2.0.4",
-        "which": "1.3.0"
+        "commander": "^2.9.0",
+        "npm-path": "^2.0.2",
+        "which": "^1.2.10"
       }
     },
     "npmlog": {
@@ -12260,10 +12260,10 @@
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "requires": {
-        "are-we-there-yet": "1.1.4",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "nth-check": {
@@ -12272,7 +12272,7 @@
       "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
       "dev": true,
       "requires": {
-        "boolbase": "1.0.0"
+        "boolbase": "~1.0.0"
       }
     },
     "num2fraction": {
@@ -12310,9 +12310,9 @@
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
-        "copy-descriptor": "0.1.1",
-        "define-property": "0.2.5",
-        "kind-of": "3.2.2"
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
       },
       "dependencies": {
         "define-property": {
@@ -12321,7 +12321,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -12350,7 +12350,7 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "isobject": {
@@ -12367,10 +12367,10 @@
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "function-bind": "1.1.1",
-        "has-symbols": "1.0.0",
-        "object-keys": "1.0.11"
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
       }
     },
     "object.entries": {
@@ -12379,10 +12379,10 @@
       "integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.11.0",
-        "function-bind": "1.1.1",
-        "has": "1.0.1"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.6.1",
+        "function-bind": "^1.1.0",
+        "has": "^1.0.1"
       }
     },
     "object.getownpropertydescriptors": {
@@ -12391,8 +12391,8 @@
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.11.0"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.1"
       }
     },
     "object.omit": {
@@ -12401,8 +12401,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
       }
     },
     "object.pick": {
@@ -12411,7 +12411,7 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -12428,10 +12428,10 @@
       "integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.11.0",
-        "function-bind": "1.1.1",
-        "has": "1.0.1"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.6.1",
+        "function-bind": "^1.1.0",
+        "has": "^1.0.1"
       }
     },
     "on-finished": {
@@ -12449,7 +12449,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -12458,7 +12458,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.1.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "opn": {
@@ -12467,7 +12467,7 @@
       "integrity": "sha512-Jd/GpzPyHF4P2/aNOVmS3lfMSWV9J7cOhCG1s08XCEAsPkB7lp6ddiU0J7XzyQRDUh8BqJ7PchfINjR8jyofRQ==",
       "dev": true,
       "requires": {
-        "is-wsl": "1.1.0"
+        "is-wsl": "^1.1.0"
       }
     },
     "optimist": {
@@ -12476,8 +12476,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8",
-        "wordwrap": "0.0.2"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       }
     },
     "optionator": {
@@ -12486,12 +12486,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       },
       "dependencies": {
         "wordwrap": {
@@ -12508,10 +12508,10 @@
       "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "cli-spinners": "0.1.2",
-        "object-assign": "4.1.1"
+        "chalk": "^1.1.1",
+        "cli-cursor": "^1.0.2",
+        "cli-spinners": "^0.1.2",
+        "object-assign": "^4.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -12526,11 +12526,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "cli-cursor": {
@@ -12539,7 +12539,7 @@
           "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
           "dev": true,
           "requires": {
-            "restore-cursor": "1.0.1"
+            "restore-cursor": "^1.0.1"
           }
         },
         "onetime": {
@@ -12554,8 +12554,8 @@
           "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
           "dev": true,
           "requires": {
-            "exit-hook": "1.1.1",
-            "onetime": "1.1.0"
+            "exit-hook": "^1.0.0",
+            "onetime": "^1.0.0"
           }
         },
         "supports-color": {
@@ -12572,7 +12572,7 @@
       "integrity": "sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs=",
       "dev": true,
       "requires": {
-        "url-parse": "1.0.5"
+        "url-parse": "1.0.x"
       },
       "dependencies": {
         "url-parse": {
@@ -12581,8 +12581,8 @@
           "integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=",
           "dev": true,
           "requires": {
-            "querystringify": "0.0.4",
-            "requires-port": "1.0.0"
+            "querystringify": "0.0.x",
+            "requires-port": "1.0.x"
           }
         }
       }
@@ -12605,9 +12605,9 @@
       "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
       "dev": true,
       "requires": {
-        "execa": "0.7.0",
-        "lcid": "1.0.0",
-        "mem": "1.1.0"
+        "execa": "^0.7.0",
+        "lcid": "^1.0.0",
+        "mem": "^1.1.0"
       }
     },
     "os-tmpdir": {
@@ -12622,8 +12622,8 @@
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
       }
     },
     "p-finally": {
@@ -12644,7 +12644,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.1.0"
+        "p-limit": "^1.1.0"
       }
     },
     "p-map": {
@@ -12659,10 +12659,10 @@
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "dev": true,
       "requires": {
-        "got": "6.7.1",
-        "registry-auth-token": "3.3.2",
-        "registry-url": "3.1.0",
-        "semver": "5.4.1"
+        "got": "^6.7.1",
+        "registry-auth-token": "^3.0.1",
+        "registry-url": "^3.0.3",
+        "semver": "^5.1.0"
       }
     },
     "pako": {
@@ -12677,9 +12677,9 @@
       "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
       "dev": true,
       "requires": {
-        "cyclist": "0.2.2",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
+        "cyclist": "~0.2.2",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.1.5"
       }
     },
     "param-case": {
@@ -12688,7 +12688,7 @@
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
       "dev": true,
       "requires": {
-        "no-case": "2.3.2"
+        "no-case": "^2.2.0"
       }
     },
     "parse-asn1": {
@@ -12697,11 +12697,11 @@
       "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
       "dev": true,
       "requires": {
-        "asn1.js": "4.10.1",
-        "browserify-aes": "1.2.0",
-        "create-hash": "1.2.0",
-        "evp_bytestokey": "1.0.3",
-        "pbkdf2": "3.0.16"
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3"
       }
     },
     "parse-domain": {
@@ -12722,10 +12722,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "parse-json": {
@@ -12734,7 +12734,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.1"
+        "error-ex": "^1.2.0"
       }
     },
     "parse-passwd": {
@@ -12755,8 +12755,8 @@
       "integrity": "sha1-V8FUKKuKiSsfQ4aWRccR0OFEtVQ=",
       "dev": true,
       "requires": {
-        "is-ssh": "1.3.0",
-        "protocols": "1.4.6"
+        "is-ssh": "^1.3.0",
+        "protocols": "^1.4.0"
       }
     },
     "parse5": {
@@ -12765,7 +12765,7 @@
       "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
       "dev": true,
       "requires": {
-        "@types/node": "10.0.3"
+        "@types/node": "*"
       }
     },
     "parseurl": {
@@ -12834,7 +12834,7 @@
       "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
       "dev": true,
       "requires": {
-        "pify": "2.3.0"
+        "pify": "^2.0.0"
       },
       "dependencies": {
         "pify": {
@@ -12851,11 +12851,11 @@
       "integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
       "dev": true,
       "requires": {
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "ripemd160": "2.0.2",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.11"
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "performance-now": {
@@ -12882,7 +12882,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pkg-dir": {
@@ -12891,7 +12891,7 @@
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0"
+        "find-up": "^2.1.0"
       }
     },
     "please-upgrade-node": {
@@ -12900,7 +12900,7 @@
       "integrity": "sha512-bslfSeW+ksUbB/sYZeEdKFyTG4YWU9YKRvqfSRvZKE675khAuBUPqV5RUwJZaGuWmVQLweK45Q+lPHFVnSlSug==",
       "dev": true,
       "requires": {
-        "semver-compare": "1.0.0"
+        "semver-compare": "^1.0.0"
       }
     },
     "pluralize": {
@@ -12927,9 +12927,9 @@
       "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "source-map": "0.6.1",
-        "supports-color": "5.4.0"
+        "chalk": "^2.4.1",
+        "source-map": "^0.6.1",
+        "supports-color": "^5.4.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -12938,7 +12938,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -12947,9 +12947,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "has-flag": {
@@ -12964,7 +12964,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -12975,9 +12975,9 @@
       "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
       "dev": true,
       "requires": {
-        "postcss": "5.2.18",
-        "postcss-message-helpers": "2.0.0",
-        "reduce-css-calc": "1.3.0"
+        "postcss": "^5.0.2",
+        "postcss-message-helpers": "^2.0.0",
+        "reduce-css-calc": "^1.2.6"
       },
       "dependencies": {
         "ansi-styles": {
@@ -12992,11 +12992,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -13019,10 +13019,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.3",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -13037,7 +13037,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -13048,9 +13048,9 @@
       "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
       "dev": true,
       "requires": {
-        "colormin": "1.1.2",
-        "postcss": "5.2.18",
-        "postcss-value-parser": "3.3.0"
+        "colormin": "^1.0.5",
+        "postcss": "^5.0.13",
+        "postcss-value-parser": "^3.2.3"
       },
       "dependencies": {
         "ansi-styles": {
@@ -13065,11 +13065,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -13092,10 +13092,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.3",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -13110,7 +13110,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -13121,8 +13121,8 @@
       "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
       "dev": true,
       "requires": {
-        "postcss": "5.2.18",
-        "postcss-value-parser": "3.3.0"
+        "postcss": "^5.0.11",
+        "postcss-value-parser": "^3.1.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -13137,11 +13137,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -13164,10 +13164,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.3",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -13182,7 +13182,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -13193,7 +13193,7 @@
       "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
       "dev": true,
       "requires": {
-        "postcss": "5.2.18"
+        "postcss": "^5.0.14"
       },
       "dependencies": {
         "ansi-styles": {
@@ -13208,11 +13208,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -13235,10 +13235,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.3",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -13253,7 +13253,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -13264,7 +13264,7 @@
       "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
       "dev": true,
       "requires": {
-        "postcss": "5.2.18"
+        "postcss": "^5.0.4"
       },
       "dependencies": {
         "ansi-styles": {
@@ -13279,11 +13279,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -13306,10 +13306,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.3",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -13324,7 +13324,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -13335,7 +13335,7 @@
       "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
       "dev": true,
       "requires": {
-        "postcss": "5.2.18"
+        "postcss": "^5.0.14"
       },
       "dependencies": {
         "ansi-styles": {
@@ -13350,11 +13350,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -13377,10 +13377,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.3",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -13395,7 +13395,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -13406,7 +13406,7 @@
       "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
       "dev": true,
       "requires": {
-        "postcss": "5.2.18"
+        "postcss": "^5.0.16"
       },
       "dependencies": {
         "ansi-styles": {
@@ -13421,11 +13421,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -13448,10 +13448,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.3",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -13466,7 +13466,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -13477,8 +13477,8 @@
       "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
       "dev": true,
       "requires": {
-        "postcss": "5.2.18",
-        "uniqs": "2.0.0"
+        "postcss": "^5.0.14",
+        "uniqs": "^2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -13493,11 +13493,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -13520,10 +13520,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.3",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -13538,7 +13538,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -13549,8 +13549,8 @@
       "integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
       "dev": true,
       "requires": {
-        "postcss": "5.2.18",
-        "uniqid": "4.1.1"
+        "postcss": "^5.0.4",
+        "uniqid": "^4.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -13565,11 +13565,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -13592,10 +13592,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.3",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -13610,7 +13610,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -13621,7 +13621,7 @@
       "integrity": "sha512-9y9kDDf2F9EjKX6x9ueNa5GARvsUbXw4ezH8vXItXHwKzljbu8awP7t5dCaabKYm18Vs1lo5bKQcnc0HkISt+w==",
       "dev": true,
       "requires": {
-        "postcss": "6.0.22"
+        "postcss": "^6.0.1"
       }
     },
     "postcss-load-config": {
@@ -13630,10 +13630,10 @@
       "integrity": "sha1-U56a/J3chiASHr+djDZz4M5Q0oo=",
       "dev": true,
       "requires": {
-        "cosmiconfig": "2.2.2",
-        "object-assign": "4.1.1",
-        "postcss-load-options": "1.2.0",
-        "postcss-load-plugins": "2.3.0"
+        "cosmiconfig": "^2.1.0",
+        "object-assign": "^4.1.0",
+        "postcss-load-options": "^1.2.0",
+        "postcss-load-plugins": "^2.3.0"
       }
     },
     "postcss-load-options": {
@@ -13642,8 +13642,8 @@
       "integrity": "sha1-sJixVZ3awt8EvAuzdfmaXP4rbYw=",
       "dev": true,
       "requires": {
-        "cosmiconfig": "2.2.2",
-        "object-assign": "4.1.1"
+        "cosmiconfig": "^2.1.0",
+        "object-assign": "^4.1.0"
       }
     },
     "postcss-load-plugins": {
@@ -13652,8 +13652,8 @@
       "integrity": "sha1-dFdoEWWZrKLwCfrUJrABdQSdjZI=",
       "dev": true,
       "requires": {
-        "cosmiconfig": "2.2.2",
-        "object-assign": "4.1.1"
+        "cosmiconfig": "^2.1.1",
+        "object-assign": "^4.1.0"
       }
     },
     "postcss-loader": {
@@ -13662,10 +13662,10 @@
       "integrity": "sha512-pV7kB5neJ0/1tZ8L1uGOBNTVBCSCXQoIsZMsrwvO8V2rKGa2tBl/f80GGVxow2jJnRJ2w1ocx693EKhZAb9Isg==",
       "dev": true,
       "requires": {
-        "loader-utils": "1.1.0",
-        "postcss": "6.0.22",
-        "postcss-load-config": "1.2.0",
-        "schema-utils": "0.4.5"
+        "loader-utils": "^1.1.0",
+        "postcss": "^6.0.0",
+        "postcss-load-config": "^1.2.0",
+        "schema-utils": "^0.4.0"
       }
     },
     "postcss-merge-idents": {
@@ -13674,9 +13674,9 @@
       "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
       "dev": true,
       "requires": {
-        "has": "1.0.1",
-        "postcss": "5.2.18",
-        "postcss-value-parser": "3.3.0"
+        "has": "^1.0.1",
+        "postcss": "^5.0.10",
+        "postcss-value-parser": "^3.1.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -13691,11 +13691,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -13718,10 +13718,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.3",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -13736,7 +13736,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -13747,7 +13747,7 @@
       "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
       "dev": true,
       "requires": {
-        "postcss": "5.2.18"
+        "postcss": "^5.0.4"
       },
       "dependencies": {
         "ansi-styles": {
@@ -13762,11 +13762,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -13789,10 +13789,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.3",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -13807,7 +13807,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -13818,11 +13818,11 @@
       "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
       "dev": true,
       "requires": {
-        "browserslist": "1.7.7",
-        "caniuse-api": "1.6.1",
-        "postcss": "5.2.18",
-        "postcss-selector-parser": "2.2.3",
-        "vendors": "1.0.2"
+        "browserslist": "^1.5.2",
+        "caniuse-api": "^1.5.2",
+        "postcss": "^5.0.4",
+        "postcss-selector-parser": "^2.2.2",
+        "vendors": "^1.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -13837,8 +13837,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000836",
-            "electron-to-chromium": "1.3.45"
+            "caniuse-db": "^1.0.30000639",
+            "electron-to-chromium": "^1.2.7"
           }
         },
         "chalk": {
@@ -13847,11 +13847,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -13874,10 +13874,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.3",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -13892,7 +13892,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -13909,9 +13909,9 @@
       "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
       "dev": true,
       "requires": {
-        "object-assign": "4.1.1",
-        "postcss": "5.2.18",
-        "postcss-value-parser": "3.3.0"
+        "object-assign": "^4.0.1",
+        "postcss": "^5.0.4",
+        "postcss-value-parser": "^3.0.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -13926,11 +13926,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -13953,10 +13953,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.3",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -13971,7 +13971,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -13982,8 +13982,8 @@
       "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
       "dev": true,
       "requires": {
-        "postcss": "5.2.18",
-        "postcss-value-parser": "3.3.0"
+        "postcss": "^5.0.12",
+        "postcss-value-parser": "^3.3.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -13998,11 +13998,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -14025,10 +14025,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.3",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -14043,7 +14043,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -14054,10 +14054,10 @@
       "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
       "dev": true,
       "requires": {
-        "alphanum-sort": "1.0.2",
-        "postcss": "5.2.18",
-        "postcss-value-parser": "3.3.0",
-        "uniqs": "2.0.0"
+        "alphanum-sort": "^1.0.1",
+        "postcss": "^5.0.2",
+        "postcss-value-parser": "^3.0.2",
+        "uniqs": "^2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14072,11 +14072,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -14099,10 +14099,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.3",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -14117,7 +14117,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -14128,10 +14128,10 @@
       "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
       "dev": true,
       "requires": {
-        "alphanum-sort": "1.0.2",
-        "has": "1.0.1",
-        "postcss": "5.2.18",
-        "postcss-selector-parser": "2.2.3"
+        "alphanum-sort": "^1.0.2",
+        "has": "^1.0.1",
+        "postcss": "^5.0.14",
+        "postcss-selector-parser": "^2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14146,11 +14146,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -14173,10 +14173,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.3",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -14191,7 +14191,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -14202,7 +14202,7 @@
       "integrity": "sha1-ZhQOzs447wa/DT41XWm/WdFB6oU=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.22"
+        "postcss": "^6.0.1"
       }
     },
     "postcss-modules-local-by-default": {
@@ -14211,8 +14211,8 @@
       "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
       "dev": true,
       "requires": {
-        "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.22"
+        "css-selector-tokenizer": "^0.7.0",
+        "postcss": "^6.0.1"
       }
     },
     "postcss-modules-scope": {
@@ -14221,8 +14221,8 @@
       "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
       "dev": true,
       "requires": {
-        "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.22"
+        "css-selector-tokenizer": "^0.7.0",
+        "postcss": "^6.0.1"
       }
     },
     "postcss-modules-values": {
@@ -14231,8 +14231,8 @@
       "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
       "dev": true,
       "requires": {
-        "icss-replace-symbols": "1.1.0",
-        "postcss": "6.0.22"
+        "icss-replace-symbols": "^1.1.0",
+        "postcss": "^6.0.1"
       }
     },
     "postcss-normalize-charset": {
@@ -14241,7 +14241,7 @@
       "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
       "dev": true,
       "requires": {
-        "postcss": "5.2.18"
+        "postcss": "^5.0.5"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14256,11 +14256,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -14283,10 +14283,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.3",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -14301,7 +14301,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -14312,10 +14312,10 @@
       "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
       "dev": true,
       "requires": {
-        "is-absolute-url": "2.1.0",
-        "normalize-url": "1.9.1",
-        "postcss": "5.2.18",
-        "postcss-value-parser": "3.3.0"
+        "is-absolute-url": "^2.0.0",
+        "normalize-url": "^1.4.0",
+        "postcss": "^5.0.14",
+        "postcss-value-parser": "^3.2.3"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14330,11 +14330,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -14357,10 +14357,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.3",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -14375,7 +14375,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -14386,8 +14386,8 @@
       "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
       "dev": true,
       "requires": {
-        "postcss": "5.2.18",
-        "postcss-value-parser": "3.3.0"
+        "postcss": "^5.0.4",
+        "postcss-value-parser": "^3.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14402,11 +14402,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -14429,10 +14429,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.3",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -14447,7 +14447,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -14458,8 +14458,8 @@
       "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
       "dev": true,
       "requires": {
-        "postcss": "5.2.18",
-        "postcss-value-parser": "3.3.0"
+        "postcss": "^5.0.4",
+        "postcss-value-parser": "^3.0.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14474,11 +14474,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -14501,10 +14501,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.3",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -14519,7 +14519,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -14530,7 +14530,7 @@
       "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
       "dev": true,
       "requires": {
-        "postcss": "5.2.18"
+        "postcss": "^5.0.4"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14545,11 +14545,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -14572,10 +14572,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.3",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -14590,7 +14590,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -14601,9 +14601,9 @@
       "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
       "dev": true,
       "requires": {
-        "has": "1.0.1",
-        "postcss": "5.2.18",
-        "postcss-value-parser": "3.3.0"
+        "has": "^1.0.1",
+        "postcss": "^5.0.8",
+        "postcss-value-parser": "^3.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14618,11 +14618,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -14645,10 +14645,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.3",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -14663,7 +14663,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -14674,9 +14674,9 @@
       "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
       "dev": true,
       "requires": {
-        "flatten": "1.0.2",
-        "indexes-of": "1.0.1",
-        "uniq": "1.0.1"
+        "flatten": "^1.0.2",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1"
       }
     },
     "postcss-svgo": {
@@ -14685,10 +14685,10 @@
       "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
       "dev": true,
       "requires": {
-        "is-svg": "2.1.0",
-        "postcss": "5.2.18",
-        "postcss-value-parser": "3.3.0",
-        "svgo": "0.7.2"
+        "is-svg": "^2.0.0",
+        "postcss": "^5.0.14",
+        "postcss-value-parser": "^3.2.3",
+        "svgo": "^0.7.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14703,11 +14703,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -14730,10 +14730,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.3",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -14748,7 +14748,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -14759,9 +14759,9 @@
       "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
       "dev": true,
       "requires": {
-        "alphanum-sort": "1.0.2",
-        "postcss": "5.2.18",
-        "uniqs": "2.0.0"
+        "alphanum-sort": "^1.0.1",
+        "postcss": "^5.0.4",
+        "uniqs": "^2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14776,11 +14776,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -14803,10 +14803,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.3",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -14821,7 +14821,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -14838,9 +14838,9 @@
       "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
       "dev": true,
       "requires": {
-        "has": "1.0.1",
-        "postcss": "5.2.18",
-        "uniqs": "2.0.0"
+        "has": "^1.0.1",
+        "postcss": "^5.0.4",
+        "uniqs": "^2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14855,11 +14855,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -14882,10 +14882,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.4.3",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "source-map": {
@@ -14900,7 +14900,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -14929,8 +14929,8 @@
       "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
       "dev": true,
       "requires": {
-        "renderkid": "2.0.1",
-        "utila": "0.4.0"
+        "renderkid": "^2.0.1",
+        "utila": "~0.4"
       }
     },
     "pretty-format": {
@@ -14939,8 +14939,8 @@
       "integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
       "dev": true,
       "requires": {
-        "ansi-regex": "3.0.0",
-        "ansi-styles": "3.2.0"
+        "ansi-regex": "^3.0.0",
+        "ansi-styles": "^3.2.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -14980,7 +14980,7 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "requires": {
-        "asap": "2.0.6"
+        "asap": "~2.0.3"
       }
     },
     "promise-inflight": {
@@ -14995,9 +14995,9 @@
       "integrity": "sha512-7p/K2f6dI+dM8yjRQEGrTQs5hTQixUAdOGpMEA3+pVxpX5oHKRSKAXyLw9Q9HUWDTdwtoo39dSHGQtN90HcEwQ==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.11.0",
-        "function-bind": "1.1.1"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.9.0",
+        "function-bind": "^1.1.1"
       }
     },
     "prop-types": {
@@ -15005,9 +15005,9 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
       "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
       "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
       }
     },
     "protocols": {
@@ -15022,7 +15022,7 @@
       "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
       "dev": true,
       "requires": {
-        "forwarded": "0.1.2",
+        "forwarded": "~0.1.2",
         "ipaddr.js": "1.6.0"
       }
     },
@@ -15044,11 +15044,11 @@
       "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.2.0",
-        "parse-asn1": "5.1.1",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1"
       }
     },
     "pump": {
@@ -15057,8 +15057,8 @@
       "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.1",
-        "once": "1.4.0"
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "pumpify": {
@@ -15067,9 +15067,9 @@
       "integrity": "sha512-UWi0klDoq8xtVzlMRgENV9F7iCTZExaJQSQL187UXsxpk9NnrKGqTqqUNYAKGOzucSOxs2+jUnRNI+rLviPhJg==",
       "dev": true,
       "requires": {
-        "duplexify": "3.6.0",
-        "inherits": "2.0.3",
-        "pump": "2.0.1"
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
       }
     },
     "punycode": {
@@ -15096,8 +15096,8 @@
       "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
       "dev": true,
       "requires": {
-        "object-assign": "4.1.1",
-        "strict-uri-encode": "1.1.0"
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
       }
     },
     "querystring": {
@@ -15130,10 +15130,10 @@
       "integrity": "sha512-IABYntqCwYelUUIwA52maSCgJbqtJjHKIoD21wgpw3dGhIUbJ5chDShDGdaFiEzdF03hN9jfQqlmn0bF4YhfrQ==",
       "dev": true,
       "requires": {
-        "array-find": "1.0.0",
-        "exenv": "1.2.2",
-        "inline-style-prefixer": "2.0.5",
-        "prop-types": "15.6.1"
+        "array-find": "^1.0.0",
+        "exenv": "^1.2.1",
+        "inline-style-prefixer": "^2.0.5",
+        "prop-types": "^15.5.8"
       },
       "dependencies": {
         "inline-style-prefixer": {
@@ -15142,8 +15142,8 @@
           "integrity": "sha1-wVPH6I/YT+9cYC6VqBaLJ3BnH+c=",
           "dev": true,
           "requires": {
-            "bowser": "1.9.3",
-            "hyphenate-style-name": "1.0.2"
+            "bowser": "^1.0.0",
+            "hyphenate-style-name": "^1.0.1"
           }
         }
       }
@@ -15154,7 +15154,7 @@
       "integrity": "sha512-pDP/NMRAXoTfrhCfyfSEwJAKLaxBU9eApMeBPB1TkDouZmvPerIClV8lTAd+uF8ZiTaVl69e1FCxQrAd/VTjGw==",
       "dev": true,
       "requires": {
-        "performance-now": "2.1.0"
+        "performance-now": "^2.1.0"
       }
     },
     "railroad-diagrams": {
@@ -15170,7 +15170,7 @@
       "dev": true,
       "requires": {
         "discontinuous-range": "1.0.0",
-        "ret": "0.1.15"
+        "ret": "~0.1.10"
       }
     },
     "randomatic": {
@@ -15179,8 +15179,8 @@
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -15189,7 +15189,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -15198,7 +15198,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -15209,7 +15209,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -15220,7 +15220,7 @@
       "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.1.0"
       }
     },
     "randomfill": {
@@ -15229,8 +15229,8 @@
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "dev": true,
       "requires": {
-        "randombytes": "2.0.6",
-        "safe-buffer": "5.1.1"
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
       }
     },
     "range-parser": {
@@ -15266,7 +15266,7 @@
             "depd": "1.1.1",
             "inherits": "2.0.3",
             "setprototypeof": "1.0.3",
-            "statuses": "1.4.0"
+            "statuses": ">= 1.3.1 < 2"
           }
         },
         "setprototypeof": {
@@ -15283,10 +15283,10 @@
       "integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
       "dev": true,
       "requires": {
-        "deep-extend": "0.4.2",
-        "ini": "1.3.5",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
+        "deep-extend": "~0.4.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       },
       "dependencies": {
         "minimist": {
@@ -15302,10 +15302,10 @@
       "resolved": "https://registry.npmjs.org/react/-/react-16.3.2.tgz",
       "integrity": "sha512-o5GPdkhciQ3cEph6qgvYB7LTOHw/GB0qRI6ZFNugj49qJCFfgHwVNjZ5u+b7nif4vOeMIOuYj3CeYe2IBD74lg==",
       "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.1"
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.0"
       }
     },
     "react-addons-create-fragment": {
@@ -15314,9 +15314,9 @@
       "integrity": "sha1-o5TefCx77Na1R1uhuXrEcs58dPg=",
       "dev": true,
       "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
+        "fbjs": "^0.8.4",
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.0"
       }
     },
     "react-day-picker": {
@@ -15324,7 +15324,7 @@
       "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-7.1.8.tgz",
       "integrity": "sha512-SK0l2V48XkGMR/R7TG296gcIwfzmm0c7r/sb+FMFL+I8ZUgt050ip9IyGR7ZETrOHgEPvfwlnaPdUwkCcntVew==",
       "requires": {
-        "prop-types": "15.6.1"
+        "prop-types": "^15.6.1"
       }
     },
     "react-dev-utils": {
@@ -15345,7 +15345,7 @@
         "inquirer": "3.3.0",
         "is-root": "1.0.0",
         "opn": "5.2.0",
-        "react-error-overlay": "4.0.0",
+        "react-error-overlay": "^4.0.0",
         "recursive-readdir": "2.2.1",
         "shell-quote": "1.6.1",
         "sockjs-client": "1.1.4",
@@ -15365,11 +15365,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "supports-color": {
@@ -15386,13 +15386,13 @@
       "integrity": "sha512-3UqwxygAP/eZdDtOKum6vClKWUlceZ7RBVQ3Fe122l1WBYOqHcBzoUZIwN8feaLVo+s2eB/q+NkBfanLgvmt+w==",
       "dev": true,
       "requires": {
-        "async": "2.6.0",
-        "babel-runtime": "6.26.0",
+        "async": "^2.1.4",
+        "babel-runtime": "^6.9.2",
         "babylon": "7.0.0-beta.31",
-        "commander": "2.15.1",
-        "doctrine": "2.1.0",
-        "node-dir": "0.1.17",
-        "recast": "0.12.9"
+        "commander": "^2.9.0",
+        "doctrine": "^2.0.0",
+        "node-dir": "^0.1.10",
+        "recast": "^0.12.6"
       },
       "dependencies": {
         "babylon": {
@@ -15408,10 +15408,10 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.3.2.tgz",
       "integrity": "sha512-MMPko3zYncNrz/7gG17wJWUREZDvskZHXOwbttzl0F0L3wDmToyuETuo/r8Y5yvDejwYcRyWI1lvVBjLJWFwKA==",
       "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.1"
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.0"
       }
     },
     "react-error-overlay": {
@@ -15426,10 +15426,10 @@
       "integrity": "sha512-qIZZxaCheb/HhcBi5fABbiCFg85+K5r1TCps1D4uaL0LAMMD/1zm/x1/kNR130Tx7nnY9V7mbFyY0DquPYeLAw==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "classnames": "2.2.5",
-        "fuse.js": "3.2.0",
-        "prop-types": "15.6.1"
+        "babel-runtime": "^6.23.0",
+        "classnames": "^2.2.5",
+        "fuse.js": "^3.0.1",
+        "prop-types": "^15.5.9"
       }
     },
     "react-html-attributes": {
@@ -15438,7 +15438,7 @@
       "integrity": "sha1-DSzPE0/Hmy01Q4N9wVkdMre5A/k=",
       "dev": true,
       "requires": {
-        "html-element-attributes": "1.3.1"
+        "html-element-attributes": "^1.0.0"
       }
     },
     "react-icon-base": {
@@ -15462,8 +15462,8 @@
       "integrity": "sha512-aIcbWb0fKFhEMB+RadoOYawlr1JoMMfrQ1oRgPUG/f/e4zERVJ6nYcIaQmrQmdHCZ63BOqe2cEkoeY0kyLBzNg==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "is-dom": "1.0.9"
+        "babel-runtime": "^6.26.0",
+        "is-dom": "^1.0.9"
       }
     },
     "react-is": {
@@ -15484,10 +15484,10 @@
       "integrity": "sha512-5VYNvy301Z0xxGBQhPmDdzOcyEkUG8sU7bpRsAPI4OHgEUkbBFrpjzs/ocNI0m824/lOqTxddXzwgmDJXx3s3Q==",
       "dev": true,
       "requires": {
-        "exenv": "1.2.2",
-        "prop-types": "15.6.1",
-        "react-lifecycles-compat": "3.0.2",
-        "warning": "3.0.0"
+        "exenv": "^1.2.0",
+        "prop-types": "^15.5.10",
+        "react-lifecycles-compat": "^3.0.0",
+        "warning": "^3.0.0"
       }
     },
     "react-reconciler": {
@@ -15496,10 +15496,10 @@
       "integrity": "sha512-50JwZ3yNyMS8fchN+jjWEJOH3Oze7UmhxeoJLn2j6f3NjpfCRbcmih83XTWmzqtar/ivd5f7tvQhvvhism2fgg==",
       "dev": true,
       "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.1"
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.0"
       }
     },
     "react-split-pane": {
@@ -15508,9 +15508,9 @@
       "integrity": "sha512-xq0PPsbkNI9xEd6yTrGPr7hzf6XfIgnsxuUEdRJELq+kLPHMsO3ymFCjhiYP35wlDPn9W46+rHDsJd7LFYteMw==",
       "dev": true,
       "requires": {
-        "inline-style-prefixer": "3.0.8",
-        "prop-types": "15.6.1",
-        "react-style-proptype": "3.2.1"
+        "inline-style-prefixer": "^3.0.6",
+        "prop-types": "^15.5.10",
+        "react-style-proptype": "^3.0.0"
       }
     },
     "react-style-proptype": {
@@ -15519,7 +15519,7 @@
       "integrity": "sha512-Z02QsgmdZ4wYNxJsHhNGGZsIF8+MO93fYmdPaC+ljdqX3rq8tl/fSMXOGBbofGJNzq5W/2LFcONllmV6vzyYHA==",
       "dev": true,
       "requires": {
-        "prop-types": "15.6.1"
+        "prop-types": "^15.5.4"
       }
     },
     "react-test-renderer": {
@@ -15528,10 +15528,10 @@
       "integrity": "sha512-lL8WHIpCTMdSe+CRkt0rfMxBkJFyhVrpdQ54BaJRIrXf9aVmbeHbRA8GFRpTvohPN5tPzMabmrzW2PUfWCfWwQ==",
       "dev": true,
       "requires": {
-        "fbjs": "0.8.16",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.1",
-        "react-is": "16.3.2"
+        "fbjs": "^0.8.16",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.0",
+        "react-is": "^16.3.2"
       }
     },
     "react-transition-group": {
@@ -15540,9 +15540,9 @@
       "integrity": "sha512-hu4/LAOFSKjWt1+1hgnOv3ldxmt6lvZGTWz4KUkFrqzXrNDIVSu6txIcPszw7PNduR8en9YTN55JLRyd/L1ZiQ==",
       "dev": true,
       "requires": {
-        "dom-helpers": "3.3.1",
-        "loose-envify": "1.3.1",
-        "prop-types": "15.6.1"
+        "dom-helpers": "^3.3.1",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.1"
       }
     },
     "react-treebeard": {
@@ -15551,12 +15551,12 @@
       "integrity": "sha512-unoy8IJL1NR5jgTtK+CqOCZKZylh/Tlid0oYajW9bLZCbFelxzmCsF8Y2hyS6pvHqM4W501oOm5O/jvg3VZCrg==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "deep-equal": "1.0.1",
-        "prop-types": "15.6.1",
-        "radium": "0.19.6",
-        "shallowequal": "0.2.2",
-        "velocity-react": "1.4.1"
+        "babel-runtime": "^6.23.0",
+        "deep-equal": "^1.0.1",
+        "prop-types": "^15.5.8",
+        "radium": "^0.19.0",
+        "shallowequal": "^0.2.2",
+        "velocity-react": "^1.3.1"
       }
     },
     "read-cmd-shim": {
@@ -15565,7 +15565,7 @@
       "integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.2"
       }
     },
     "read-pkg": {
@@ -15574,9 +15574,9 @@
       "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "dev": true,
       "requires": {
-        "load-json-file": "2.0.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "2.0.0"
+        "load-json-file": "^2.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^2.0.0"
       }
     },
     "read-pkg-up": {
@@ -15585,8 +15585,8 @@
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0",
-        "read-pkg": "2.0.0"
+        "find-up": "^2.0.0",
+        "read-pkg": "^2.0.0"
       }
     },
     "readable-stream": {
@@ -15595,13 +15595,13 @@
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.0.3",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readdirp": {
@@ -15610,10 +15610,10 @@
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.3",
-        "set-immediate-shim": "1.0.1"
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "readable-stream": "^2.0.2",
+        "set-immediate-shim": "^1.0.1"
       }
     },
     "realpath-native": {
@@ -15622,7 +15622,7 @@
       "integrity": "sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==",
       "dev": true,
       "requires": {
-        "util.promisify": "1.0.0"
+        "util.promisify": "^1.0.0"
       }
     },
     "recast": {
@@ -15632,10 +15632,10 @@
       "dev": true,
       "requires": {
         "ast-types": "0.10.1",
-        "core-js": "2.5.6",
-        "esprima": "4.0.0",
-        "private": "0.1.8",
-        "source-map": "0.6.1"
+        "core-js": "^2.4.1",
+        "esprima": "~4.0.0",
+        "private": "~0.1.5",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "core-js": {
@@ -15652,7 +15652,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "1.1.7"
+        "resolve": "^1.1.6"
       }
     },
     "recursive-readdir": {
@@ -15670,7 +15670,7 @@
           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.0.0"
           }
         }
       }
@@ -15681,8 +15681,8 @@
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "2.1.0",
-        "strip-indent": "1.0.1"
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
       }
     },
     "reduce-css-calc": {
@@ -15691,9 +15691,9 @@
       "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
       "dev": true,
       "requires": {
-        "balanced-match": "0.4.2",
-        "math-expression-evaluator": "1.2.17",
-        "reduce-function-call": "1.0.2"
+        "balanced-match": "^0.4.2",
+        "math-expression-evaluator": "^1.2.14",
+        "reduce-function-call": "^1.0.1"
       },
       "dependencies": {
         "balanced-match": {
@@ -15710,7 +15710,7 @@
       "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
       "dev": true,
       "requires": {
-        "balanced-match": "0.4.2"
+        "balanced-match": "^0.4.2"
       },
       "dependencies": {
         "balanced-match": {
@@ -15727,10 +15727,10 @@
       "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.10",
-        "lodash-es": "4.17.10",
-        "loose-envify": "1.3.1",
-        "symbol-observable": "1.2.0"
+        "lodash": "^4.2.1",
+        "lodash-es": "^4.2.1",
+        "loose-envify": "^1.1.0",
+        "symbol-observable": "^1.0.3"
       }
     },
     "regenerate": {
@@ -15751,9 +15751,9 @@
       "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "private": "0.1.8"
+        "babel-runtime": "^6.18.0",
+        "babel-types": "^6.19.0",
+        "private": "^0.1.6"
       }
     },
     "regex-cache": {
@@ -15762,7 +15762,7 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "0.1.3"
+        "is-equal-shallow": "^0.1.3"
       }
     },
     "regex-not": {
@@ -15771,8 +15771,8 @@
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
       "requires": {
-        "extend-shallow": "3.0.2",
-        "safe-regex": "1.1.0"
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "regexpp": {
@@ -15787,9 +15787,9 @@
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "dev": true,
       "requires": {
-        "regenerate": "1.3.3",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
       }
     },
     "registry-auth-token": {
@@ -15798,8 +15798,8 @@
       "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
       "dev": true,
       "requires": {
-        "rc": "1.2.6",
-        "safe-buffer": "5.1.1"
+        "rc": "^1.1.6",
+        "safe-buffer": "^5.0.1"
       }
     },
     "registry-url": {
@@ -15808,7 +15808,7 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "1.2.6"
+        "rc": "^1.0.1"
       }
     },
     "regjsgen": {
@@ -15823,7 +15823,7 @@
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
       "requires": {
-        "jsesc": "0.5.0"
+        "jsesc": "~0.5.0"
       },
       "dependencies": {
         "jsesc": {
@@ -15852,11 +15852,11 @@
       "integrity": "sha1-iYyr/Ivt5Le5ETWj/9Mj5YwNsxk=",
       "dev": true,
       "requires": {
-        "css-select": "1.2.0",
-        "dom-converter": "0.1.4",
-        "htmlparser2": "3.3.0",
-        "strip-ansi": "3.0.1",
-        "utila": "0.3.3"
+        "css-select": "^1.1.0",
+        "dom-converter": "~0.1",
+        "htmlparser2": "~3.3.0",
+        "strip-ansi": "^3.0.0",
+        "utila": "~0.3"
       },
       "dependencies": {
         "domhandler": {
@@ -15865,7 +15865,7 @@
           "integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
           "dev": true,
           "requires": {
-            "domelementtype": "1.3.0"
+            "domelementtype": "1"
           }
         },
         "domutils": {
@@ -15874,7 +15874,7 @@
           "integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
           "dev": true,
           "requires": {
-            "domelementtype": "1.3.0"
+            "domelementtype": "1"
           }
         },
         "htmlparser2": {
@@ -15883,10 +15883,10 @@
           "integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
           "dev": true,
           "requires": {
-            "domelementtype": "1.3.0",
-            "domhandler": "2.1.0",
-            "domutils": "1.1.6",
-            "readable-stream": "1.0.34"
+            "domelementtype": "1",
+            "domhandler": "2.1",
+            "domutils": "1.1",
+            "readable-stream": "1.0"
           }
         },
         "isarray": {
@@ -15901,10 +15901,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -15939,7 +15939,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "request": {
@@ -15948,28 +15948,28 @@
       "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.7.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.6",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.2",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.18",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.2",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.4",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "hawk": "~6.0.2",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "stringstream": "~0.0.5",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
       }
     },
     "request-promise-core": {
@@ -15978,7 +15978,7 @@
       "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "^4.13.1"
       }
     },
     "request-promise-native": {
@@ -15988,8 +15988,8 @@
       "dev": true,
       "requires": {
         "request-promise-core": "1.1.1",
-        "stealthy-require": "1.1.1",
-        "tough-cookie": "2.3.4"
+        "stealthy-require": "^1.1.0",
+        "tough-cookie": ">=2.3.3"
       }
     },
     "require-directory": {
@@ -16016,8 +16016,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
       },
       "dependencies": {
         "resolve-from": {
@@ -16046,7 +16046,7 @@
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "dev": true,
       "requires": {
-        "resolve-from": "3.0.0"
+        "resolve-from": "^3.0.0"
       }
     },
     "resolve-dir": {
@@ -16055,8 +16055,8 @@
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "dev": true,
       "requires": {
-        "expand-tilde": "2.0.2",
-        "global-modules": "1.0.0"
+        "expand-tilde": "^2.0.0",
+        "global-modules": "^1.0.0"
       }
     },
     "resolve-from": {
@@ -16077,8 +16077,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "ret": {
@@ -16093,7 +16093,7 @@
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "dev": true,
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -16102,7 +16102,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "ripemd160": {
@@ -16111,8 +16111,8 @@
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "dev": true,
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.3"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "rst-selector-parser": {
@@ -16121,8 +16121,8 @@
       "integrity": "sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=",
       "dev": true,
       "requires": {
-        "lodash.flattendeep": "4.4.0",
-        "nearley": "2.13.0"
+        "lodash.flattendeep": "^4.4.0",
+        "nearley": "^2.7.10"
       }
     },
     "run-async": {
@@ -16131,7 +16131,7 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "2.1.0"
+        "is-promise": "^2.1.0"
       }
     },
     "run-queue": {
@@ -16140,7 +16140,7 @@
       "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
       "dev": true,
       "requires": {
-        "aproba": "1.2.0"
+        "aproba": "^1.1.1"
       }
     },
     "rx-lite": {
@@ -16155,7 +16155,7 @@
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "dev": true,
       "requires": {
-        "rx-lite": "3.1.2"
+        "rx-lite": "*"
       }
     },
     "rxjs": {
@@ -16187,7 +16187,7 @@
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
-        "ret": "0.1.15"
+        "ret": "~0.1.10"
       }
     },
     "sane": {
@@ -16196,14 +16196,14 @@
       "integrity": "sha1-pVzucHS+0yE7VLQIie55H6L1AXY=",
       "dev": true,
       "requires": {
-        "anymatch": "2.0.0",
-        "exec-sh": "0.2.1",
-        "fb-watchman": "2.0.0",
-        "fsevents": "1.2.3",
-        "micromatch": "3.1.10",
-        "minimist": "1.2.0",
-        "walker": "1.0.7",
-        "watch": "0.18.0"
+        "anymatch": "^2.0.0",
+        "exec-sh": "^0.2.0",
+        "fb-watchman": "^2.0.0",
+        "fsevents": "^1.2.3",
+        "micromatch": "^3.1.4",
+        "minimist": "^1.1.1",
+        "walker": "~1.0.5",
+        "watch": "~0.18.0"
       },
       "dependencies": {
         "arr-diff": {
@@ -16224,16 +16224,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0",
-            "array-unique": "0.3.2",
-            "extend-shallow": "2.0.1",
-            "fill-range": "4.0.0",
-            "isobject": "3.0.1",
-            "repeat-element": "1.1.2",
-            "snapdragon": "0.8.2",
-            "snapdragon-node": "2.1.1",
-            "split-string": "3.1.0",
-            "to-regex": "3.0.2"
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -16242,7 +16242,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -16253,13 +16253,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "posix-character-classes": "0.1.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -16268,7 +16268,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             },
             "extend-shallow": {
@@ -16277,7 +16277,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             },
             "is-accessor-descriptor": {
@@ -16286,7 +16286,7 @@
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -16295,7 +16295,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -16306,7 +16306,7 @@
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -16315,7 +16315,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -16326,9 +16326,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
               }
             },
             "kind-of": {
@@ -16345,14 +16345,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "0.3.2",
-            "define-property": "1.0.0",
-            "expand-brackets": "2.1.4",
-            "extend-shallow": "2.0.1",
-            "fragment-cache": "0.2.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -16361,7 +16361,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "1.0.2"
+                "is-descriptor": "^1.0.0"
               }
             },
             "extend-shallow": {
@@ -16370,7 +16370,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -16381,10 +16381,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-number": "3.0.0",
-            "repeat-string": "1.6.1",
-            "to-regex-range": "2.1.1"
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
           },
           "dependencies": {
             "extend-shallow": {
@@ -16393,7 +16393,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -16404,7 +16404,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -16413,7 +16413,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -16422,9 +16422,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "is-number": {
@@ -16433,7 +16433,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -16442,7 +16442,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -16465,19 +16465,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "braces": "2.3.2",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "extglob": "2.0.4",
-            "fragment-cache": "0.2.1",
-            "kind-of": "6.0.2",
-            "nanomatch": "1.2.9",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
           }
         },
         "minimist": {
@@ -16494,10 +16494,10 @@
       "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "lodash": "4.17.10",
-        "scss-tokenizer": "0.2.3",
-        "yargs": "7.1.0"
+        "glob": "^7.0.0",
+        "lodash": "^4.0.0",
+        "scss-tokenizer": "^0.2.3",
+        "yargs": "^7.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -16512,9 +16512,9 @@
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "find-up": {
@@ -16523,8 +16523,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "load-json-file": {
@@ -16533,11 +16533,11 @@
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "os-locale": {
@@ -16546,7 +16546,7 @@
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "dev": true,
           "requires": {
-            "lcid": "1.0.0"
+            "lcid": "^1.0.0"
           }
         },
         "path-exists": {
@@ -16555,7 +16555,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-type": {
@@ -16564,9 +16564,9 @@
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pify": {
@@ -16581,9 +16581,9 @@
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -16592,8 +16592,8 @@
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         },
         "string-width": {
@@ -16602,9 +16602,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "strip-bom": {
@@ -16613,7 +16613,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "which-module": {
@@ -16628,19 +16628,19 @@
           "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
           "dev": true,
           "requires": {
-            "camelcase": "3.0.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "5.0.0"
+            "camelcase": "^3.0.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.2",
+            "which-module": "^1.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^5.0.0"
           }
         },
         "yargs-parser": {
@@ -16649,7 +16649,7 @@
           "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
           "dev": true,
           "requires": {
-            "camelcase": "3.0.0"
+            "camelcase": "^3.0.0"
           }
         }
       }
@@ -16660,11 +16660,11 @@
       "integrity": "sha512-MeVVJFejJELlAbA7jrRchi88PGP6U9yIfqyiG+bBC4a9s2PX+ulJB9h8bbEohtPBfZmlLhNZ0opQM9hovRXvlw==",
       "dev": true,
       "requires": {
-        "clone-deep": "2.0.2",
-        "loader-utils": "1.1.0",
-        "lodash.tail": "4.1.1",
-        "neo-async": "2.5.1",
-        "pify": "3.0.0"
+        "clone-deep": "^2.0.1",
+        "loader-utils": "^1.0.1",
+        "lodash.tail": "^4.1.1",
+        "neo-async": "^2.5.0",
+        "pify": "^3.0.0"
       }
     },
     "sax": {
@@ -16679,8 +16679,8 @@
       "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
       "dev": true,
       "requires": {
-        "ajv": "6.4.0",
-        "ajv-keywords": "3.2.0"
+        "ajv": "^6.1.0",
+        "ajv-keywords": "^3.1.0"
       },
       "dependencies": {
         "ajv": {
@@ -16689,10 +16689,10 @@
           "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "1.1.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1",
-            "uri-js": "3.0.2"
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0",
+            "uri-js": "^3.0.2"
           }
         }
       }
@@ -16703,8 +16703,8 @@
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "dev": true,
       "requires": {
-        "js-base64": "2.4.3",
-        "source-map": "0.4.4"
+        "js-base64": "^2.1.8",
+        "source-map": "^0.4.2"
       },
       "dependencies": {
         "source-map": {
@@ -16713,7 +16713,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -16737,18 +16737,18 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.6.3",
+        "http-errors": "~1.6.2",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.4.0"
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.4.0"
       }
     },
     "serialize-javascript": {
@@ -16763,10 +16763,10 @@
       "integrity": "sha1-k10kDN/g9YBTB/3+ln2IlCosvPA=",
       "dev": true,
       "requires": {
-        "etag": "1.8.1",
+        "etag": "~1.8.1",
         "fresh": "0.5.2",
         "ms": "2.1.1",
-        "parseurl": "1.3.2",
+        "parseurl": "~1.3.2",
         "safe-buffer": "5.1.1"
       },
       "dependencies": {
@@ -16784,9 +16784,9 @@
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "dev": true,
       "requires": {
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
         "send": "0.16.2"
       }
     },
@@ -16808,10 +16808,10 @@
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-extendable": "0.1.1",
-        "is-plain-object": "2.0.4",
-        "split-string": "3.1.0"
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -16820,7 +16820,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -16842,8 +16842,8 @@
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "shallow-clone": {
@@ -16852,9 +16852,9 @@
       "integrity": "sha512-oeXreoKR/SyNJtRJMAKPDSvd28OqEwG4eR/xc856cRGBII7gX9lvAqDxusPm0846z/w/hWYjI1NpKwJ00NHzRA==",
       "dev": true,
       "requires": {
-        "is-extendable": "0.1.1",
-        "kind-of": "5.1.0",
-        "mixin-object": "2.0.1"
+        "is-extendable": "^0.1.1",
+        "kind-of": "^5.0.0",
+        "mixin-object": "^2.0.1"
       },
       "dependencies": {
         "kind-of": {
@@ -16871,7 +16871,7 @@
       "integrity": "sha1-HjL9W8q2rWiKSBLLDMBO/HXHAU4=",
       "dev": true,
       "requires": {
-        "lodash.keys": "3.1.2"
+        "lodash.keys": "^3.1.2"
       }
     },
     "shebang-command": {
@@ -16880,7 +16880,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -16895,10 +16895,10 @@
       "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
       "dev": true,
       "requires": {
-        "array-filter": "0.0.1",
-        "array-map": "0.0.0",
-        "array-reduce": "0.0.0",
-        "jsonify": "0.0.0"
+        "array-filter": "~0.0.0",
+        "array-map": "~0.0.0",
+        "array-reduce": "~0.0.0",
+        "jsonify": "~0.0.0"
       }
     },
     "shelljs": {
@@ -16907,9 +16907,9 @@
       "integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "interpret": "1.1.0",
-        "rechoir": "0.6.2"
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
       }
     },
     "shellwords": {
@@ -16936,7 +16936,7 @@
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0"
+        "is-fullwidth-code-point": "^2.0.0"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -16953,14 +16953,14 @@
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
       "requires": {
-        "base": "0.11.2",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "map-cache": "0.2.2",
-        "source-map": "0.5.7",
-        "source-map-resolve": "0.5.1",
-        "use": "3.1.0"
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -16969,7 +16969,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
@@ -16978,7 +16978,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "source-map": {
@@ -16995,9 +16995,9 @@
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "snapdragon-util": "3.0.1"
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -17006,7 +17006,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -17015,7 +17015,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -17024,7 +17024,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -17033,9 +17033,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "isobject": {
@@ -17058,7 +17058,7 @@
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.2.0"
       }
     },
     "sntp": {
@@ -17067,7 +17067,7 @@
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "dev": true,
       "requires": {
-        "hoek": "4.2.1"
+        "hoek": "4.x.x"
       }
     },
     "sockjs-client": {
@@ -17076,12 +17076,12 @@
       "integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
+        "debug": "^2.6.6",
         "eventsource": "0.1.6",
-        "faye-websocket": "0.11.1",
-        "inherits": "2.0.3",
-        "json3": "3.3.2",
-        "url-parse": "1.4.0"
+        "faye-websocket": "~0.11.0",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^1.1.8"
       }
     },
     "sort-keys": {
@@ -17090,7 +17090,7 @@
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
       "dev": true,
       "requires": {
-        "is-plain-obj": "1.1.0"
+        "is-plain-obj": "^1.0.0"
       }
     },
     "source-list-map": {
@@ -17111,11 +17111,11 @@
       "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
       "dev": true,
       "requires": {
-        "atob": "2.1.1",
-        "decode-uri-component": "0.2.0",
-        "resolve-url": "0.2.1",
-        "source-map-url": "0.4.0",
-        "urix": "0.1.0"
+        "atob": "^2.0.0",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
       }
     },
     "source-map-support": {
@@ -17124,8 +17124,8 @@
       "integrity": "sha512-mR7/Nd5l1z6g99010shcXJiNEaf3fEtmLhRB/sBcQVJGodcHCULPp2y4Sfa43Kv2zq7T+Izmfp/WHCR6dYkQCA==",
       "dev": true,
       "requires": {
-        "buffer-from": "1.0.0",
-        "source-map": "0.6.1"
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "source-map-url": {
@@ -17140,7 +17140,7 @@
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "dev": true,
       "requires": {
-        "spdx-license-ids": "1.2.2"
+        "spdx-license-ids": "^1.0.2"
       }
     },
     "spdx-expression-parse": {
@@ -17161,7 +17161,7 @@
       "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
       "dev": true,
       "requires": {
-        "through": "2.3.8"
+        "through": "2"
       }
     },
     "split-string": {
@@ -17170,7 +17170,7 @@
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "3.0.2"
+        "extend-shallow": "^3.0.0"
       }
     },
     "split2": {
@@ -17179,7 +17179,7 @@
       "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
       "dev": true,
       "requires": {
-        "through2": "2.0.3"
+        "through2": "^2.0.2"
       }
     },
     "sprintf-js": {
@@ -17194,14 +17194,14 @@
       "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
       "dev": true,
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
       }
     },
     "ssri": {
@@ -17210,7 +17210,7 @@
       "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.1.1"
       }
     },
     "stack-utils": {
@@ -17231,8 +17231,8 @@
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
-        "define-property": "0.2.5",
-        "object-copy": "0.1.0"
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -17241,7 +17241,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -17258,7 +17258,7 @@
       "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "^2.0.1"
       }
     },
     "stealthy-require": {
@@ -17273,8 +17273,8 @@
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
+        "inherits": "~2.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "stream-each": {
@@ -17283,8 +17283,8 @@
       "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.1",
-        "stream-shift": "1.0.0"
+        "end-of-stream": "^1.1.0",
+        "stream-shift": "^1.0.0"
       }
     },
     "stream-http": {
@@ -17293,11 +17293,11 @@
       "integrity": "sha512-cQ0jo17BLca2r0GfRdZKYAGLU6JRoIWxqSOakUMuKOT6MOK7AAlE856L33QuDmAy/eeOrhLee3dZKX0Uadu93A==",
       "dev": true,
       "requires": {
-        "builtin-status-codes": "3.0.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "to-arraybuffer": "1.0.1",
-        "xtend": "4.0.1"
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.3",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "stream-shift": {
@@ -17312,7 +17312,7 @@
       "integrity": "sha1-WdbqOT2HwsDdrBCqDVYbxrpvDhA=",
       "dev": true,
       "requires": {
-        "any-observable": "0.2.0"
+        "any-observable": "^0.2.0"
       }
     },
     "strict-uri-encode": {
@@ -17333,8 +17333,8 @@
       "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
       "dev": true,
       "requires": {
-        "astral-regex": "1.0.0",
-        "strip-ansi": "4.0.0"
+        "astral-regex": "^1.0.0",
+        "strip-ansi": "^4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -17349,7 +17349,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -17360,8 +17360,8 @@
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -17382,7 +17382,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -17393,9 +17393,9 @@
       "integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.11.0",
-        "function-bind": "1.1.1"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.4.3",
+        "function-bind": "^1.0.2"
       }
     },
     "string.prototype.padstart": {
@@ -17404,9 +17404,9 @@
       "integrity": "sha1-W8+tOfRkm7LQMSkuGbzwtRDUskI=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.11.0",
-        "function-bind": "1.1.1"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.4.3",
+        "function-bind": "^1.0.2"
       }
     },
     "string_decoder": {
@@ -17415,7 +17415,7 @@
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
     },
     "stringify-object": {
@@ -17424,9 +17424,9 @@
       "integrity": "sha512-O696NF21oLiDy8PhpWu8AEqoZHw++QW6mUv0UvKZe8gWSdSvMXkiLufK7OmnP27Dro4GU5kb9U7JIO0mBuCRQg==",
       "dev": true,
       "requires": {
-        "get-own-enumerable-property-symbols": "2.0.1",
-        "is-obj": "1.0.1",
-        "is-regexp": "1.0.0"
+        "get-own-enumerable-property-symbols": "^2.0.1",
+        "is-obj": "^1.0.1",
+        "is-regexp": "^1.0.0"
       }
     },
     "stringstream": {
@@ -17441,7 +17441,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -17462,7 +17462,7 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1"
+        "get-stdin": "^4.0.1"
       }
     },
     "strip-json-comments": {
@@ -17477,11 +17477,11 @@
       "integrity": "sha1-9/uTdYpppXEUAYEnfuoMLrEwH6M=",
       "dev": true,
       "requires": {
-        "byline": "5.0.0",
-        "duplexer": "0.1.1",
-        "minimist": "0.1.0",
-        "moment": "2.22.1",
-        "through": "2.3.8"
+        "byline": "^5.0.0",
+        "duplexer": "^0.1.1",
+        "minimist": "^0.1.0",
+        "moment": "^2.6.0",
+        "through": "^2.3.4"
       },
       "dependencies": {
         "minimist": {
@@ -17498,8 +17498,8 @@
       "integrity": "sha512-T+UNsAcl3Yg+BsPKs1vd22Fr8sVT+CJMtzqc6LEw9bbJZb43lm9GoeIfUcDEefBSWC0BhYbcdupV1GtI4DGzxg==",
       "dev": true,
       "requires": {
-        "loader-utils": "1.1.0",
-        "schema-utils": "0.4.5"
+        "loader-utils": "^1.1.0",
+        "schema-utils": "^0.4.5"
       }
     },
     "supports-color": {
@@ -17508,7 +17508,7 @@
       "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
       "dev": true,
       "requires": {
-        "has-flag": "2.0.0"
+        "has-flag": "^2.0.0"
       }
     },
     "svg-tag-names": {
@@ -17523,13 +17523,13 @@
       "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
       "dev": true,
       "requires": {
-        "coa": "1.0.4",
-        "colors": "1.1.2",
-        "csso": "2.3.2",
-        "js-yaml": "3.7.0",
-        "mkdirp": "0.5.1",
-        "sax": "1.2.4",
-        "whet.extend": "0.9.9"
+        "coa": "~1.0.1",
+        "colors": "~1.1.2",
+        "csso": "~2.3.1",
+        "js-yaml": "~3.7.0",
+        "mkdirp": "~0.5.1",
+        "sax": "~1.2.1",
+        "whet.extend": "~0.9.9"
       },
       "dependencies": {
         "colors": {
@@ -17550,8 +17550,8 @@
           "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
           "dev": true,
           "requires": {
-            "argparse": "1.0.10",
-            "esprima": "2.7.3"
+            "argparse": "^1.0.7",
+            "esprima": "^2.6.0"
           }
         }
       }
@@ -17574,12 +17574,12 @@
       "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "ajv-keywords": "2.1.1",
-        "chalk": "2.3.0",
-        "lodash": "4.17.10",
+        "ajv": "^5.2.3",
+        "ajv-keywords": "^2.1.0",
+        "chalk": "^2.1.0",
+        "lodash": "^4.17.4",
         "slice-ansi": "1.0.0",
-        "string-width": "2.1.1"
+        "string-width": "^2.1.1"
       },
       "dependencies": {
         "ajv-keywords": {
@@ -17602,9 +17602,9 @@
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "dev": true,
       "requires": {
-        "block-stream": "0.0.9",
-        "fstream": "1.0.11",
-        "inherits": "2.0.3"
+        "block-stream": "*",
+        "fstream": "^1.0.2",
+        "inherits": "2"
       }
     },
     "temp-dir": {
@@ -17619,12 +17619,12 @@
       "integrity": "sha1-jP9jD7fp2gXwR8dM5M5NaFRX1JI=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "is-stream": "1.1.0",
-        "make-dir": "1.1.0",
-        "pify": "3.0.0",
-        "temp-dir": "1.0.0",
-        "uuid": "3.1.0"
+        "graceful-fs": "^4.1.2",
+        "is-stream": "^1.1.0",
+        "make-dir": "^1.0.0",
+        "pify": "^3.0.0",
+        "temp-dir": "^1.0.0",
+        "uuid": "^3.0.1"
       }
     },
     "tempfile": {
@@ -17633,8 +17633,8 @@
       "integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2",
-        "uuid": "2.0.3"
+        "os-tmpdir": "^1.0.0",
+        "uuid": "^2.0.1"
       },
       "dependencies": {
         "uuid": {
@@ -17651,11 +17651,11 @@
       "integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
       "dev": true,
       "requires": {
-        "arrify": "1.0.1",
-        "micromatch": "3.1.10",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "require-main-filename": "1.0.1"
+        "arrify": "^1.0.1",
+        "micromatch": "^3.1.8",
+        "object-assign": "^4.1.0",
+        "read-pkg-up": "^1.0.1",
+        "require-main-filename": "^1.0.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -17676,16 +17676,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0",
-            "array-unique": "0.3.2",
-            "extend-shallow": "2.0.1",
-            "fill-range": "4.0.0",
-            "isobject": "3.0.1",
-            "repeat-element": "1.1.2",
-            "snapdragon": "0.8.2",
-            "snapdragon-node": "2.1.1",
-            "split-string": "3.1.0",
-            "to-regex": "3.0.2"
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -17694,7 +17694,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -17705,13 +17705,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "posix-character-classes": "0.1.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -17720,7 +17720,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             },
             "extend-shallow": {
@@ -17729,7 +17729,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             },
             "is-accessor-descriptor": {
@@ -17738,7 +17738,7 @@
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -17747,7 +17747,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -17758,7 +17758,7 @@
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -17767,7 +17767,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -17778,9 +17778,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
               }
             },
             "kind-of": {
@@ -17797,14 +17797,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "0.3.2",
-            "define-property": "1.0.0",
-            "expand-brackets": "2.1.4",
-            "extend-shallow": "2.0.1",
-            "fragment-cache": "0.2.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -17813,7 +17813,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "1.0.2"
+                "is-descriptor": "^1.0.0"
               }
             },
             "extend-shallow": {
@@ -17822,7 +17822,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -17833,10 +17833,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-number": "3.0.0",
-            "repeat-string": "1.6.1",
-            "to-regex-range": "2.1.1"
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
           },
           "dependencies": {
             "extend-shallow": {
@@ -17845,7 +17845,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -17866,7 +17866,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -17875,7 +17875,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -17884,9 +17884,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "is-number": {
@@ -17895,7 +17895,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -17904,7 +17904,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -17940,19 +17940,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "braces": "2.3.2",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "extglob": "2.0.4",
-            "fragment-cache": "0.2.1",
-            "kind-of": "6.0.2",
-            "nanomatch": "1.2.9",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
           }
         },
         "path-exists": {
@@ -18043,8 +18043,8 @@
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3",
-        "xtend": "4.0.1"
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
       }
     },
     "time-stamp": {
@@ -18065,7 +18065,7 @@
       "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
       "dev": true,
       "requires": {
-        "setimmediate": "1.0.5"
+        "setimmediate": "^1.0.4"
       }
     },
     "tmp": {
@@ -18074,7 +18074,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
     },
     "tmpl": {
@@ -18101,7 +18101,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "to-regex": {
@@ -18110,10 +18110,10 @@
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
       "requires": {
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "regex-not": "1.0.2",
-        "safe-regex": "1.1.0"
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "to-regex-range": {
@@ -18122,8 +18122,8 @@
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1"
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
       },
       "dependencies": {
         "is-number": {
@@ -18132,7 +18132,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         }
       }
@@ -18149,7 +18149,7 @@
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "dev": true,
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "tr46": {
@@ -18158,7 +18158,7 @@
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "dev": true,
       "requires": {
-        "punycode": "2.1.0"
+        "punycode": "^2.1.0"
       },
       "dependencies": {
         "punycode": {
@@ -18193,7 +18193,7 @@
       "integrity": "sha1-fskRMJJHZsf1c74wIMNPj9/QDWI=",
       "dev": true,
       "requires": {
-        "glob": "6.0.4"
+        "glob": "^6.0.4"
       },
       "dependencies": {
         "glob": {
@@ -18202,11 +18202,11 @@
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -18223,7 +18223,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -18239,7 +18239,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-is": {
@@ -18249,7 +18249,7 @@
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.18"
+        "mime-types": "~2.1.18"
       }
     },
     "typedarray": {
@@ -18269,9 +18269,9 @@
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
       },
       "dependencies": {
         "source-map": {
@@ -18286,9 +18286,9 @@
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
           "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
+            "camelcase": "^1.0.2",
+            "cliui": "^2.1.0",
+            "decamelize": "^1.0.0",
             "window-size": "0.1.0"
           }
         }
@@ -18307,14 +18307,14 @@
       "integrity": "sha512-hIQJ1yxAPhEA2yW/i7Fr+SXZVMp+VEI3d42RTHBgQd2yhp/1UdBcR3QEWPV5ahBxlqQDMEMTuTEvDHSFINfwSw==",
       "dev": true,
       "requires": {
-        "cacache": "10.0.4",
-        "find-cache-dir": "1.0.0",
-        "schema-utils": "0.4.5",
-        "serialize-javascript": "1.5.0",
-        "source-map": "0.6.1",
-        "uglify-es": "3.3.9",
-        "webpack-sources": "1.1.0",
-        "worker-farm": "1.6.0"
+        "cacache": "^10.0.4",
+        "find-cache-dir": "^1.0.0",
+        "schema-utils": "^0.4.5",
+        "serialize-javascript": "^1.4.0",
+        "source-map": "^0.6.1",
+        "uglify-es": "^3.3.4",
+        "webpack-sources": "^1.1.0",
+        "worker-farm": "^1.5.2"
       },
       "dependencies": {
         "commander": {
@@ -18329,8 +18329,8 @@
           "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
           "dev": true,
           "requires": {
-            "commander": "2.13.0",
-            "source-map": "0.6.1"
+            "commander": "~2.13.0",
+            "source-map": "~0.6.1"
           }
         }
       }
@@ -18347,10 +18347,10 @@
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "get-value": "2.0.6",
-        "is-extendable": "0.1.1",
-        "set-value": "0.4.3"
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^0.4.3"
       },
       "dependencies": {
         "extend-shallow": {
@@ -18359,7 +18359,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "set-value": {
@@ -18368,10 +18368,10 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
           }
         }
       }
@@ -18388,7 +18388,7 @@
       "integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
       "dev": true,
       "requires": {
-        "macaddress": "0.2.8"
+        "macaddress": "^0.2.8"
       }
     },
     "uniqs": {
@@ -18403,7 +18403,7 @@
       "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
       "dev": true,
       "requires": {
-        "unique-slug": "2.0.0"
+        "unique-slug": "^2.0.0"
       }
     },
     "unique-slug": {
@@ -18412,7 +18412,7 @@
       "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
       "dev": true,
       "requires": {
-        "imurmurhash": "0.1.4"
+        "imurmurhash": "^0.1.4"
       }
     },
     "universalify": {
@@ -18433,8 +18433,8 @@
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
-        "has-value": "0.3.1",
-        "isobject": "3.0.1"
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "has-value": {
@@ -18443,9 +18443,9 @@
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
-            "get-value": "2.0.6",
-            "has-values": "0.1.4",
-            "isobject": "2.1.0"
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -18497,7 +18497,7 @@
       "integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
       "dev": true,
       "requires": {
-        "punycode": "2.1.0"
+        "punycode": "^2.1.0"
       },
       "dependencies": {
         "punycode": {
@@ -18538,9 +18538,9 @@
       "integrity": "sha512-h3qf9TNn53BpuXTTcpC+UehiRrl0Cv45Yr/xWayApjw6G8Bg2dGke7rIwDQ39piciWCWrC+WiqLjOh3SUp9n0Q==",
       "dev": true,
       "requires": {
-        "loader-utils": "1.1.0",
-        "mime": "1.4.1",
-        "schema-utils": "0.3.0"
+        "loader-utils": "^1.0.2",
+        "mime": "^1.4.1",
+        "schema-utils": "^0.3.0"
       },
       "dependencies": {
         "schema-utils": {
@@ -18549,7 +18549,7 @@
           "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
           "dev": true,
           "requires": {
-            "ajv": "5.5.2"
+            "ajv": "^5.0.0"
           }
         }
       }
@@ -18560,8 +18560,8 @@
       "integrity": "sha512-ERuGxDiQ6Xw/agN4tuoCRbmwRuZP0cJ1lJxJubXr5Q/5cDa78+Dc4wfvtxzhzhkm5VvmW6Mf8EVj9SPGN4l8Lg==",
       "dev": true,
       "requires": {
-        "querystringify": "2.0.0",
-        "requires-port": "1.0.0"
+        "querystringify": "^2.0.0",
+        "requires-port": "^1.0.0"
       },
       "dependencies": {
         "querystringify": {
@@ -18578,7 +18578,7 @@
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "dev": true,
       "requires": {
-        "prepend-http": "1.0.4"
+        "prepend-http": "^1.0.1"
       }
     },
     "use": {
@@ -18587,7 +18587,7 @@
       "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
       "dev": true,
       "requires": {
-        "kind-of": "6.0.2"
+        "kind-of": "^6.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -18627,8 +18627,8 @@
       "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "object.getownpropertydescriptors": "2.0.3"
+        "define-properties": "^1.1.2",
+        "object.getownpropertydescriptors": "^2.0.3"
       }
     },
     "utila": {
@@ -18655,8 +18655,8 @@
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "dev": true,
       "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
+        "spdx-correct": "~1.0.0",
+        "spdx-expression-parse": "~1.0.0"
       }
     },
     "vary": {
@@ -18677,10 +18677,10 @@
       "integrity": "sha512-ZyXBm+9C/6kNUNyc+aeNKEhtTu/Mn+OfpsNBGuTxU8S2DUcis/KQL0rTN6jWL+7ygdOrun18qhheNZTA7YERmg==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.10",
-        "prop-types": "15.6.1",
-        "react-transition-group": "2.3.1",
-        "velocity-animate": "1.5.1"
+        "lodash": "^4.17.5",
+        "prop-types": "^15.5.8",
+        "react-transition-group": "^2.0.0",
+        "velocity-animate": "^1.4.0"
       }
     },
     "vendors": {
@@ -18695,9 +18695,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "vm-browserify": {
@@ -18715,7 +18715,7 @@
       "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
       "dev": true,
       "requires": {
-        "browser-process-hrtime": "0.1.2"
+        "browser-process-hrtime": "^0.1.2"
       }
     },
     "walker": {
@@ -18724,7 +18724,7 @@
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "dev": true,
       "requires": {
-        "makeerror": "1.0.11"
+        "makeerror": "1.0.x"
       }
     },
     "warning": {
@@ -18733,7 +18733,7 @@
       "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
       "dev": true,
       "requires": {
-        "loose-envify": "1.3.1"
+        "loose-envify": "^1.0.0"
       }
     },
     "watch": {
@@ -18742,8 +18742,8 @@
       "integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
       "dev": true,
       "requires": {
-        "exec-sh": "0.2.1",
-        "minimist": "1.2.0"
+        "exec-sh": "^0.2.0",
+        "minimist": "^1.2.0"
       },
       "dependencies": {
         "minimist": {
@@ -18760,9 +18760,9 @@
       "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
       "dev": true,
       "requires": {
-        "chokidar": "2.0.3",
-        "graceful-fs": "4.1.11",
-        "neo-async": "2.5.1"
+        "chokidar": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "neo-async": "^2.5.0"
       }
     },
     "wcwidth": {
@@ -18771,7 +18771,7 @@
       "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
       "dev": true,
       "requires": {
-        "defaults": "1.0.3"
+        "defaults": "^1.0.3"
       }
     },
     "webidl-conversions": {
@@ -18786,28 +18786,28 @@
       "integrity": "sha512-3kOFejWqj5ISpJk4Qj/V7w98h9Vl52wak3CLiw/cDOfbVTq7FeoZ0SdoHHY9PYlHr50ZS42OfvzE2vB4nncKQg==",
       "dev": true,
       "requires": {
-        "acorn": "5.5.3",
-        "acorn-dynamic-import": "2.0.2",
-        "ajv": "6.4.0",
-        "ajv-keywords": "3.2.0",
-        "async": "2.6.0",
-        "enhanced-resolve": "3.4.1",
-        "escope": "3.6.0",
-        "interpret": "1.1.0",
-        "json-loader": "0.5.7",
-        "json5": "0.5.1",
-        "loader-runner": "2.3.0",
-        "loader-utils": "1.1.0",
-        "memory-fs": "0.4.1",
-        "mkdirp": "0.5.1",
-        "node-libs-browser": "2.1.0",
-        "source-map": "0.5.7",
-        "supports-color": "4.5.0",
-        "tapable": "0.2.8",
-        "uglifyjs-webpack-plugin": "0.4.6",
-        "watchpack": "1.6.0",
-        "webpack-sources": "1.1.0",
-        "yargs": "8.0.2"
+        "acorn": "^5.0.0",
+        "acorn-dynamic-import": "^2.0.0",
+        "ajv": "^6.1.0",
+        "ajv-keywords": "^3.1.0",
+        "async": "^2.1.2",
+        "enhanced-resolve": "^3.4.0",
+        "escope": "^3.6.0",
+        "interpret": "^1.0.0",
+        "json-loader": "^0.5.4",
+        "json5": "^0.5.1",
+        "loader-runner": "^2.3.0",
+        "loader-utils": "^1.1.0",
+        "memory-fs": "~0.4.1",
+        "mkdirp": "~0.5.0",
+        "node-libs-browser": "^2.0.0",
+        "source-map": "^0.5.3",
+        "supports-color": "^4.2.1",
+        "tapable": "^0.2.7",
+        "uglifyjs-webpack-plugin": "^0.4.6",
+        "watchpack": "^1.4.0",
+        "webpack-sources": "^1.0.1",
+        "yargs": "^8.0.2"
       },
       "dependencies": {
         "ajv": {
@@ -18816,10 +18816,10 @@
           "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "1.1.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1",
-            "uri-js": "3.0.2"
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0",
+            "uri-js": "^3.0.2"
           }
         },
         "source-map": {
@@ -18847,11 +18847,11 @@
       "integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
       "dev": true,
       "requires": {
-        "memory-fs": "0.4.1",
-        "mime": "1.6.0",
-        "path-is-absolute": "1.0.1",
-        "range-parser": "1.2.0",
-        "time-stamp": "2.0.0"
+        "memory-fs": "~0.4.1",
+        "mime": "^1.5.0",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "time-stamp": "^2.0.0"
       },
       "dependencies": {
         "mime": {
@@ -18869,9 +18869,9 @@
       "dev": true,
       "requires": {
         "ansi-html": "0.0.7",
-        "html-entities": "1.2.1",
-        "querystring": "0.2.0",
-        "strip-ansi": "3.0.1"
+        "html-entities": "^1.2.0",
+        "querystring": "^0.2.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "webpack-sources": {
@@ -18880,8 +18880,8 @@
       "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
       "dev": true,
       "requires": {
-        "source-list-map": "2.0.0",
-        "source-map": "0.6.1"
+        "source-list-map": "^2.0.0",
+        "source-map": "~0.6.1"
       }
     },
     "websocket-driver": {
@@ -18890,8 +18890,8 @@
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "dev": true,
       "requires": {
-        "http-parser-js": "0.4.12",
-        "websocket-extensions": "0.1.3"
+        "http-parser-js": ">=0.4.0",
+        "websocket-extensions": ">=0.1.1"
       }
     },
     "websocket-extensions": {
@@ -18926,9 +18926,9 @@
       "integrity": "sha512-FwygsxsXx27x6XXuExA/ox3Ktwcbf+OAvrKmLulotDAiO1Q6ixchPFaHYsis2zZBZSJTR0+dR+JVtf7MlbqZjw==",
       "dev": true,
       "requires": {
-        "lodash.sortby": "4.7.0",
-        "tr46": "1.0.1",
-        "webidl-conversions": "4.0.2"
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
       }
     },
     "whet.extend": {
@@ -18943,7 +18943,7 @@
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -18958,7 +18958,7 @@
       "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "^1.0.2"
       },
       "dependencies": {
         "string-width": {
@@ -18967,9 +18967,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         }
       }
@@ -18992,7 +18992,7 @@
       "integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
       "dev": true,
       "requires": {
-        "errno": "0.1.7"
+        "errno": "~0.1.7"
       }
     },
     "wrap-ansi": {
@@ -19001,8 +19001,8 @@
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       },
       "dependencies": {
         "string-width": {
@@ -19011,9 +19011,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         }
       }
@@ -19030,7 +19030,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       }
     },
     "write-file-atomic": {
@@ -19039,9 +19039,9 @@
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "signal-exit": "3.0.2"
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
       }
     },
     "write-json-file": {
@@ -19050,12 +19050,12 @@
       "integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
       "dev": true,
       "requires": {
-        "detect-indent": "5.0.0",
-        "graceful-fs": "4.1.11",
-        "make-dir": "1.1.0",
-        "pify": "3.0.0",
-        "sort-keys": "2.0.0",
-        "write-file-atomic": "2.3.0"
+        "detect-indent": "^5.0.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^1.0.0",
+        "pify": "^3.0.0",
+        "sort-keys": "^2.0.0",
+        "write-file-atomic": "^2.0.0"
       },
       "dependencies": {
         "detect-indent": {
@@ -19070,7 +19070,7 @@
           "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
           "dev": true,
           "requires": {
-            "is-plain-obj": "1.1.0"
+            "is-plain-obj": "^1.0.0"
           }
         }
       }
@@ -19081,8 +19081,8 @@
       "integrity": "sha1-AwqZlMyZk9JbTnWp8aGSNgcpHOk=",
       "dev": true,
       "requires": {
-        "sort-keys": "2.0.0",
-        "write-json-file": "2.3.0"
+        "sort-keys": "^2.0.0",
+        "write-json-file": "^2.2.0"
       },
       "dependencies": {
         "sort-keys": {
@@ -19091,7 +19091,7 @@
           "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
           "dev": true,
           "requires": {
-            "is-plain-obj": "1.1.0"
+            "is-plain-obj": "^1.0.0"
           }
         }
       }
@@ -19102,8 +19102,8 @@
       "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
       "dev": true,
       "requires": {
-        "async-limiter": "1.0.0",
-        "safe-buffer": "5.1.1"
+        "async-limiter": "~1.0.0",
+        "safe-buffer": "~5.1.0"
       }
     },
     "xml-name-validator": {
@@ -19136,19 +19136,19 @@
       "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
       "dev": true,
       "requires": {
-        "camelcase": "4.1.0",
-        "cliui": "3.2.0",
-        "decamelize": "1.2.0",
-        "get-caller-file": "1.0.2",
-        "os-locale": "2.1.0",
-        "read-pkg-up": "2.0.0",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "2.1.1",
-        "which-module": "2.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "7.0.0"
+        "camelcase": "^4.1.0",
+        "cliui": "^3.2.0",
+        "decamelize": "^1.1.1",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^2.0.0",
+        "read-pkg-up": "^2.0.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^2.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^3.2.1",
+        "yargs-parser": "^7.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -19163,9 +19163,9 @@
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           },
           "dependencies": {
             "string-width": {
@@ -19174,9 +19174,9 @@
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             }
           }
@@ -19189,7 +19189,7 @@
       "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
       "dev": true,
       "requires": {
-        "camelcase": "4.1.0"
+        "camelcase": "^4.1.0"
       },
       "dependencies": {
         "camelcase": {

--- a/packages/matchbox/package-lock.json
+++ b/packages/matchbox/package-lock.json
@@ -1,88 +1,111 @@
 {
-	"requires": true,
+	"name": "@sparkpost/matchbox",
+	"version": "3.1.2",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
+		"@sparkpost/matchbox-icons": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@sparkpost/matchbox-icons/-/matchbox-icons-1.1.1.tgz",
+			"integrity": "sha512-dxvgRtJmFDbzsLibZ7BOW7T39gCxB0LgVgoepZTxmse3NvVqJY1wft/lyCEfnmCtLEafcqU2MnTJemMuOh36Qg==",
+			"requires": {
+				"prop-types": "^15.6.1",
+				"react": "^15.3.0 || ^16.0.0",
+				"react-dom": "^15.3.0 || ^16.0.0"
+			}
+		},
 		"@types/acorn": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/@types/acorn/-/acorn-4.0.3.tgz",
 			"integrity": "sha512-gou/kWQkGPMZjdCKNZGDpqxLm9+ErG/pFZKPX4tvCjr0Xf4FCYYX3nAsu7aDVKJV3KUe27+mvqqyWT/9VZoM/A==",
+			"dev": true,
 			"requires": {
-				"@types/estree": "0.0.39"
+				"@types/estree": "*"
 			}
 		},
 		"@types/estree": {
 			"version": "0.0.39",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
+			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+			"dev": true
 		},
 		"@vue/component-compiler-utils": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@vue/component-compiler-utils/-/component-compiler-utils-1.1.0.tgz",
 			"integrity": "sha512-i7AW2TWjoaC5n3gVEbyjm7Ty7b3noq6hTv9/HD8uBIrqsiBTBJ00UvfdyWggDvLTZ32yo6kBj/DhSkqoIvpRMg==",
+			"dev": true,
 			"requires": {
-				"consolidate": "0.15.1",
-				"hash-sum": "1.0.2",
-				"lru-cache": "4.1.2",
-				"merge-source-map": "1.1.0",
-				"postcss": "6.0.21",
-				"postcss-selector-parser": "3.1.1",
-				"prettier": "1.12.1",
-				"source-map": "0.5.7",
-				"vue-template-es2015-compiler": "1.6.0"
+				"consolidate": "^0.15.1",
+				"hash-sum": "^1.0.2",
+				"lru-cache": "^4.1.2",
+				"merge-source-map": "^1.1.0",
+				"postcss": "^6.0.20",
+				"postcss-selector-parser": "^3.1.1",
+				"prettier": "^1.11.1",
+				"source-map": "^0.5.6",
+				"vue-template-es2015-compiler": "^1.6.0"
 			},
 			"dependencies": {
 				"dot-prop": {
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
 					"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+					"dev": true,
 					"requires": {
-						"is-obj": "1.0.1"
+						"is-obj": "^1.0.0"
 					}
 				},
 				"postcss-selector-parser": {
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
 					"integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+					"dev": true,
 					"requires": {
-						"dot-prop": "4.2.0",
-						"indexes-of": "1.0.1",
-						"uniq": "1.0.1"
+						"dot-prop": "^4.1.1",
+						"indexes-of": "^1.0.1",
+						"uniq": "^1.0.1"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				}
 			}
 		},
 		"abab": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
-			"integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
+			"integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
+			"dev": true
 		},
 		"abbrev": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+			"dev": true
 		},
 		"acorn": {
 			"version": "5.5.3",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
-			"integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
+			"integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
+			"dev": true
 		},
 		"acorn-globals": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
 			"integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
+			"dev": true,
 			"requires": {
-				"acorn": "4.0.13"
+				"acorn": "^4.0.4"
 			},
 			"dependencies": {
 				"acorn": {
 					"version": "4.0.13",
 					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+					"dev": true
 				}
 			}
 		},
@@ -90,99 +113,115 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
 			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2",
-				"longest": "1.0.1",
-				"repeat-string": "1.6.1"
+				"kind-of": "^3.0.2",
+				"longest": "^1.0.1",
+				"repeat-string": "^1.5.2"
 			}
 		},
 		"alphanum-sort": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
-			"integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
+			"integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
+			"dev": true
 		},
 		"amdefine": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+			"dev": true
 		},
 		"ansi-regex": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+			"dev": true
 		},
 		"ansi-styles": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
 			"requires": {
-				"color-convert": "1.9.1"
+				"color-convert": "^1.9.0"
 			}
 		},
 		"append-transform": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
 			"integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+			"dev": true,
 			"requires": {
-				"default-require-extensions": "1.0.0"
+				"default-require-extensions": "^1.0.0"
 			}
 		},
 		"aproba": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+			"dev": true
 		},
 		"are-we-there-yet": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
 			"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+			"dev": true,
 			"requires": {
-				"delegates": "1.0.0",
-				"readable-stream": "2.3.6"
+				"delegates": "^1.0.0",
+				"readable-stream": "^2.0.6"
 			}
 		},
 		"argparse": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
 			"requires": {
-				"sprintf-js": "1.0.3"
+				"sprintf-js": "~1.0.2"
 			}
 		},
 		"arr-diff": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+			"dev": true
 		},
 		"arr-flatten": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"dev": true
 		},
 		"arr-union": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+			"dev": true
 		},
 		"array-equal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+			"dev": true
 		},
 		"array-find-index": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+			"dev": true
 		},
 		"array-unique": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+			"dev": true
 		},
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+			"dev": true
 		},
 		"asap": {
 			"version": "2.0.6",
@@ -192,210 +231,234 @@
 		"asn1": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+			"dev": true
 		},
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+			"dev": true
 		},
 		"assign-symbols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+			"dev": true
 		},
 		"async": {
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
 			"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+			"dev": true,
 			"requires": {
-				"lodash": "4.17.10"
+				"lodash": "^4.14.0"
 			}
 		},
 		"async-each": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
 			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+			"dev": true,
 			"optional": true
 		},
 		"async-foreach": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
-			"integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI="
+			"integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
+			"dev": true
 		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"dev": true
 		},
 		"atob": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.0.tgz",
-			"integrity": "sha512-SuiKH8vbsOyCALjA/+EINmt/Kdl+TQPrtFgW7XZZcwtryFu9e5kQoX3bjCW6mIvGH1fbeAZZuvwGR5IlBRznGw=="
+			"integrity": "sha512-SuiKH8vbsOyCALjA/+EINmt/Kdl+TQPrtFgW7XZZcwtryFu9e5kQoX3bjCW6mIvGH1fbeAZZuvwGR5IlBRznGw==",
+			"dev": true
 		},
 		"autoprefixer": {
 			"version": "7.2.6",
 			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.6.tgz",
 			"integrity": "sha512-Iq8TRIB+/9eQ8rbGhcP7ct5cYb/3qjNYAR2SnzLCEcwF6rvVOax8+9+fccgXk4bEhQGjOZd5TLhsksmAdsbGqQ==",
+			"dev": true,
 			"requires": {
-				"browserslist": "2.11.3",
-				"caniuse-lite": "1.0.30000830",
-				"normalize-range": "0.1.2",
-				"num2fraction": "1.2.2",
-				"postcss": "6.0.21",
-				"postcss-value-parser": "3.3.0"
+				"browserslist": "^2.11.3",
+				"caniuse-lite": "^1.0.30000805",
+				"normalize-range": "^0.1.2",
+				"num2fraction": "^1.2.2",
+				"postcss": "^6.0.17",
+				"postcss-value-parser": "^3.2.3"
 			}
 		},
 		"aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+			"dev": true
 		},
 		"aws4": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-			"integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
+			"integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
+			"dev": true
 		},
 		"babel-cli": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
 			"integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
+			"dev": true,
 			"requires": {
-				"babel-core": "6.26.0",
-				"babel-polyfill": "6.26.0",
-				"babel-register": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"chokidar": "1.7.0",
-				"commander": "2.15.1",
-				"convert-source-map": "1.5.1",
-				"fs-readdir-recursive": "1.1.0",
-				"glob": "7.1.2",
-				"lodash": "4.17.10",
-				"output-file-sync": "1.1.2",
-				"path-is-absolute": "1.0.1",
-				"slash": "1.0.0",
-				"source-map": "0.5.7",
-				"v8flags": "2.1.1"
+				"babel-core": "^6.26.0",
+				"babel-polyfill": "^6.26.0",
+				"babel-register": "^6.26.0",
+				"babel-runtime": "^6.26.0",
+				"chokidar": "^1.6.1",
+				"commander": "^2.11.0",
+				"convert-source-map": "^1.5.0",
+				"fs-readdir-recursive": "^1.0.0",
+				"glob": "^7.1.2",
+				"lodash": "^4.17.4",
+				"output-file-sync": "^1.1.2",
+				"path-is-absolute": "^1.0.1",
+				"slash": "^1.0.0",
+				"source-map": "^0.5.6",
+				"v8flags": "^2.1.1"
 			},
 			"dependencies": {
 				"anymatch": {
 					"version": "1.3.2",
 					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
 					"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+					"dev": true,
 					"optional": true,
 					"requires": {
-						"micromatch": "2.3.11",
-						"normalize-path": "2.1.1"
+						"micromatch": "^2.1.5",
+						"normalize-path": "^2.0.0"
 					}
 				},
 				"arr-diff": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+					"dev": true,
 					"optional": true,
 					"requires": {
-						"arr-flatten": "1.1.0"
+						"arr-flatten": "^1.0.1"
 					}
 				},
 				"array-unique": {
 					"version": "0.2.1",
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
 					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+					"dev": true,
 					"optional": true
 				},
 				"braces": {
 					"version": "1.8.5",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+					"dev": true,
 					"optional": true,
 					"requires": {
-						"expand-range": "1.8.2",
-						"preserve": "0.2.0",
-						"repeat-element": "1.1.2"
+						"expand-range": "^1.8.1",
+						"preserve": "^0.2.0",
+						"repeat-element": "^1.1.2"
 					}
 				},
 				"chokidar": {
 					"version": "1.7.0",
 					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
 					"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+					"dev": true,
 					"optional": true,
 					"requires": {
-						"anymatch": "1.3.2",
-						"async-each": "1.0.1",
-						"fsevents": "1.2.2",
-						"glob-parent": "2.0.0",
-						"inherits": "2.0.3",
-						"is-binary-path": "1.0.1",
-						"is-glob": "2.0.1",
-						"path-is-absolute": "1.0.1",
-						"readdirp": "2.1.0"
+						"anymatch": "^1.3.0",
+						"async-each": "^1.0.0",
+						"fsevents": "^1.0.0",
+						"glob-parent": "^2.0.0",
+						"inherits": "^2.0.1",
+						"is-binary-path": "^1.0.0",
+						"is-glob": "^2.0.0",
+						"path-is-absolute": "^1.0.0",
+						"readdirp": "^2.0.0"
 					}
 				},
 				"expand-brackets": {
 					"version": "0.1.5",
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+					"dev": true,
 					"optional": true,
 					"requires": {
-						"is-posix-bracket": "0.1.1"
+						"is-posix-bracket": "^0.1.0"
 					}
 				},
 				"extglob": {
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+					"dev": true,
 					"optional": true,
 					"requires": {
-						"is-extglob": "1.0.0"
+						"is-extglob": "^1.0.0"
 					}
 				},
 				"glob-parent": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+					"dev": true,
 					"optional": true,
 					"requires": {
-						"is-glob": "2.0.1"
+						"is-glob": "^2.0.0"
 					}
 				},
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
 					"requires": {
-						"is-extglob": "1.0.0"
+						"is-extglob": "^1.0.0"
 					}
 				},
 				"micromatch": {
 					"version": "2.3.11",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+					"dev": true,
 					"optional": true,
 					"requires": {
-						"arr-diff": "2.0.0",
-						"array-unique": "0.2.1",
-						"braces": "1.8.5",
-						"expand-brackets": "0.1.5",
-						"extglob": "0.3.2",
-						"filename-regex": "2.0.1",
-						"is-extglob": "1.0.0",
-						"is-glob": "2.0.1",
-						"kind-of": "3.2.2",
-						"normalize-path": "2.1.1",
-						"object.omit": "2.0.1",
-						"parse-glob": "3.0.4",
-						"regex-cache": "0.4.4"
+						"arr-diff": "^2.0.0",
+						"array-unique": "^0.2.1",
+						"braces": "^1.8.2",
+						"expand-brackets": "^0.1.4",
+						"extglob": "^0.3.1",
+						"filename-regex": "^2.0.0",
+						"is-extglob": "^1.0.0",
+						"is-glob": "^2.0.1",
+						"kind-of": "^3.0.2",
+						"normalize-path": "^2.0.1",
+						"object.omit": "^2.0.0",
+						"parse-glob": "^3.0.4",
+						"regex-cache": "^0.4.2"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				}
 			}
 		},
@@ -403,33 +466,37 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+			"dev": true,
 			"requires": {
-				"chalk": "1.1.3",
-				"esutils": "2.0.2",
-				"js-tokens": "3.0.2"
+				"chalk": "^1.1.3",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.2"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					}
 				},
 				"supports-color": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
 				}
 			}
 		},
@@ -437,37 +504,40 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
 			"integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+			"dev": true,
 			"requires": {
-				"babel-code-frame": "6.26.0",
-				"babel-generator": "6.26.1",
-				"babel-helpers": "6.24.1",
-				"babel-messages": "6.23.0",
-				"babel-register": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"convert-source-map": "1.5.1",
-				"debug": "2.6.9",
-				"json5": "0.5.1",
-				"lodash": "4.17.10",
-				"minimatch": "3.0.4",
-				"path-is-absolute": "1.0.1",
-				"private": "0.1.8",
-				"slash": "1.0.0",
-				"source-map": "0.5.7"
+				"babel-code-frame": "^6.26.0",
+				"babel-generator": "^6.26.0",
+				"babel-helpers": "^6.24.1",
+				"babel-messages": "^6.23.0",
+				"babel-register": "^6.26.0",
+				"babel-runtime": "^6.26.0",
+				"babel-template": "^6.26.0",
+				"babel-traverse": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"babylon": "^6.18.0",
+				"convert-source-map": "^1.5.0",
+				"debug": "^2.6.8",
+				"json5": "^0.5.1",
+				"lodash": "^4.17.4",
+				"minimatch": "^3.0.4",
+				"path-is-absolute": "^1.0.1",
+				"private": "^0.1.7",
+				"slash": "^1.0.0",
+				"source-map": "^0.5.6"
 			},
 			"dependencies": {
 				"babylon": {
 					"version": "6.18.0",
 					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-					"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+					"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+					"dev": true
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				}
 			}
 		},
@@ -475,26 +545,29 @@
 			"version": "6.26.1",
 			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
 			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+			"dev": true,
 			"requires": {
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"detect-indent": "4.0.0",
-				"jsesc": "1.3.0",
-				"lodash": "4.17.10",
-				"source-map": "0.5.7",
-				"trim-right": "1.0.1"
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"detect-indent": "^4.0.0",
+				"jsesc": "^1.3.0",
+				"lodash": "^4.17.4",
+				"source-map": "^0.5.7",
+				"trim-right": "^1.0.1"
 			},
 			"dependencies": {
 				"jsesc": {
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-					"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+					"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+					"dev": true
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				}
 			}
 		},
@@ -502,406 +575,450 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
 			"integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
+			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"esutils": "2.0.2"
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"esutils": "^2.0.2"
 			}
 		},
 		"babel-helper-call-delegate": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+			"dev": true,
 			"requires": {
-				"babel-helper-hoist-variables": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-hoist-variables": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-define-map": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
 			"integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+			"dev": true,
 			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"lodash": "4.17.10"
+				"babel-helper-function-name": "^6.24.1",
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"lodash": "^4.17.4"
 			}
 		},
 		"babel-helper-function-name": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+			"dev": true,
 			"requires": {
-				"babel-helper-get-function-arity": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-get-function-arity": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-get-function-arity": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-hoist-variables": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-optimise-call-expression": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
 			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-regex": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
 			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"lodash": "4.17.10"
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"lodash": "^4.17.4"
 			}
 		},
 		"babel-helper-replace-supers": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
 			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+			"dev": true,
 			"requires": {
-				"babel-helper-optimise-call-expression": "6.24.1",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-optimise-call-expression": "^6.24.1",
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helpers": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-jest": {
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-20.0.3.tgz",
 			"integrity": "sha1-5KA7E9wQOJ4UD8ZF0J/8TO0wFnE=",
+			"dev": true,
 			"requires": {
-				"babel-core": "6.26.0",
-				"babel-plugin-istanbul": "4.1.6",
-				"babel-preset-jest": "20.0.3"
+				"babel-core": "^6.0.0",
+				"babel-plugin-istanbul": "^4.0.0",
+				"babel-preset-jest": "^20.0.3"
 			}
 		},
 		"babel-messages": {
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-check-es2015-constants": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-external-helpers": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz",
 			"integrity": "sha1-IoX0iwK9Xe3oUXXK+MYuhq3M76E=",
+			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-istanbul": {
 			"version": "4.1.6",
 			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
 			"integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
+			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-object-rest-spread": "6.13.0",
-				"find-up": "2.1.0",
-				"istanbul-lib-instrument": "1.10.1",
-				"test-exclude": "4.2.1"
+				"babel-plugin-syntax-object-rest-spread": "^6.13.0",
+				"find-up": "^2.1.0",
+				"istanbul-lib-instrument": "^1.10.1",
+				"test-exclude": "^4.2.1"
 			}
 		},
 		"babel-plugin-jest-hoist": {
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-20.0.3.tgz",
-			"integrity": "sha1-r+3IU70/jcNUjqZx++adA8wsF2c="
+			"integrity": "sha1-r+3IU70/jcNUjqZx++adA8wsF2c=",
+			"dev": true
 		},
 		"babel-plugin-syntax-class-properties": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
-			"integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
+			"integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=",
+			"dev": true
 		},
 		"babel-plugin-syntax-flow": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
-			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
+			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=",
+			"dev": true
 		},
 		"babel-plugin-syntax-jsx": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
+			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
+			"dev": true
 		},
 		"babel-plugin-syntax-object-rest-spread": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+			"dev": true
 		},
 		"babel-plugin-transform-class-properties": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
 			"integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
+			"dev": true,
 			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-plugin-syntax-class-properties": "6.13.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-helper-function-name": "^6.24.1",
+				"babel-plugin-syntax-class-properties": "^6.8.0",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-arrow-functions": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
 			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-block-scoped-functions": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
 			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-block-scoping": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
 			"integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"lodash": "4.17.10"
+				"babel-runtime": "^6.26.0",
+				"babel-template": "^6.26.0",
+				"babel-traverse": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"lodash": "^4.17.4"
 			}
 		},
 		"babel-plugin-transform-es2015-classes": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
 			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+			"dev": true,
 			"requires": {
-				"babel-helper-define-map": "6.26.0",
-				"babel-helper-function-name": "6.24.1",
-				"babel-helper-optimise-call-expression": "6.24.1",
-				"babel-helper-replace-supers": "6.24.1",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-define-map": "^6.24.1",
+				"babel-helper-function-name": "^6.24.1",
+				"babel-helper-optimise-call-expression": "^6.24.1",
+				"babel-helper-replace-supers": "^6.24.1",
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-computed-properties": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
 			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-destructuring": {
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-duplicate-keys": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
 			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-for-of": {
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
 			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-function-name": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+			"dev": true,
 			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-function-name": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-literals": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
 			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-amd": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
 			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+			"dev": true,
 			"requires": {
-				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-commonjs": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
 			"integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
+			"dev": true,
 			"requires": {
-				"babel-plugin-transform-strict-mode": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-plugin-transform-strict-mode": "^6.24.1",
+				"babel-runtime": "^6.26.0",
+				"babel-template": "^6.26.0",
+				"babel-types": "^6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-systemjs": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
 			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+			"dev": true,
 			"requires": {
-				"babel-helper-hoist-variables": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-helper-hoist-variables": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-umd": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
 			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+			"dev": true,
 			"requires": {
-				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-object-super": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
 			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+			"dev": true,
 			"requires": {
-				"babel-helper-replace-supers": "6.24.1",
-				"babel-runtime": "6.26.0"
+				"babel-helper-replace-supers": "^6.24.1",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-parameters": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+			"dev": true,
 			"requires": {
-				"babel-helper-call-delegate": "6.24.1",
-				"babel-helper-get-function-arity": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-call-delegate": "^6.24.1",
+				"babel-helper-get-function-arity": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-shorthand-properties": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
 			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-spread": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-sticky-regex": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+			"dev": true,
 			"requires": {
-				"babel-helper-regex": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-regex": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-template-literals": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
 			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-typeof-symbol": {
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
 			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-unicode-regex": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+			"dev": true,
 			"requires": {
-				"babel-helper-regex": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"regexpu-core": "2.0.0"
+				"babel-helper-regex": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"regexpu-core": "^2.0.0"
 			},
 			"dependencies": {
 				"regexpu-core": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
 					"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+					"dev": true,
 					"requires": {
-						"regenerate": "1.3.3",
-						"regjsgen": "0.2.0",
-						"regjsparser": "0.1.5"
+						"regenerate": "^1.2.1",
+						"regjsgen": "^0.2.0",
+						"regjsparser": "^0.1.4"
 					}
 				}
 			}
@@ -910,92 +1027,103 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
 			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
+			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-flow": "6.18.0",
-				"babel-runtime": "6.26.0"
+				"babel-plugin-syntax-flow": "^6.18.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-object-rest-spread": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
 			"integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-object-rest-spread": "6.13.0",
-				"babel-runtime": "6.26.0"
+				"babel-plugin-syntax-object-rest-spread": "^6.8.0",
+				"babel-runtime": "^6.26.0"
 			}
 		},
 		"babel-plugin-transform-react-display-name": {
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
 			"integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
+			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-react-jsx": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
 			"integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
+			"dev": true,
 			"requires": {
-				"babel-helper-builder-react-jsx": "6.26.0",
-				"babel-plugin-syntax-jsx": "6.18.0",
-				"babel-runtime": "6.26.0"
+				"babel-helper-builder-react-jsx": "^6.24.1",
+				"babel-plugin-syntax-jsx": "^6.8.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-react-jsx-self": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
 			"integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
+			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-jsx": "6.18.0",
-				"babel-runtime": "6.26.0"
+				"babel-plugin-syntax-jsx": "^6.8.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-react-jsx-source": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
 			"integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
+			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-jsx": "6.18.0",
-				"babel-runtime": "6.26.0"
+				"babel-plugin-syntax-jsx": "^6.8.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-regenerator": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
 			"integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+			"dev": true,
 			"requires": {
-				"regenerator-transform": "0.10.1"
+				"regenerator-transform": "^0.10.0"
 			}
 		},
 		"babel-plugin-transform-strict-mode": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-polyfill": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
 			"integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"core-js": "2.5.5",
-				"regenerator-runtime": "0.10.5"
+				"babel-runtime": "^6.26.0",
+				"core-js": "^2.5.0",
+				"regenerator-runtime": "^0.10.5"
 			},
 			"dependencies": {
 				"core-js": {
 					"version": "2.5.5",
 					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-					"integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs="
+					"integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
+					"dev": true
 				},
 				"regenerator-runtime": {
 					"version": "0.10.5",
 					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-					"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+					"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+					"dev": true
 				}
 			}
 		},
@@ -1003,80 +1131,86 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
 			"integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
+			"dev": true,
 			"requires": {
-				"babel-plugin-check-es2015-constants": "6.22.0",
-				"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-				"babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-				"babel-plugin-transform-es2015-block-scoping": "6.26.0",
-				"babel-plugin-transform-es2015-classes": "6.24.1",
-				"babel-plugin-transform-es2015-computed-properties": "6.24.1",
-				"babel-plugin-transform-es2015-destructuring": "6.23.0",
-				"babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-				"babel-plugin-transform-es2015-for-of": "6.23.0",
-				"babel-plugin-transform-es2015-function-name": "6.24.1",
-				"babel-plugin-transform-es2015-literals": "6.22.0",
-				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
-				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-				"babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-				"babel-plugin-transform-es2015-modules-umd": "6.24.1",
-				"babel-plugin-transform-es2015-object-super": "6.24.1",
-				"babel-plugin-transform-es2015-parameters": "6.24.1",
-				"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-				"babel-plugin-transform-es2015-spread": "6.22.0",
-				"babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-				"babel-plugin-transform-es2015-template-literals": "6.22.0",
-				"babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-				"babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-				"babel-plugin-transform-regenerator": "6.26.0"
+				"babel-plugin-check-es2015-constants": "^6.22.0",
+				"babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+				"babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+				"babel-plugin-transform-es2015-block-scoping": "^6.24.1",
+				"babel-plugin-transform-es2015-classes": "^6.24.1",
+				"babel-plugin-transform-es2015-computed-properties": "^6.24.1",
+				"babel-plugin-transform-es2015-destructuring": "^6.22.0",
+				"babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
+				"babel-plugin-transform-es2015-for-of": "^6.22.0",
+				"babel-plugin-transform-es2015-function-name": "^6.24.1",
+				"babel-plugin-transform-es2015-literals": "^6.22.0",
+				"babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+				"babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+				"babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
+				"babel-plugin-transform-es2015-modules-umd": "^6.24.1",
+				"babel-plugin-transform-es2015-object-super": "^6.24.1",
+				"babel-plugin-transform-es2015-parameters": "^6.24.1",
+				"babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
+				"babel-plugin-transform-es2015-spread": "^6.22.0",
+				"babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
+				"babel-plugin-transform-es2015-template-literals": "^6.22.0",
+				"babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
+				"babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
+				"babel-plugin-transform-regenerator": "^6.24.1"
 			}
 		},
 		"babel-preset-flow": {
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
 			"integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
+			"dev": true,
 			"requires": {
-				"babel-plugin-transform-flow-strip-types": "6.22.0"
+				"babel-plugin-transform-flow-strip-types": "^6.22.0"
 			}
 		},
 		"babel-preset-jest": {
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-20.0.3.tgz",
 			"integrity": "sha1-y6yq3stdaJyh4d4TYOv8ZoYsF4o=",
+			"dev": true,
 			"requires": {
-				"babel-plugin-jest-hoist": "20.0.3"
+				"babel-plugin-jest-hoist": "^20.0.3"
 			}
 		},
 		"babel-preset-react": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
 			"integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
+			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-jsx": "6.18.0",
-				"babel-plugin-transform-react-display-name": "6.25.0",
-				"babel-plugin-transform-react-jsx": "6.24.1",
-				"babel-plugin-transform-react-jsx-self": "6.22.0",
-				"babel-plugin-transform-react-jsx-source": "6.22.0",
-				"babel-preset-flow": "6.23.0"
+				"babel-plugin-syntax-jsx": "^6.3.13",
+				"babel-plugin-transform-react-display-name": "^6.23.0",
+				"babel-plugin-transform-react-jsx": "^6.24.1",
+				"babel-plugin-transform-react-jsx-self": "^6.22.0",
+				"babel-plugin-transform-react-jsx-source": "^6.22.0",
+				"babel-preset-flow": "^6.23.0"
 			}
 		},
 		"babel-register": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+			"dev": true,
 			"requires": {
-				"babel-core": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"core-js": "2.5.5",
-				"home-or-tmp": "2.0.0",
-				"lodash": "4.17.10",
-				"mkdirp": "0.5.1",
-				"source-map-support": "0.4.18"
+				"babel-core": "^6.26.0",
+				"babel-runtime": "^6.26.0",
+				"core-js": "^2.5.0",
+				"home-or-tmp": "^2.0.0",
+				"lodash": "^4.17.4",
+				"mkdirp": "^0.5.1",
+				"source-map-support": "^0.4.15"
 			},
 			"dependencies": {
 				"core-js": {
 					"version": "2.5.5",
 					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-					"integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs="
+					"integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
+					"dev": true
 				}
 			}
 		},
@@ -1084,15 +1218,17 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+			"dev": true,
 			"requires": {
-				"core-js": "2.5.5",
-				"regenerator-runtime": "0.11.1"
+				"core-js": "^2.4.0",
+				"regenerator-runtime": "^0.11.0"
 			},
 			"dependencies": {
 				"core-js": {
 					"version": "2.5.5",
 					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-					"integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs="
+					"integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
+					"dev": true
 				}
 			}
 		},
@@ -1100,18 +1236,20 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
 			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"lodash": "4.17.10"
+				"babel-runtime": "^6.26.0",
+				"babel-traverse": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"babylon": "^6.18.0",
+				"lodash": "^4.17.4"
 			},
 			"dependencies": {
 				"babylon": {
 					"version": "6.18.0",
 					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-					"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+					"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+					"dev": true
 				}
 			}
 		},
@@ -1119,22 +1257,24 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+			"dev": true,
 			"requires": {
-				"babel-code-frame": "6.26.0",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"debug": "2.6.9",
-				"globals": "9.18.0",
-				"invariant": "2.2.4",
-				"lodash": "4.17.10"
+				"babel-code-frame": "^6.26.0",
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"babylon": "^6.18.0",
+				"debug": "^2.6.8",
+				"globals": "^9.18.0",
+				"invariant": "^2.2.2",
+				"lodash": "^4.17.4"
 			},
 			"dependencies": {
 				"babylon": {
 					"version": "6.18.0",
 					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-					"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+					"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+					"dev": true
 				}
 			}
 		},
@@ -1142,70 +1282,78 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"esutils": "2.0.2",
-				"lodash": "4.17.10",
-				"to-fast-properties": "1.0.3"
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
 			}
 		},
 		"balanced-match": {
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-			"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+			"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+			"dev": true
 		},
 		"base": {
 			"version": "0.11.2",
 			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
 			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+			"dev": true,
 			"requires": {
-				"cache-base": "1.0.1",
-				"class-utils": "0.3.6",
-				"component-emitter": "1.2.1",
-				"define-property": "1.0.0",
-				"isobject": "3.0.1",
-				"mixin-deep": "1.3.1",
-				"pascalcase": "0.1.1"
+				"cache-base": "^1.0.1",
+				"class-utils": "^0.3.5",
+				"component-emitter": "^1.2.1",
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.1",
+				"mixin-deep": "^1.2.0",
+				"pascalcase": "^0.1.1"
 			},
 			"dependencies": {
 				"define-property": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
 					"requires": {
-						"is-descriptor": "1.0.2"
+						"is-descriptor": "^1.0.0"
 					}
 				},
 				"is-accessor-descriptor": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-data-descriptor": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-descriptor": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
 					}
 				},
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
 				}
 			}
 		},
@@ -1213,56 +1361,64 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
 			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+			"dev": true,
 			"optional": true,
 			"requires": {
-				"tweetnacl": "0.14.5"
+				"tweetnacl": "^0.14.3"
 			}
 		},
 		"big.js": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-			"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
+			"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+			"dev": true
 		},
 		"binary-extensions": {
 			"version": "1.11.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
 			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
+			"dev": true,
 			"optional": true
 		},
 		"block-stream": {
 			"version": "0.0.9",
 			"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
 			"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+			"dev": true,
 			"requires": {
-				"inherits": "2.0.3"
+				"inherits": "~2.0.0"
 			}
 		},
 		"bluebird": {
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-			"integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+			"integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+			"dev": true
 		},
 		"boom": {
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
 			"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+			"dev": true,
 			"requires": {
-				"hoek": "4.2.1"
+				"hoek": "4.x.x"
 			}
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
 			"requires": {
-				"balanced-match": "1.0.0",
+				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			},
 			"dependencies": {
 				"balanced-match": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+					"dev": true
 				}
 			}
 		},
@@ -1270,25 +1426,27 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
 			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+			"dev": true,
 			"requires": {
-				"arr-flatten": "1.1.0",
-				"array-unique": "0.3.2",
-				"extend-shallow": "2.0.1",
-				"fill-range": "4.0.0",
-				"isobject": "3.0.1",
-				"repeat-element": "1.1.2",
-				"snapdragon": "0.8.2",
-				"snapdragon-node": "2.1.1",
-				"split-string": "3.1.0",
-				"to-regex": "3.0.2"
+				"arr-flatten": "^1.1.0",
+				"array-unique": "^0.3.2",
+				"extend-shallow": "^2.0.1",
+				"fill-range": "^4.0.0",
+				"isobject": "^3.0.1",
+				"repeat-element": "^1.1.2",
+				"snapdragon": "^0.8.1",
+				"snapdragon-node": "^2.0.1",
+				"split-string": "^3.0.2",
+				"to-regex": "^3.0.1"
 			},
 			"dependencies": {
 				"extend-shallow": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
 					"requires": {
-						"is-extendable": "0.1.1"
+						"is-extendable": "^0.1.0"
 					}
 				}
 			}
@@ -1297,6 +1455,7 @@
 			"version": "1.11.2",
 			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
 			"integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
+			"dev": true,
 			"requires": {
 				"resolve": "1.1.7"
 			},
@@ -1304,7 +1463,8 @@
 				"resolve": {
 					"version": "1.1.7",
 					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+					"dev": true
 				}
 			}
 		},
@@ -1312,73 +1472,81 @@
 			"version": "2.11.3",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
 			"integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
+			"dev": true,
 			"requires": {
-				"caniuse-lite": "1.0.30000830",
-				"electron-to-chromium": "1.3.42"
+				"caniuse-lite": "^1.0.30000792",
+				"electron-to-chromium": "^1.3.30"
 			}
 		},
 		"bser": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
 			"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+			"dev": true,
 			"requires": {
-				"node-int64": "0.4.0"
+				"node-int64": "^0.4.0"
 			}
 		},
 		"builtin-modules": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+			"dev": true
 		},
 		"cache-base": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
 			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+			"dev": true,
 			"requires": {
-				"collection-visit": "1.0.0",
-				"component-emitter": "1.2.1",
-				"get-value": "2.0.6",
-				"has-value": "1.0.0",
-				"isobject": "3.0.1",
-				"set-value": "2.0.0",
-				"to-object-path": "0.3.0",
-				"union-value": "1.0.0",
-				"unset-value": "1.0.0"
+				"collection-visit": "^1.0.0",
+				"component-emitter": "^1.2.1",
+				"get-value": "^2.0.6",
+				"has-value": "^1.0.0",
+				"isobject": "^3.0.1",
+				"set-value": "^2.0.0",
+				"to-object-path": "^0.3.0",
+				"union-value": "^1.0.0",
+				"unset-value": "^1.0.0"
 			}
 		},
 		"camel-case": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
 			"integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+			"dev": true,
 			"requires": {
-				"no-case": "2.3.2",
-				"upper-case": "1.1.3"
+				"no-case": "^2.2.0",
+				"upper-case": "^1.1.1"
 			}
 		},
 		"camelcase": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
 			"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+			"dev": true,
 			"optional": true
 		},
 		"caniuse-api": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
 			"integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
+			"dev": true,
 			"requires": {
-				"browserslist": "1.7.7",
-				"caniuse-db": "1.0.30000830",
-				"lodash.memoize": "4.1.2",
-				"lodash.uniq": "4.5.0"
+				"browserslist": "^1.3.6",
+				"caniuse-db": "^1.0.30000529",
+				"lodash.memoize": "^4.1.2",
+				"lodash.uniq": "^4.5.0"
 			},
 			"dependencies": {
 				"browserslist": {
 					"version": "1.7.7",
 					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
 					"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+					"dev": true,
 					"requires": {
-						"caniuse-db": "1.0.30000830",
-						"electron-to-chromium": "1.3.42"
+						"caniuse-db": "^1.0.30000639",
+						"electron-to-chromium": "^1.2.7"
 					}
 				}
 			}
@@ -1386,97 +1554,108 @@
 		"caniuse-db": {
 			"version": "1.0.30000830",
 			"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000830.tgz",
-			"integrity": "sha1-bkUlWzRWSf0V/1kHLaHhK7PeLxM="
+			"integrity": "sha1-bkUlWzRWSf0V/1kHLaHhK7PeLxM=",
+			"dev": true
 		},
 		"caniuse-lite": {
 			"version": "1.0.30000830",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000830.tgz",
-			"integrity": "sha512-yMqGkujkoOIZfvOYiWdqPALgY/PVGiqCHUJb6yNq7xhI/pR+gQO0U2K6lRDqAiJv4+CIU3CtTLblNGw0QGnr6g=="
+			"integrity": "sha512-yMqGkujkoOIZfvOYiWdqPALgY/PVGiqCHUJb6yNq7xhI/pR+gQO0U2K6lRDqAiJv4+CIU3CtTLblNGw0QGnr6g==",
+			"dev": true
 		},
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+			"dev": true
 		},
 		"center-align": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
 			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+			"dev": true,
 			"optional": true,
 			"requires": {
-				"align-text": "0.1.4",
-				"lazy-cache": "1.0.4"
+				"align-text": "^0.1.3",
+				"lazy-cache": "^1.0.3"
 			}
 		},
 		"chalk": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
 			"integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+			"dev": true,
 			"requires": {
-				"ansi-styles": "3.2.1",
-				"escape-string-regexp": "1.0.5",
-				"supports-color": "5.4.0"
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
 			}
 		},
 		"change-case": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/change-case/-/change-case-3.0.2.tgz",
 			"integrity": "sha512-Mww+SLF6MZ0U6kdg11algyKd5BARbyM4TbFBepwowYSR5ClfQGCGtxNXgykpN0uF/bstWeaGDT4JWaDh8zWAHA==",
+			"dev": true,
 			"requires": {
-				"camel-case": "3.0.0",
-				"constant-case": "2.0.0",
-				"dot-case": "2.1.1",
-				"header-case": "1.0.1",
-				"is-lower-case": "1.1.3",
-				"is-upper-case": "1.1.2",
-				"lower-case": "1.1.4",
-				"lower-case-first": "1.0.2",
-				"no-case": "2.3.2",
-				"param-case": "2.1.1",
-				"pascal-case": "2.0.1",
-				"path-case": "2.1.1",
-				"sentence-case": "2.1.1",
-				"snake-case": "2.1.0",
-				"swap-case": "1.1.2",
-				"title-case": "2.1.1",
-				"upper-case": "1.1.3",
-				"upper-case-first": "1.1.2"
+				"camel-case": "^3.0.0",
+				"constant-case": "^2.0.0",
+				"dot-case": "^2.1.0",
+				"header-case": "^1.0.0",
+				"is-lower-case": "^1.1.0",
+				"is-upper-case": "^1.1.0",
+				"lower-case": "^1.1.1",
+				"lower-case-first": "^1.0.0",
+				"no-case": "^2.3.2",
+				"param-case": "^2.1.0",
+				"pascal-case": "^2.0.0",
+				"path-case": "^2.1.0",
+				"sentence-case": "^2.1.0",
+				"snake-case": "^2.1.0",
+				"swap-case": "^1.1.0",
+				"title-case": "^2.1.0",
+				"upper-case": "^1.1.1",
+				"upper-case-first": "^1.1.0"
 			}
 		},
 		"ci-info": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
-			"integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg=="
+			"integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
+			"dev": true
 		},
 		"clap": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
 			"integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
+			"dev": true,
 			"requires": {
-				"chalk": "1.1.3"
+				"chalk": "^1.1.3"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					}
 				},
 				"supports-color": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
 				}
 			}
 		},
@@ -1484,19 +1663,21 @@
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
 			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+			"dev": true,
 			"requires": {
-				"arr-union": "3.1.0",
-				"define-property": "0.2.5",
-				"isobject": "3.0.1",
-				"static-extend": "0.1.2"
+				"arr-union": "^3.1.0",
+				"define-property": "^0.2.5",
+				"isobject": "^3.0.0",
+				"static-extend": "^0.1.1"
 			},
 			"dependencies": {
 				"define-property": {
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
 					}
 				}
 			}
@@ -1510,163 +1691,187 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
 			"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+			"dev": true,
 			"optional": true,
 			"requires": {
-				"center-align": "0.1.3",
-				"right-align": "0.1.3",
+				"center-align": "^0.1.1",
+				"right-align": "^0.1.1",
 				"wordwrap": "0.0.2"
 			}
 		},
 		"clone": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+			"dev": true
 		},
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"dev": true
 		},
 		"coa": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
 			"integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
+			"dev": true,
 			"requires": {
-				"q": "1.5.1"
+				"q": "^1.1.2"
 			}
 		},
 		"code-point-at": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+			"dev": true
 		},
 		"collection-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
 			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+			"dev": true,
 			"requires": {
-				"map-visit": "1.0.0",
-				"object-visit": "1.0.1"
+				"map-visit": "^1.0.0",
+				"object-visit": "^1.0.0"
 			}
 		},
 		"color": {
 			"version": "0.11.4",
 			"resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
 			"integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
+			"dev": true,
 			"requires": {
-				"clone": "1.0.4",
-				"color-convert": "1.9.1",
-				"color-string": "0.3.0"
+				"clone": "^1.0.2",
+				"color-convert": "^1.3.0",
+				"color-string": "^0.3.0"
 			}
 		},
 		"color-convert": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
 			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+			"dev": true,
 			"requires": {
-				"color-name": "1.1.3"
+				"color-name": "^1.1.1"
 			}
 		},
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
 		},
 		"color-string": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
 			"integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+			"dev": true,
 			"requires": {
-				"color-name": "1.1.3"
+				"color-name": "^1.0.0"
 			}
 		},
 		"colormin": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
 			"integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
+			"dev": true,
 			"requires": {
-				"color": "0.11.4",
+				"color": "^0.11.0",
 				"css-color-names": "0.0.4",
-				"has": "1.0.1"
+				"has": "^1.0.1"
 			}
 		},
 		"colors": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-			"integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
+			"integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+			"dev": true
 		},
 		"combined-stream": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
 			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+			"dev": true,
 			"requires": {
-				"delayed-stream": "1.0.0"
+				"delayed-stream": "~1.0.0"
 			}
 		},
 		"commander": {
 			"version": "2.15.1",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-			"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+			"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+			"dev": true
 		},
 		"compare-versions": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.1.0.tgz",
-			"integrity": "sha512-4hAxDSBypT/yp2ySFD346So6Ragw5xmBn/e/agIGl3bZr6DLUqnoRZPusxKrXdYRZpgexO9daejmIenlq/wrIQ=="
+			"integrity": "sha512-4hAxDSBypT/yp2ySFD346So6Ragw5xmBn/e/agIGl3bZr6DLUqnoRZPusxKrXdYRZpgexO9daejmIenlq/wrIQ==",
+			"dev": true
 		},
 		"component-emitter": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+			"dev": true
 		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
 		},
 		"concat-with-sourcemaps": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.5.tgz",
 			"integrity": "sha512-YtnS0VEY+e2Khzsey/6mra9EoM6h/5gxaC0e3mcHpA5yfDxafhygytNmcJWodvUgyXzSiL5MSkPO6bQGgfliHw==",
+			"dev": true,
 			"requires": {
-				"source-map": "0.6.1"
+				"source-map": "^0.6.1"
 			}
 		},
 		"console-control-strings": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+			"dev": true
 		},
 		"consolidate": {
 			"version": "0.15.1",
 			"resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.15.1.tgz",
 			"integrity": "sha512-DW46nrsMJgy9kqAbPt5rKaCr7uFtpo4mSUvLHIUbJEjm0vo+aY5QLwBUq3FK4tRnJr/X0Psc0C4jf/h+HtXSMw==",
+			"dev": true,
 			"requires": {
-				"bluebird": "3.5.1"
+				"bluebird": "^3.1.1"
 			}
 		},
 		"constant-case": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/constant-case/-/constant-case-2.0.0.tgz",
 			"integrity": "sha1-QXV2TTidP6nI7NKRhu1gBSQ7akY=",
+			"dev": true,
 			"requires": {
-				"snake-case": "2.1.0",
-				"upper-case": "1.1.3"
+				"snake-case": "^2.1.0",
+				"upper-case": "^1.1.1"
 			}
 		},
 		"content-type-parser": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
-			"integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ=="
+			"integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ==",
+			"dev": true
 		},
 		"convert-source-map": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+			"dev": true
 		},
 		"copy-descriptor": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+			"dev": true
 		},
 		"core-js": {
 			"version": "1.2.7",
@@ -1676,26 +1881,29 @@
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
 		},
 		"cosmiconfig": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
 			"integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
+			"dev": true,
 			"requires": {
-				"is-directory": "0.3.1",
-				"js-yaml": "3.7.0",
-				"minimist": "1.2.0",
-				"object-assign": "4.1.1",
-				"os-homedir": "1.0.2",
-				"parse-json": "2.2.0",
-				"require-from-string": "1.2.1"
+				"is-directory": "^0.3.1",
+				"js-yaml": "^3.4.3",
+				"minimist": "^1.2.0",
+				"object-assign": "^4.1.0",
+				"os-homedir": "^1.0.1",
+				"parse-json": "^2.2.0",
+				"require-from-string": "^1.1.0"
 			},
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
 				}
 			}
 		},
@@ -1703,16 +1911,18 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
 			"integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+			"dev": true,
 			"requires": {
-				"boom": "5.2.0"
+				"boom": "5.x.x"
 			},
 			"dependencies": {
 				"boom": {
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
 					"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+					"dev": true,
 					"requires": {
-						"hoek": "4.2.1"
+						"hoek": "4.x.x"
 					}
 				}
 			}
@@ -1720,12 +1930,14 @@
 		"css-color-names": {
 			"version": "0.0.4",
 			"resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
-			"integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA="
+			"integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
+			"dev": true
 		},
 		"css-modules-loader-core": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/css-modules-loader-core/-/css-modules-loader-core-1.1.0.tgz",
 			"integrity": "sha1-WQhmgpShvs0mGuCkziGwtVHyHRY=",
+			"dev": true,
 			"requires": {
 				"icss-replace-symbols": "1.1.0",
 				"postcss": "6.0.1",
@@ -1738,61 +1950,69 @@
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					},
 					"dependencies": {
 						"supports-color": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+							"dev": true
 						}
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
 				},
 				"postcss": {
 					"version": "6.0.1",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.1.tgz",
 					"integrity": "sha1-AA29H47vIXqjaLmiEsX8QLKo8/I=",
+					"dev": true,
 					"requires": {
-						"chalk": "1.1.3",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
+						"chalk": "^1.1.3",
+						"source-map": "^0.5.6",
+						"supports-color": "^3.2.3"
 					}
 				},
 				"postcss-modules-extract-imports": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
 					"integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
+					"dev": true,
 					"requires": {
-						"postcss": "6.0.1"
+						"postcss": "^6.0.1"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -1801,129 +2021,141 @@
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
 			"integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
+			"dev": true,
 			"requires": {
-				"cssesc": "0.1.0",
-				"fastparse": "1.1.1",
-				"regexpu-core": "1.0.0"
+				"cssesc": "^0.1.0",
+				"fastparse": "^1.1.1",
+				"regexpu-core": "^1.0.0"
 			}
 		},
 		"cssesc": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
-			"integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q="
+			"integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
+			"dev": true
 		},
 		"cssnano": {
 			"version": "3.10.0",
 			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
 			"integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
+			"dev": true,
 			"requires": {
-				"autoprefixer": "6.7.7",
-				"decamelize": "1.2.0",
-				"defined": "1.0.0",
-				"has": "1.0.1",
-				"object-assign": "4.1.1",
-				"postcss": "5.2.18",
-				"postcss-calc": "5.3.1",
-				"postcss-colormin": "2.2.2",
-				"postcss-convert-values": "2.6.1",
-				"postcss-discard-comments": "2.0.4",
-				"postcss-discard-duplicates": "2.1.0",
-				"postcss-discard-empty": "2.1.0",
-				"postcss-discard-overridden": "0.1.1",
-				"postcss-discard-unused": "2.2.3",
-				"postcss-filter-plugins": "2.0.2",
-				"postcss-merge-idents": "2.1.7",
-				"postcss-merge-longhand": "2.0.2",
-				"postcss-merge-rules": "2.1.2",
-				"postcss-minify-font-values": "1.0.5",
-				"postcss-minify-gradients": "1.0.5",
-				"postcss-minify-params": "1.2.2",
-				"postcss-minify-selectors": "2.1.1",
-				"postcss-normalize-charset": "1.1.1",
-				"postcss-normalize-url": "3.0.8",
-				"postcss-ordered-values": "2.2.3",
-				"postcss-reduce-idents": "2.4.0",
-				"postcss-reduce-initial": "1.0.1",
-				"postcss-reduce-transforms": "1.0.4",
-				"postcss-svgo": "2.1.6",
-				"postcss-unique-selectors": "2.0.2",
-				"postcss-value-parser": "3.3.0",
-				"postcss-zindex": "2.2.0"
+				"autoprefixer": "^6.3.1",
+				"decamelize": "^1.1.2",
+				"defined": "^1.0.0",
+				"has": "^1.0.1",
+				"object-assign": "^4.0.1",
+				"postcss": "^5.0.14",
+				"postcss-calc": "^5.2.0",
+				"postcss-colormin": "^2.1.8",
+				"postcss-convert-values": "^2.3.4",
+				"postcss-discard-comments": "^2.0.4",
+				"postcss-discard-duplicates": "^2.0.1",
+				"postcss-discard-empty": "^2.0.1",
+				"postcss-discard-overridden": "^0.1.1",
+				"postcss-discard-unused": "^2.2.1",
+				"postcss-filter-plugins": "^2.0.0",
+				"postcss-merge-idents": "^2.1.5",
+				"postcss-merge-longhand": "^2.0.1",
+				"postcss-merge-rules": "^2.0.3",
+				"postcss-minify-font-values": "^1.0.2",
+				"postcss-minify-gradients": "^1.0.1",
+				"postcss-minify-params": "^1.0.4",
+				"postcss-minify-selectors": "^2.0.4",
+				"postcss-normalize-charset": "^1.1.0",
+				"postcss-normalize-url": "^3.0.7",
+				"postcss-ordered-values": "^2.1.0",
+				"postcss-reduce-idents": "^2.2.2",
+				"postcss-reduce-initial": "^1.0.0",
+				"postcss-reduce-transforms": "^1.0.3",
+				"postcss-svgo": "^2.1.1",
+				"postcss-unique-selectors": "^2.0.2",
+				"postcss-value-parser": "^3.2.3",
+				"postcss-zindex": "^2.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"autoprefixer": {
 					"version": "6.7.7",
 					"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
 					"integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
+					"dev": true,
 					"requires": {
-						"browserslist": "1.7.7",
-						"caniuse-db": "1.0.30000830",
-						"normalize-range": "0.1.2",
-						"num2fraction": "1.2.2",
-						"postcss": "5.2.18",
-						"postcss-value-parser": "3.3.0"
+						"browserslist": "^1.7.6",
+						"caniuse-db": "^1.0.30000634",
+						"normalize-range": "^0.1.2",
+						"num2fraction": "^1.2.2",
+						"postcss": "^5.2.16",
+						"postcss-value-parser": "^3.2.3"
 					}
 				},
 				"browserslist": {
 					"version": "1.7.7",
 					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
 					"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+					"dev": true,
 					"requires": {
-						"caniuse-db": "1.0.30000830",
-						"electron-to-chromium": "1.3.42"
+						"caniuse-db": "^1.0.30000639",
+						"electron-to-chromium": "^1.2.7"
 					}
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					},
 					"dependencies": {
 						"supports-color": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+							"dev": true
 						}
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
 				},
 				"postcss": {
 					"version": "5.2.18",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
 					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"dev": true,
 					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.3",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
+						"chalk": "^1.1.3",
+						"js-base64": "^2.1.9",
+						"source-map": "^0.5.6",
+						"supports-color": "^3.2.3"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -1932,59 +2164,67 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
 			"integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
+			"dev": true,
 			"requires": {
-				"clap": "1.2.3",
-				"source-map": "0.5.7"
+				"clap": "^1.0.9",
+				"source-map": "^0.5.3"
 			},
 			"dependencies": {
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				}
 			}
 		},
 		"cssom": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
-			"integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs="
+			"integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs=",
+			"dev": true
 		},
 		"cssstyle": {
 			"version": "0.2.37",
 			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
 			"integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+			"dev": true,
 			"requires": {
-				"cssom": "0.3.2"
+				"cssom": "0.3.x"
 			}
 		},
 		"currently-unhandled": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
 			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+			"dev": true,
 			"requires": {
-				"array-find-index": "1.0.2"
+				"array-find-index": "^1.0.1"
 			}
 		},
 		"dashdash": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"date-time": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/date-time/-/date-time-2.1.0.tgz",
 			"integrity": "sha512-/9+C44X7lot0IeiyfgJmETtRMhBidBYM2QFFIkGa0U1k+hSyY87Nw7PY3eDqpvCBm7I3WCSfPeZskW/YYq6m4g==",
+			"dev": true,
 			"requires": {
-				"time-zone": "1.0.0"
+				"time-zone": "^1.0.0"
 			}
 		},
 		"debug": {
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
 			}
@@ -1992,32 +2232,37 @@
 		"decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+			"dev": true
 		},
 		"decode-uri-component": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+			"dev": true
 		},
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"dev": true
 		},
 		"default-require-extensions": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
 			"integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+			"dev": true,
 			"requires": {
-				"strip-bom": "2.0.0"
+				"strip-bom": "^2.0.0"
 			},
 			"dependencies": {
 				"strip-bom": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
 					"requires": {
-						"is-utf8": "0.2.1"
+						"is-utf8": "^0.2.0"
 					}
 				}
 			}
@@ -2026,71 +2271,81 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
 			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+			"dev": true,
 			"requires": {
-				"is-descriptor": "1.0.2",
-				"isobject": "3.0.1"
+				"is-descriptor": "^1.0.2",
+				"isobject": "^3.0.1"
 			},
 			"dependencies": {
 				"is-accessor-descriptor": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-data-descriptor": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-descriptor": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
 					}
 				},
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
 				}
 			}
 		},
 		"defined": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-			"integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+			"integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+			"dev": true
 		},
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"dev": true
 		},
 		"delegates": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+			"dev": true
 		},
 		"detect-indent": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+			"dev": true,
 			"requires": {
-				"repeating": "2.0.1"
+				"repeating": "^2.0.0"
 			}
 		},
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+			"dev": true
 		},
 		"dom-helpers": {
 			"version": "3.3.1",
@@ -2101,133 +2356,150 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/dot-case/-/dot-case-2.1.1.tgz",
 			"integrity": "sha1-NNzzf1Co6TwrO8qLt/uRVcfaO+4=",
+			"dev": true,
 			"requires": {
-				"no-case": "2.3.2"
+				"no-case": "^2.2.0"
 			}
 		},
 		"ecc-jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
 			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+			"dev": true,
 			"optional": true,
 			"requires": {
-				"jsbn": "0.1.1"
+				"jsbn": "~0.1.0"
 			}
 		},
 		"electron-to-chromium": {
 			"version": "1.3.42",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.42.tgz",
-			"integrity": "sha1-lcM78B0MxAVVauyJn+Yf1NduoPk="
+			"integrity": "sha1-lcM78B0MxAVVauyJn+Yf1NduoPk=",
+			"dev": true
 		},
 		"emojis-list": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
+			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+			"dev": true
 		},
 		"encoding": {
 			"version": "0.1.12",
 			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
 			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
 			"requires": {
-				"iconv-lite": "0.4.21"
+				"iconv-lite": "~0.4.13"
 			}
 		},
 		"errno": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
 			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+			"dev": true,
 			"requires": {
-				"prr": "1.0.1"
+				"prr": "~1.0.1"
 			}
 		},
 		"error-ex": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
 			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+			"dev": true,
 			"requires": {
-				"is-arrayish": "0.2.1"
+				"is-arrayish": "^0.2.1"
 			}
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
 		},
 		"escodegen": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
 			"integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
+			"dev": true,
 			"requires": {
-				"esprima": "3.1.3",
-				"estraverse": "4.2.0",
-				"esutils": "2.0.2",
-				"optionator": "0.8.2",
-				"source-map": "0.6.1"
+				"esprima": "^3.1.3",
+				"estraverse": "^4.2.0",
+				"esutils": "^2.0.2",
+				"optionator": "^0.8.1",
+				"source-map": "~0.6.1"
 			},
 			"dependencies": {
 				"esprima": {
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+					"dev": true
 				}
 			}
 		},
 		"esprima": {
 			"version": "2.7.3",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-			"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+			"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+			"dev": true
 		},
 		"estraverse": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+			"dev": true
 		},
 		"estree-walker": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.3.1.tgz",
-			"integrity": "sha1-5rGlHPcpJSTnI3wxLl/mZgwc4ao="
+			"integrity": "sha1-5rGlHPcpJSTnI3wxLl/mZgwc4ao=",
+			"dev": true
 		},
 		"esutils": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"dev": true
 		},
 		"exec-sh": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
 			"integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
+			"dev": true,
 			"requires": {
-				"merge": "1.2.0"
+				"merge": "^1.1.3"
 			}
 		},
 		"expand-brackets": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
 			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+			"dev": true,
 			"requires": {
-				"debug": "2.6.9",
-				"define-property": "0.2.5",
-				"extend-shallow": "2.0.1",
-				"posix-character-classes": "0.1.1",
-				"regex-not": "1.0.2",
-				"snapdragon": "0.8.2",
-				"to-regex": "3.0.2"
+				"debug": "^2.3.3",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"posix-character-classes": "^0.1.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
 			},
 			"dependencies": {
 				"define-property": {
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
 					}
 				},
 				"extend-shallow": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
 					"requires": {
-						"is-extendable": "0.1.1"
+						"is-extendable": "^0.1.0"
 					}
 				}
 			}
@@ -2236,34 +2508,38 @@
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+			"dev": true,
 			"requires": {
-				"fill-range": "2.2.3"
+				"fill-range": "^2.1.0"
 			},
 			"dependencies": {
 				"fill-range": {
 					"version": "2.2.3",
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 					"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+					"dev": true,
 					"requires": {
-						"is-number": "2.1.0",
-						"isobject": "2.1.0",
-						"randomatic": "1.1.7",
-						"repeat-element": "1.1.2",
-						"repeat-string": "1.6.1"
+						"is-number": "^2.1.0",
+						"isobject": "^2.0.0",
+						"randomatic": "^1.1.3",
+						"repeat-element": "^1.1.2",
+						"repeat-string": "^1.5.2"
 					}
 				},
 				"is-number": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
 					"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"isobject": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 					"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+					"dev": true,
 					"requires": {
 						"isarray": "1.0.0"
 					}
@@ -2273,23 +2549,26 @@
 		"extend": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+			"dev": true
 		},
 		"extend-shallow": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
 			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+			"dev": true,
 			"requires": {
-				"assign-symbols": "1.0.0",
-				"is-extendable": "1.0.1"
+				"assign-symbols": "^1.0.0",
+				"is-extendable": "^1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"dev": true,
 					"requires": {
-						"is-plain-object": "2.0.4"
+						"is-plain-object": "^2.0.4"
 					}
 				}
 			}
@@ -2298,97 +2577,110 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
 			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+			"dev": true,
 			"requires": {
-				"array-unique": "0.3.2",
-				"define-property": "1.0.0",
-				"expand-brackets": "2.1.4",
-				"extend-shallow": "2.0.1",
-				"fragment-cache": "0.2.1",
-				"regex-not": "1.0.2",
-				"snapdragon": "0.8.2",
-				"to-regex": "3.0.2"
+				"array-unique": "^0.3.2",
+				"define-property": "^1.0.0",
+				"expand-brackets": "^2.1.4",
+				"extend-shallow": "^2.0.1",
+				"fragment-cache": "^0.2.1",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
 			},
 			"dependencies": {
 				"define-property": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
 					"requires": {
-						"is-descriptor": "1.0.2"
+						"is-descriptor": "^1.0.0"
 					}
 				},
 				"extend-shallow": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
 					"requires": {
-						"is-extendable": "0.1.1"
+						"is-extendable": "^0.1.0"
 					}
 				},
 				"is-accessor-descriptor": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-data-descriptor": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-descriptor": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
 					}
 				},
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
 				}
 			}
 		},
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"dev": true
 		},
 		"fast-deep-equal": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+			"dev": true
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+			"dev": true
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"dev": true
 		},
 		"fastparse": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
-			"integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg="
+			"integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg=",
+			"dev": true
 		},
 		"fb-watchman": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
 			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+			"dev": true,
 			"requires": {
-				"bser": "2.0.0"
+				"bser": "^2.0.0"
 			}
 		},
 		"fbjs": {
@@ -2396,46 +2688,50 @@
 			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
 			"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
 			"requires": {
-				"core-js": "1.2.7",
-				"isomorphic-fetch": "2.2.1",
-				"loose-envify": "1.3.1",
-				"object-assign": "4.1.1",
-				"promise": "7.3.1",
-				"setimmediate": "1.0.5",
-				"ua-parser-js": "0.7.17"
+				"core-js": "^1.0.0",
+				"isomorphic-fetch": "^2.1.1",
+				"loose-envify": "^1.0.0",
+				"object-assign": "^4.1.0",
+				"promise": "^7.1.1",
+				"setimmediate": "^1.0.5",
+				"ua-parser-js": "^0.7.9"
 			}
 		},
 		"filename-regex": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+			"dev": true
 		},
 		"fileset": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
 			"integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
+			"dev": true,
 			"requires": {
-				"glob": "7.1.2",
-				"minimatch": "3.0.4"
+				"glob": "^7.0.3",
+				"minimatch": "^3.0.3"
 			}
 		},
 		"fill-range": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
 			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+			"dev": true,
 			"requires": {
-				"extend-shallow": "2.0.1",
-				"is-number": "3.0.0",
-				"repeat-string": "1.6.1",
-				"to-regex-range": "2.1.1"
+				"extend-shallow": "^2.0.1",
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1",
+				"to-regex-range": "^2.1.0"
 			},
 			"dependencies": {
 				"extend-shallow": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
 					"requires": {
-						"is-extendable": "0.1.1"
+						"is-extendable": "^0.1.0"
 					}
 				}
 			}
@@ -2444,141 +2740,164 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+			"dev": true,
 			"requires": {
-				"locate-path": "2.0.0"
+				"locate-path": "^2.0.0"
 			}
 		},
 		"flatten": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
-			"integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I="
+			"integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
+			"dev": true
 		},
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+			"dev": true
 		},
 		"for-own": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"dev": true,
 			"requires": {
-				"for-in": "1.0.2"
+				"for-in": "^1.0.1"
 			}
 		},
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+			"dev": true
 		},
 		"form-data": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
 			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+			"dev": true,
 			"requires": {
-				"asynckit": "0.4.0",
+				"asynckit": "^0.4.0",
 				"combined-stream": "1.0.6",
-				"mime-types": "2.1.18"
+				"mime-types": "^2.1.12"
 			}
 		},
 		"fragment-cache": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
 			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+			"dev": true,
 			"requires": {
-				"map-cache": "0.2.2"
+				"map-cache": "^0.2.2"
 			}
 		},
 		"fs-extra": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
 			"integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
+			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"jsonfile": "3.0.1",
-				"universalify": "0.1.1"
+				"graceful-fs": "^4.1.2",
+				"jsonfile": "^3.0.0",
+				"universalify": "^0.1.0"
 			}
 		},
 		"fs-readdir-recursive": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
-			"integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA=="
+			"integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+			"dev": true
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
 		},
 		"fsevents": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.2.tgz",
 			"integrity": "sha512-iownA+hC4uHFp+7gwP/y5SzaiUo7m2vpa0dhpzw8YuKtiZsz7cIXsFbXpLEeBM6WuCQyw1MH4RRe6XI8GFUctQ==",
+			"dev": true,
 			"optional": true,
 			"requires": {
-				"nan": "2.10.0",
-				"node-pre-gyp": "0.9.1"
+				"nan": "^2.9.2",
+				"node-pre-gyp": "^0.9.0"
 			},
 			"dependencies": {
 				"abbrev": {
 					"version": "1.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.2.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
-						"delegates": "1.0.0",
-						"readable-stream": "2.3.6"
+						"delegates": "^1.0.0",
+						"readable-stream": "^2.0.6"
 					}
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
+					"dev": true,
 					"requires": {
-						"balanced-match": "1.0.0",
+						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
 				"chownr": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"debug": {
 					"version": "2.6.9",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -2587,140 +2906,160 @@
 				"deep-extend": {
 					"version": "0.4.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"delegates": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"detect-libc": {
 					"version": "1.0.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"fs-minipass": {
 					"version": "1.2.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
-						"minipass": "2.2.4"
+						"minipass": "^2.2.1"
 					}
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"gauge": {
 					"version": "2.7.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
-						"aproba": "1.2.0",
-						"console-control-strings": "1.1.0",
-						"has-unicode": "2.0.1",
-						"object-assign": "4.1.1",
-						"signal-exit": "3.0.2",
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wide-align": "1.1.2"
+						"aproba": "^1.0.3",
+						"console-control-strings": "^1.0.0",
+						"has-unicode": "^2.0.0",
+						"object-assign": "^4.1.0",
+						"signal-exit": "^3.0.0",
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wide-align": "^1.1.0"
 					}
 				},
 				"glob": {
 					"version": "7.1.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"has-unicode": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"iconv-lite": {
 					"version": "0.4.21",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
-						"safer-buffer": "2.1.2"
+						"safer-buffer": "^2.1.0"
 					}
 				},
 				"ignore-walk": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
-						"minimatch": "3.0.4"
+						"minimatch": "^3.0.4"
 					}
 				},
 				"inflight": {
 					"version": "1.0.6",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
-						"once": "1.4.0",
-						"wrappy": "1.0.2"
+						"once": "^1.3.0",
+						"wrappy": "1"
 					}
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"isarray": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
-						"brace-expansion": "1.1.11"
+						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
-						"safe-buffer": "5.1.1",
-						"yallist": "3.0.2"
+						"safe-buffer": "^5.1.1",
+						"yallist": "^3.0.0"
 					}
 				},
 				"minizlib": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
-						"minipass": "2.2.4"
+						"minipass": "^2.2.1"
 					}
 				},
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -2728,128 +3067,145 @@
 				"ms": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"needle": {
 					"version": "2.2.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
-						"debug": "2.6.9",
-						"iconv-lite": "0.4.21",
-						"sax": "1.2.4"
+						"debug": "^2.1.2",
+						"iconv-lite": "^0.4.4",
+						"sax": "^1.2.4"
 					}
 				},
 				"node-pre-gyp": {
 					"version": "0.9.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
-						"detect-libc": "1.0.3",
-						"mkdirp": "0.5.1",
-						"needle": "2.2.0",
-						"nopt": "4.0.1",
-						"npm-packlist": "1.1.10",
-						"npmlog": "4.1.2",
-						"rc": "1.2.6",
-						"rimraf": "2.6.2",
-						"semver": "5.5.0",
-						"tar": "4.4.1"
+						"detect-libc": "^1.0.2",
+						"mkdirp": "^0.5.1",
+						"needle": "^2.2.0",
+						"nopt": "^4.0.1",
+						"npm-packlist": "^1.1.6",
+						"npmlog": "^4.0.2",
+						"rc": "^1.1.7",
+						"rimraf": "^2.6.1",
+						"semver": "^5.3.0",
+						"tar": "^4"
 					}
 				},
 				"nopt": {
 					"version": "4.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
-						"abbrev": "1.1.1",
-						"osenv": "0.1.5"
+						"abbrev": "1",
+						"osenv": "^0.1.4"
 					}
 				},
 				"npm-bundled": {
 					"version": "1.0.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"npm-packlist": {
 					"version": "1.1.10",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
-						"ignore-walk": "3.0.1",
-						"npm-bundled": "1.0.3"
+						"ignore-walk": "^3.0.1",
+						"npm-bundled": "^1.0.1"
 					}
 				},
 				"npmlog": {
 					"version": "4.1.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
-						"are-we-there-yet": "1.1.4",
-						"console-control-strings": "1.1.0",
-						"gauge": "2.7.4",
-						"set-blocking": "2.0.0"
+						"are-we-there-yet": "~1.1.2",
+						"console-control-strings": "~1.1.0",
+						"gauge": "~2.7.3",
+						"set-blocking": "~2.0.0"
 					}
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
-						"wrappy": "1.0.2"
+						"wrappy": "1"
 					}
 				},
 				"os-homedir": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
-						"os-homedir": "1.0.2",
-						"os-tmpdir": "1.0.2"
+						"os-homedir": "^1.0.0",
+						"os-tmpdir": "^1.0.0"
 					}
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"rc": {
 					"version": "1.2.6",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
-						"deep-extend": "0.4.2",
-						"ini": "1.3.5",
-						"minimist": "1.2.0",
-						"strip-json-comments": "2.0.1"
+						"deep-extend": "~0.4.0",
+						"ini": "~1.3.0",
+						"minimist": "^1.2.0",
+						"strip-json-comments": "~2.0.1"
 					},
 					"dependencies": {
 						"minimist": {
 							"version": "1.2.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -2857,117 +3213,134 @@
 				"readable-stream": {
 					"version": "2.3.6",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "1.0.0",
-						"process-nextick-args": "2.0.0",
-						"safe-buffer": "5.1.1",
-						"string_decoder": "1.1.1",
-						"util-deprecate": "1.0.2"
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
 					}
 				},
 				"rimraf": {
 					"version": "2.6.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
-						"glob": "7.1.2"
+						"glob": "^7.0.5"
 					}
 				},
 				"safe-buffer": {
 					"version": "5.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"sax": {
 					"version": "1.2.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"semver": {
 					"version": "5.5.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				},
 				"string_decoder": {
 					"version": "1.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
-						"safe-buffer": "5.1.1"
+						"safe-buffer": "~5.1.0"
 					}
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"strip-json-comments": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"tar": {
 					"version": "4.4.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
-						"chownr": "1.0.1",
-						"fs-minipass": "1.2.5",
-						"minipass": "2.2.4",
-						"minizlib": "1.1.0",
-						"mkdirp": "0.5.1",
-						"safe-buffer": "5.1.1",
-						"yallist": "3.0.2"
+						"chownr": "^1.0.1",
+						"fs-minipass": "^1.2.5",
+						"minipass": "^2.2.4",
+						"minizlib": "^1.1.0",
+						"mkdirp": "^0.5.0",
+						"safe-buffer": "^5.1.1",
+						"yallist": "^3.0.2"
 					}
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"wide-align": {
 					"version": "1.1.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
-						"string-width": "1.0.2"
+						"string-width": "^1.0.2"
 					}
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"yallist": {
 					"version": "3.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				}
 			}
 		},
@@ -2975,71 +3348,79 @@
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
 			"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"inherits": "2.0.3",
-				"mkdirp": "0.5.1",
-				"rimraf": "2.6.2"
+				"graceful-fs": "^4.1.2",
+				"inherits": "~2.0.0",
+				"mkdirp": ">=0.5 0",
+				"rimraf": "2"
 			}
 		},
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
 		},
 		"gauge": {
 			"version": "2.7.4",
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+			"dev": true,
 			"requires": {
-				"aproba": "1.2.0",
-				"console-control-strings": "1.1.0",
-				"has-unicode": "2.0.1",
-				"object-assign": "4.1.1",
-				"signal-exit": "3.0.2",
-				"string-width": "1.0.2",
-				"strip-ansi": "3.0.1",
-				"wide-align": "1.1.2"
+				"aproba": "^1.0.3",
+				"console-control-strings": "^1.0.0",
+				"has-unicode": "^2.0.0",
+				"object-assign": "^4.1.0",
+				"signal-exit": "^3.0.0",
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1",
+				"wide-align": "^1.1.0"
 			}
 		},
 		"gaze": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
 			"integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
+			"dev": true,
 			"requires": {
-				"globule": "1.2.0"
+				"globule": "^1.0.0"
 			}
 		},
 		"generate-function": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-			"integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
+			"integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+			"dev": true
 		},
 		"generate-object-property": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
 			"integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+			"dev": true,
 			"requires": {
-				"is-property": "1.0.2"
+				"is-property": "^1.0.0"
 			}
 		},
 		"generic-names": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/generic-names/-/generic-names-1.0.3.tgz",
 			"integrity": "sha1-LXhqEhruUIh2eWk56OO/+DbCCRc=",
+			"dev": true,
 			"requires": {
-				"loader-utils": "0.2.17"
+				"loader-utils": "^0.2.16"
 			},
 			"dependencies": {
 				"loader-utils": {
 					"version": "0.2.17",
 					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
 					"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+					"dev": true,
 					"requires": {
-						"big.js": "3.2.0",
-						"emojis-list": "2.1.0",
-						"json5": "0.5.1",
-						"object-assign": "4.1.1"
+						"big.js": "^3.1.3",
+						"emojis-list": "^2.0.0",
+						"json5": "^0.5.0",
+						"object-assign": "^4.0.1"
 					}
 				}
 			}
@@ -3047,67 +3428,76 @@
 		"get-caller-file": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+			"dev": true
 		},
 		"get-stdin": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-			"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+			"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+			"dev": true
 		},
 		"get-value": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+			"dev": true
 		},
 		"getpass": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"glob": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"dev": true,
 			"requires": {
-				"fs.realpath": "1.0.0",
-				"inflight": "1.0.6",
-				"inherits": "2.0.3",
-				"minimatch": "3.0.4",
-				"once": "1.4.0",
-				"path-is-absolute": "1.0.1"
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
 			}
 		},
 		"glob-base": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+			"dev": true,
 			"requires": {
-				"glob-parent": "2.0.0",
-				"is-glob": "2.0.1"
+				"glob-parent": "^2.0.0",
+				"is-glob": "^2.0.0"
 			},
 			"dependencies": {
 				"glob-parent": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+					"dev": true,
 					"requires": {
-						"is-glob": "2.0.1"
+						"is-glob": "^2.0.0"
 					}
 				},
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
 					"requires": {
-						"is-extglob": "1.0.0"
+						"is-extglob": "^1.0.0"
 					}
 				}
 			}
@@ -3115,50 +3505,57 @@
 		"globals": {
 			"version": "9.18.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+			"dev": true
 		},
 		"globule": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
 			"integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
+			"dev": true,
 			"requires": {
-				"glob": "7.1.2",
-				"lodash": "4.17.10",
-				"minimatch": "3.0.4"
+				"glob": "~7.1.1",
+				"lodash": "~4.17.4",
+				"minimatch": "~3.0.2"
 			}
 		},
 		"graceful-fs": {
 			"version": "4.1.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+			"dev": true
 		},
 		"growly": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
+			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+			"dev": true
 		},
 		"handlebars": {
 			"version": "4.0.11",
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
 			"integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+			"dev": true,
 			"requires": {
-				"async": "1.5.2",
-				"optimist": "0.6.1",
-				"source-map": "0.4.4",
-				"uglify-js": "2.8.29"
+				"async": "^1.4.0",
+				"optimist": "^0.6.1",
+				"source-map": "^0.4.4",
+				"uglify-js": "^2.6"
 			},
 			"dependencies": {
 				"async": {
 					"version": "1.5.2",
 					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+					"dev": true
 				},
 				"source-map": {
 					"version": "0.4.4",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
 					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+					"dev": true,
 					"requires": {
-						"amdefine": "1.0.1"
+						"amdefine": ">=0.0.4"
 					}
 				}
 			}
@@ -3166,26 +3563,29 @@
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+			"dev": true
 		},
 		"har-validator": {
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
 			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+			"dev": true,
 			"requires": {
-				"ajv": "5.5.2",
-				"har-schema": "2.0.0"
+				"ajv": "^5.1.0",
+				"har-schema": "^2.0.0"
 			},
 			"dependencies": {
 				"ajv": {
 					"version": "5.5.2",
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
 					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+					"dev": true,
 					"requires": {
-						"co": "4.6.0",
-						"fast-deep-equal": "1.1.0",
-						"fast-json-stable-stringify": "2.0.0",
-						"json-schema-traverse": "0.3.1"
+						"co": "^4.6.0",
+						"fast-deep-equal": "^1.0.0",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.3.0"
 					}
 				}
 			}
@@ -3194,53 +3594,60 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
 			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+			"dev": true,
 			"requires": {
-				"function-bind": "1.1.1"
+				"function-bind": "^1.0.2"
 			}
 		},
 		"has-ansi": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"dev": true,
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
 		},
 		"has-unicode": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+			"dev": true
 		},
 		"has-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
 			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+			"dev": true,
 			"requires": {
-				"get-value": "2.0.6",
-				"has-values": "1.0.0",
-				"isobject": "3.0.1"
+				"get-value": "^2.0.6",
+				"has-values": "^1.0.0",
+				"isobject": "^3.0.0"
 			}
 		},
 		"has-values": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
 			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+			"dev": true,
 			"requires": {
-				"is-number": "3.0.0",
-				"kind-of": "4.0.0"
+				"is-number": "^3.0.0",
+				"kind-of": "^4.0.0"
 			},
 			"dependencies": {
 				"kind-of": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"dev": true,
 					"requires": {
-						"is-buffer": "1.1.6"
+						"is-buffer": "^1.1.5"
 					}
 				}
 			}
@@ -3248,68 +3655,77 @@
 		"hash-sum": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
-			"integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ="
+			"integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
+			"dev": true
 		},
 		"hawk": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
 			"integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+			"dev": true,
 			"requires": {
-				"boom": "4.3.1",
-				"cryptiles": "3.1.2",
-				"hoek": "4.2.1",
-				"sntp": "2.1.0"
+				"boom": "4.x.x",
+				"cryptiles": "3.x.x",
+				"hoek": "4.x.x",
+				"sntp": "2.x.x"
 			}
 		},
 		"header-case": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/header-case/-/header-case-1.0.1.tgz",
 			"integrity": "sha1-lTWXMZfBRLCWE81l0xfvGZY70C0=",
+			"dev": true,
 			"requires": {
-				"no-case": "2.3.2",
-				"upper-case": "1.1.3"
+				"no-case": "^2.2.0",
+				"upper-case": "^1.1.3"
 			}
 		},
 		"hoek": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-			"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+			"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
+			"dev": true
 		},
 		"home-or-tmp": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+			"dev": true,
 			"requires": {
-				"os-homedir": "1.0.2",
-				"os-tmpdir": "1.0.2"
+				"os-homedir": "^1.0.0",
+				"os-tmpdir": "^1.0.1"
 			}
 		},
 		"hosted-git-info": {
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
-			"integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
+			"integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
+			"dev": true
 		},
 		"html-comment-regex": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz",
-			"integrity": "sha1-ZouTd26q5V696POtRkswekljYl4="
+			"integrity": "sha1-ZouTd26q5V696POtRkswekljYl4=",
+			"dev": true
 		},
 		"html-encoding-sniffer": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
 			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+			"dev": true,
 			"requires": {
-				"whatwg-encoding": "1.0.3"
+				"whatwg-encoding": "^1.0.1"
 			}
 		},
 		"http-signature": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0",
-				"jsprim": "1.4.1",
-				"sshpk": "1.14.1"
+				"assert-plus": "^1.0.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
 			}
 		},
 		"iconv-lite": {
@@ -3317,286 +3733,328 @@
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
 			"integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
 			"requires": {
-				"safer-buffer": "2.1.2"
+				"safer-buffer": "^2.1.0"
 			}
 		},
 		"icss-replace-symbols": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
-			"integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0="
+			"integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
+			"dev": true
 		},
 		"import-cwd": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
 			"integrity": "sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=",
+			"dev": true,
 			"requires": {
-				"import-from": "2.1.0"
+				"import-from": "^2.1.0"
 			}
 		},
 		"import-from": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/import-from/-/import-from-2.1.0.tgz",
 			"integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
+			"dev": true,
 			"requires": {
-				"resolve-from": "3.0.0"
+				"resolve-from": "^3.0.0"
 			},
 			"dependencies": {
 				"resolve-from": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+					"dev": true
 				}
 			}
 		},
 		"in-publish": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
-			"integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E="
+			"integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
+			"dev": true
 		},
 		"incstr": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/incstr/-/incstr-1.2.3.tgz",
-			"integrity": "sha512-ySi29Lzdc3QnB1LzZgRf5kl59m5tPucNagrAyJJ9rWz4+Pa6IxAHSNyUHYvEvaj6QPwWAY2/thi3Rxt45qi3HQ=="
+			"integrity": "sha512-ySi29Lzdc3QnB1LzZgRf5kl59m5tPucNagrAyJJ9rWz4+Pa6IxAHSNyUHYvEvaj6QPwWAY2/thi3Rxt45qi3HQ==",
+			"dev": true
 		},
 		"indexes-of": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
-			"integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
+			"integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
+			"dev": true
 		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
 			"requires": {
-				"once": "1.4.0",
-				"wrappy": "1.0.2"
+				"once": "^1.3.0",
+				"wrappy": "1"
 			}
 		},
 		"inherits": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"dev": true
 		},
 		"invariant": {
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
 			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+			"dev": true,
 			"requires": {
-				"loose-envify": "1.3.1"
+				"loose-envify": "^1.0.0"
 			}
 		},
 		"invert-kv": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+			"dev": true
 		},
 		"irregular-plurals": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
-			"integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y="
+			"integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y=",
+			"dev": true
 		},
 		"is-absolute-url": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
-			"integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY="
+			"integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY=",
+			"dev": true
 		},
 		"is-accessor-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.0.2"
 			}
 		},
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+			"dev": true
 		},
 		"is-binary-path": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+			"dev": true,
 			"optional": true,
 			"requires": {
-				"binary-extensions": "1.11.0"
+				"binary-extensions": "^1.0.0"
 			}
 		},
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+			"dev": true
 		},
 		"is-builtin-module": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+			"dev": true,
 			"requires": {
-				"builtin-modules": "1.1.1"
+				"builtin-modules": "^1.0.0"
 			}
 		},
 		"is-ci": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
 			"integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+			"dev": true,
 			"requires": {
-				"ci-info": "1.1.3"
+				"ci-info": "^1.0.0"
 			}
 		},
 		"is-data-descriptor": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.0.2"
 			}
 		},
 		"is-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+			"dev": true,
 			"requires": {
-				"is-accessor-descriptor": "0.1.6",
-				"is-data-descriptor": "0.1.4",
-				"kind-of": "5.1.0"
+				"is-accessor-descriptor": "^0.1.6",
+				"is-data-descriptor": "^0.1.4",
+				"kind-of": "^5.0.0"
 			},
 			"dependencies": {
 				"kind-of": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+					"dev": true
 				}
 			}
 		},
 		"is-directory": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
-			"integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
+			"integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+			"dev": true
 		},
 		"is-dotfile": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+			"dev": true
 		},
 		"is-equal-shallow": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+			"dev": true,
 			"requires": {
-				"is-primitive": "2.0.0"
+				"is-primitive": "^2.0.0"
 			}
 		},
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"dev": true
 		},
 		"is-finite": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+			"dev": true,
 			"requires": {
-				"number-is-nan": "1.0.1"
+				"number-is-nan": "^1.0.0"
 			}
 		},
 		"is-fullwidth-code-point": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+			"dev": true,
 			"requires": {
-				"number-is-nan": "1.0.1"
+				"number-is-nan": "^1.0.0"
 			}
 		},
 		"is-lower-case": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz",
 			"integrity": "sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=",
+			"dev": true,
 			"requires": {
-				"lower-case": "1.1.4"
+				"lower-case": "^1.1.0"
 			}
 		},
 		"is-module": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
-			"integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE="
+			"integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+			"dev": true
 		},
 		"is-my-ip-valid": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-			"integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ=="
+			"integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+			"dev": true
 		},
 		"is-my-json-valid": {
 			"version": "2.17.2",
 			"resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
 			"integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
+			"dev": true,
 			"requires": {
-				"generate-function": "2.0.0",
-				"generate-object-property": "1.2.0",
-				"is-my-ip-valid": "1.0.0",
-				"jsonpointer": "4.0.1",
-				"xtend": "4.0.1"
+				"generate-function": "^2.0.0",
+				"generate-object-property": "^1.1.0",
+				"is-my-ip-valid": "^1.0.0",
+				"jsonpointer": "^4.0.0",
+				"xtend": "^4.0.0"
 			}
 		},
 		"is-number": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.0.2"
 			}
 		},
 		"is-obj": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+			"dev": true
 		},
 		"is-odd": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
 			"integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
+			"dev": true,
 			"requires": {
-				"is-number": "4.0.0"
+				"is-number": "^4.0.0"
 			},
 			"dependencies": {
 				"is-number": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+					"dev": true
 				}
 			}
 		},
 		"is-plain-obj": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+			"dev": true
 		},
 		"is-plain-object": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"dev": true,
 			"requires": {
-				"isobject": "3.0.1"
+				"isobject": "^3.0.1"
 			}
 		},
 		"is-posix-bracket": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+			"dev": true
 		},
 		"is-primitive": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+			"dev": true
 		},
 		"is-property": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-			"integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+			"integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+			"dev": true
 		},
 		"is-reference": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.1.0.tgz",
 			"integrity": "sha512-h37O/IX4efe56o9k41II1ECMqKwtqHa7/12dLDEzJIFux2x15an4WCDb0/eKdmUgRpLJ3bR0DrzDc7vOrVgRDw==",
+			"dev": true,
 			"requires": {
 				"@types/estree": "0.0.38"
 			},
@@ -3604,7 +4062,8 @@
 				"@types/estree": {
 					"version": "0.0.38",
 					"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.38.tgz",
-					"integrity": "sha512-F/v7t1LwS4vnXuPooJQGBRKRGIoxWUTmA4VHfqjOccFsNDThD5bfUNpITive6s352O7o384wcpEaDV8rHCehDA=="
+					"integrity": "sha512-F/v7t1LwS4vnXuPooJQGBRKRGIoxWUTmA4VHfqjOccFsNDThD5bfUNpITive6s352O7o384wcpEaDV8rHCehDA==",
+					"dev": true
 				}
 			}
 		},
@@ -3617,85 +4076,96 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
 			"integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
+			"dev": true,
 			"requires": {
-				"html-comment-regex": "1.1.1"
+				"html-comment-regex": "^1.1.0"
 			}
 		},
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"dev": true
 		},
 		"is-upper-case": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz",
 			"integrity": "sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=",
+			"dev": true,
 			"requires": {
-				"upper-case": "1.1.3"
+				"upper-case": "^1.1.0"
 			}
 		},
 		"is-utf8": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+			"dev": true
 		},
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+			"dev": true
 		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
 		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
 		},
 		"isobject": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+			"dev": true
 		},
 		"isomorphic-fetch": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
 			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
 			"requires": {
-				"node-fetch": "1.7.3",
-				"whatwg-fetch": "2.0.4"
+				"node-fetch": "^1.0.1",
+				"whatwg-fetch": ">=0.10.0"
 			}
 		},
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+			"dev": true
 		},
 		"istanbul-api": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.3.1.tgz",
 			"integrity": "sha512-duj6AlLcsWNwUpfyfHt0nWIeRiZpuShnP40YTxOGQgtaN8fd6JYSxsvxUphTDy8V5MfDXo4s/xVCIIvVCO808g==",
+			"dev": true,
 			"requires": {
-				"async": "2.6.0",
-				"compare-versions": "3.1.0",
-				"fileset": "2.0.3",
-				"istanbul-lib-coverage": "1.2.0",
-				"istanbul-lib-hook": "1.2.0",
-				"istanbul-lib-instrument": "1.10.1",
-				"istanbul-lib-report": "1.1.4",
-				"istanbul-lib-source-maps": "1.2.4",
-				"istanbul-reports": "1.3.0",
-				"js-yaml": "3.7.0",
-				"mkdirp": "0.5.1",
-				"once": "1.4.0"
+				"async": "^2.1.4",
+				"compare-versions": "^3.1.0",
+				"fileset": "^2.0.2",
+				"istanbul-lib-coverage": "^1.2.0",
+				"istanbul-lib-hook": "^1.2.0",
+				"istanbul-lib-instrument": "^1.10.1",
+				"istanbul-lib-report": "^1.1.4",
+				"istanbul-lib-source-maps": "^1.2.4",
+				"istanbul-reports": "^1.3.0",
+				"js-yaml": "^3.7.0",
+				"mkdirp": "^0.5.1",
+				"once": "^1.4.0"
 			},
 			"dependencies": {
 				"debug": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -3704,52 +4174,58 @@
 					"version": "1.2.4",
 					"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.4.tgz",
 					"integrity": "sha512-UzuK0g1wyQijiaYQxj/CdNycFhAd2TLtO2obKQMTZrZ1jzEMRY3rvpASEKkaxbRR6brvdovfA03znPa/pXcejg==",
+					"dev": true,
 					"requires": {
-						"debug": "3.1.0",
-						"istanbul-lib-coverage": "1.2.0",
-						"mkdirp": "0.5.1",
-						"rimraf": "2.6.2",
-						"source-map": "0.5.7"
+						"debug": "^3.1.0",
+						"istanbul-lib-coverage": "^1.2.0",
+						"mkdirp": "^0.5.1",
+						"rimraf": "^2.6.1",
+						"source-map": "^0.5.3"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				}
 			}
 		},
 		"istanbul-lib-coverage": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz",
-			"integrity": "sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A=="
+			"integrity": "sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A==",
+			"dev": true
 		},
 		"istanbul-lib-hook": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.0.tgz",
 			"integrity": "sha512-p3En6/oGkFQV55Up8ZPC2oLxvgSxD8CzA0yBrhRZSh3pfv3OFj9aSGVC0yoerAi/O4u7jUVnOGVX1eVFM+0tmQ==",
+			"dev": true,
 			"requires": {
-				"append-transform": "0.4.0"
+				"append-transform": "^0.4.0"
 			}
 		},
 		"istanbul-lib-instrument": {
 			"version": "1.10.1",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz",
 			"integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
+			"dev": true,
 			"requires": {
-				"babel-generator": "6.26.1",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"istanbul-lib-coverage": "1.2.0",
-				"semver": "5.5.0"
+				"babel-generator": "^6.18.0",
+				"babel-template": "^6.16.0",
+				"babel-traverse": "^6.18.0",
+				"babel-types": "^6.18.0",
+				"babylon": "^6.18.0",
+				"istanbul-lib-coverage": "^1.2.0",
+				"semver": "^5.3.0"
 			},
 			"dependencies": {
 				"babylon": {
 					"version": "6.18.0",
 					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-					"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+					"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+					"dev": true
 				}
 			}
 		},
@@ -3757,24 +4233,27 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.4.tgz",
 			"integrity": "sha512-Azqvq5tT0U09nrncK3q82e/Zjkxa4tkFZv7E6VcqP0QCPn6oNljDPfrZEC/umNXds2t7b8sRJfs6Kmpzt8m2kA==",
+			"dev": true,
 			"requires": {
-				"istanbul-lib-coverage": "1.2.0",
-				"mkdirp": "0.5.1",
-				"path-parse": "1.0.5",
-				"supports-color": "3.2.3"
+				"istanbul-lib-coverage": "^1.2.0",
+				"mkdirp": "^0.5.1",
+				"path-parse": "^1.0.5",
+				"supports-color": "^3.1.2"
 			},
 			"dependencies": {
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -3783,18 +4262,20 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz",
 			"integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
+			"dev": true,
 			"requires": {
-				"debug": "3.1.0",
-				"istanbul-lib-coverage": "1.2.0",
-				"mkdirp": "0.5.1",
-				"rimraf": "2.6.2",
-				"source-map": "0.5.7"
+				"debug": "^3.1.0",
+				"istanbul-lib-coverage": "^1.1.2",
+				"mkdirp": "^0.5.1",
+				"rimraf": "^2.6.1",
+				"source-map": "^0.5.3"
 			},
 			"dependencies": {
 				"debug": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -3802,7 +4283,8 @@
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				}
 			}
 		},
@@ -3810,279 +4292,308 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.3.0.tgz",
 			"integrity": "sha512-y2Z2IMqE1gefWUaVjrBm0mSKvUkaBy9Vqz8iwr/r40Y9hBbIteH5wqHG/9DLTfJ9xUnUT2j7A3+VVJ6EaYBllA==",
+			"dev": true,
 			"requires": {
-				"handlebars": "4.0.11"
+				"handlebars": "^4.0.3"
 			}
 		},
 		"jest": {
 			"version": "20.0.4",
 			"resolved": "https://registry.npmjs.org/jest/-/jest-20.0.4.tgz",
 			"integrity": "sha1-PdJgwpidba1nix6cxNkZRPbWAqw=",
+			"dev": true,
 			"requires": {
-				"jest-cli": "20.0.4"
+				"jest-cli": "^20.0.4"
 			},
 			"dependencies": {
 				"ansi-escapes": {
 					"version": "1.4.0",
 					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-					"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+					"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+					"dev": true
 				},
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"arr-diff": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+					"dev": true,
 					"requires": {
-						"arr-flatten": "1.1.0"
+						"arr-flatten": "^1.0.1"
 					}
 				},
 				"array-unique": {
 					"version": "0.2.1",
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+					"dev": true
 				},
 				"braces": {
 					"version": "1.8.5",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+					"dev": true,
 					"requires": {
-						"expand-range": "1.8.2",
-						"preserve": "0.2.0",
-						"repeat-element": "1.1.2"
+						"expand-range": "^1.8.1",
+						"preserve": "^0.2.0",
+						"repeat-element": "^1.1.2"
 					}
 				},
 				"callsites": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
+					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+					"dev": true
 				},
 				"camelcase": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					}
 				},
 				"cliui": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"dev": true,
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wrap-ansi": "2.1.0"
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wrap-ansi": "^2.0.0"
 					}
 				},
 				"expand-brackets": {
 					"version": "0.1.5",
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+					"dev": true,
 					"requires": {
-						"is-posix-bracket": "0.1.1"
+						"is-posix-bracket": "^0.1.0"
 					}
 				},
 				"extglob": {
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+					"dev": true,
 					"requires": {
-						"is-extglob": "1.0.0"
+						"is-extglob": "^1.0.0"
 					}
 				},
 				"find-up": {
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"dev": true,
 					"requires": {
-						"path-exists": "2.1.0",
-						"pinkie-promise": "2.0.1"
+						"path-exists": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
 					"requires": {
-						"is-extglob": "1.0.0"
+						"is-extglob": "^1.0.0"
 					}
 				},
 				"jest-cli": {
 					"version": "20.0.4",
 					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-20.0.4.tgz",
 					"integrity": "sha1-5TKxnYiuW8bEF+iwWTpv6VSx3JM=",
+					"dev": true,
 					"requires": {
-						"ansi-escapes": "1.4.0",
-						"callsites": "2.0.0",
-						"chalk": "1.1.3",
-						"graceful-fs": "4.1.11",
-						"is-ci": "1.1.0",
-						"istanbul-api": "1.3.1",
-						"istanbul-lib-coverage": "1.2.0",
-						"istanbul-lib-instrument": "1.10.1",
-						"istanbul-lib-source-maps": "1.2.3",
-						"jest-changed-files": "20.0.3",
-						"jest-config": "20.0.4",
-						"jest-docblock": "20.0.3",
-						"jest-environment-jsdom": "20.0.3",
-						"jest-haste-map": "20.0.5",
-						"jest-jasmine2": "20.0.4",
-						"jest-message-util": "20.0.3",
-						"jest-regex-util": "20.0.3",
-						"jest-resolve-dependencies": "20.0.3",
-						"jest-runtime": "20.0.4",
-						"jest-snapshot": "20.0.3",
-						"jest-util": "20.0.3",
-						"micromatch": "2.3.11",
-						"node-notifier": "5.2.1",
-						"pify": "2.3.0",
-						"slash": "1.0.0",
-						"string-length": "1.0.1",
-						"throat": "3.2.0",
-						"which": "1.3.0",
-						"worker-farm": "1.6.0",
-						"yargs": "7.1.0"
+						"ansi-escapes": "^1.4.0",
+						"callsites": "^2.0.0",
+						"chalk": "^1.1.3",
+						"graceful-fs": "^4.1.11",
+						"is-ci": "^1.0.10",
+						"istanbul-api": "^1.1.1",
+						"istanbul-lib-coverage": "^1.0.1",
+						"istanbul-lib-instrument": "^1.4.2",
+						"istanbul-lib-source-maps": "^1.1.0",
+						"jest-changed-files": "^20.0.3",
+						"jest-config": "^20.0.4",
+						"jest-docblock": "^20.0.3",
+						"jest-environment-jsdom": "^20.0.3",
+						"jest-haste-map": "^20.0.4",
+						"jest-jasmine2": "^20.0.4",
+						"jest-message-util": "^20.0.3",
+						"jest-regex-util": "^20.0.3",
+						"jest-resolve-dependencies": "^20.0.3",
+						"jest-runtime": "^20.0.4",
+						"jest-snapshot": "^20.0.3",
+						"jest-util": "^20.0.3",
+						"micromatch": "^2.3.11",
+						"node-notifier": "^5.0.2",
+						"pify": "^2.3.0",
+						"slash": "^1.0.0",
+						"string-length": "^1.0.1",
+						"throat": "^3.0.0",
+						"which": "^1.2.12",
+						"worker-farm": "^1.3.1",
+						"yargs": "^7.0.2"
 					}
 				},
 				"load-json-file": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
 					}
 				},
 				"micromatch": {
 					"version": "2.3.11",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+					"dev": true,
 					"requires": {
-						"arr-diff": "2.0.0",
-						"array-unique": "0.2.1",
-						"braces": "1.8.5",
-						"expand-brackets": "0.1.5",
-						"extglob": "0.3.2",
-						"filename-regex": "2.0.1",
-						"is-extglob": "1.0.0",
-						"is-glob": "2.0.1",
-						"kind-of": "3.2.2",
-						"normalize-path": "2.1.1",
-						"object.omit": "2.0.1",
-						"parse-glob": "3.0.4",
-						"regex-cache": "0.4.4"
+						"arr-diff": "^2.0.0",
+						"array-unique": "^0.2.1",
+						"braces": "^1.8.2",
+						"expand-brackets": "^0.1.4",
+						"extglob": "^0.3.1",
+						"filename-regex": "^2.0.0",
+						"is-extglob": "^1.0.0",
+						"is-glob": "^2.0.1",
+						"kind-of": "^3.0.2",
+						"normalize-path": "^2.0.1",
+						"object.omit": "^2.0.0",
+						"parse-glob": "^3.0.4",
+						"regex-cache": "^0.4.2"
 					}
 				},
 				"os-locale": {
 					"version": "1.4.0",
 					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+					"dev": true,
 					"requires": {
-						"lcid": "1.0.0"
+						"lcid": "^1.0.0"
 					}
 				},
 				"path-exists": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"dev": true,
 					"requires": {
-						"pinkie-promise": "2.0.1"
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"path-type": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"read-pkg": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+					"dev": true,
 					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
 					}
 				},
 				"read-pkg-up": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+					"dev": true,
 					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
 					}
 				},
 				"strip-bom": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
 					"requires": {
-						"is-utf8": "0.2.1"
+						"is-utf8": "^0.2.0"
 					}
 				},
 				"supports-color": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
 				},
 				"which-module": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+					"dev": true
 				},
 				"yargs": {
 					"version": "7.1.0",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
 					"integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+					"dev": true,
 					"requires": {
-						"camelcase": "3.0.0",
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "1.4.0",
-						"read-pkg-up": "1.0.1",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "1.0.2",
-						"which-module": "1.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "5.0.0"
+						"camelcase": "^3.0.0",
+						"cliui": "^3.2.0",
+						"decamelize": "^1.1.1",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^1.4.0",
+						"read-pkg-up": "^1.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^1.0.2",
+						"which-module": "^1.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^5.0.0"
 					}
 				},
 				"yargs-parser": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
 					"integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+					"dev": true,
 					"requires": {
-						"camelcase": "3.0.0"
+						"camelcase": "^3.0.0"
 					}
 				}
 			}
@@ -4090,46 +4601,51 @@
 		"jest-changed-files": {
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-20.0.3.tgz",
-			"integrity": "sha1-k5TVzGXEOEBhSb7xv01Sto4D4/g="
+			"integrity": "sha1-k5TVzGXEOEBhSb7xv01Sto4D4/g=",
+			"dev": true
 		},
 		"jest-config": {
 			"version": "20.0.4",
 			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-20.0.4.tgz",
 			"integrity": "sha1-43kwqyIXyRNgXv8T5712PsSPruo=",
+			"dev": true,
 			"requires": {
-				"chalk": "1.1.3",
-				"glob": "7.1.2",
-				"jest-environment-jsdom": "20.0.3",
-				"jest-environment-node": "20.0.3",
-				"jest-jasmine2": "20.0.4",
-				"jest-matcher-utils": "20.0.3",
-				"jest-regex-util": "20.0.3",
-				"jest-resolve": "20.0.4",
-				"jest-validate": "20.0.3",
-				"pretty-format": "20.0.3"
+				"chalk": "^1.1.3",
+				"glob": "^7.1.1",
+				"jest-environment-jsdom": "^20.0.3",
+				"jest-environment-node": "^20.0.3",
+				"jest-jasmine2": "^20.0.4",
+				"jest-matcher-utils": "^20.0.3",
+				"jest-regex-util": "^20.0.3",
+				"jest-resolve": "^20.0.4",
+				"jest-validate": "^20.0.3",
+				"pretty-format": "^20.0.3"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					}
 				},
 				"supports-color": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
 				}
 			}
 		},
@@ -4137,144 +4653,160 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-20.0.3.tgz",
 			"integrity": "sha1-gfKI/Z5nXw+yPHXxwrGURf5YZhc=",
+			"dev": true,
 			"requires": {
-				"chalk": "1.1.3",
-				"diff": "3.5.0",
-				"jest-matcher-utils": "20.0.3",
-				"pretty-format": "20.0.3"
+				"chalk": "^1.1.3",
+				"diff": "^3.2.0",
+				"jest-matcher-utils": "^20.0.3",
+				"pretty-format": "^20.0.3"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					}
 				},
 				"supports-color": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
 				}
 			}
 		},
 		"jest-docblock": {
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-20.0.3.tgz",
-			"integrity": "sha1-F76phDQswz2DxQ++FUXqDvqkRxI="
+			"integrity": "sha1-F76phDQswz2DxQ++FUXqDvqkRxI=",
+			"dev": true
 		},
 		"jest-environment-jsdom": {
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-20.0.3.tgz",
 			"integrity": "sha1-BIqKwS7iJfcZBBdxODS7mZeH3pk=",
+			"dev": true,
 			"requires": {
-				"jest-mock": "20.0.3",
-				"jest-util": "20.0.3",
-				"jsdom": "9.12.0"
+				"jest-mock": "^20.0.3",
+				"jest-util": "^20.0.3",
+				"jsdom": "^9.12.0"
 			}
 		},
 		"jest-environment-node": {
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-20.0.3.tgz",
 			"integrity": "sha1-1Ii8RhKvLCRumG6K52caCZFj1AM=",
+			"dev": true,
 			"requires": {
-				"jest-mock": "20.0.3",
-				"jest-util": "20.0.3"
+				"jest-mock": "^20.0.3",
+				"jest-util": "^20.0.3"
 			}
 		},
 		"jest-haste-map": {
 			"version": "20.0.5",
 			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-20.0.5.tgz",
 			"integrity": "sha512-0IKAQjUvuZjMCNi/0VNQQF74/H9KB67hsHJqGiwTWQC6XO5Azs7kLWm+6Q/dwuhvDUvABDOBMFK2/FwZ3sZ07Q==",
+			"dev": true,
 			"requires": {
-				"fb-watchman": "2.0.0",
-				"graceful-fs": "4.1.11",
-				"jest-docblock": "20.0.3",
-				"micromatch": "2.3.11",
-				"sane": "1.6.0",
-				"worker-farm": "1.6.0"
+				"fb-watchman": "^2.0.0",
+				"graceful-fs": "^4.1.11",
+				"jest-docblock": "^20.0.3",
+				"micromatch": "^2.3.11",
+				"sane": "~1.6.0",
+				"worker-farm": "^1.3.1"
 			},
 			"dependencies": {
 				"arr-diff": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+					"dev": true,
 					"requires": {
-						"arr-flatten": "1.1.0"
+						"arr-flatten": "^1.0.1"
 					}
 				},
 				"array-unique": {
 					"version": "0.2.1",
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+					"dev": true
 				},
 				"braces": {
 					"version": "1.8.5",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+					"dev": true,
 					"requires": {
-						"expand-range": "1.8.2",
-						"preserve": "0.2.0",
-						"repeat-element": "1.1.2"
+						"expand-range": "^1.8.1",
+						"preserve": "^0.2.0",
+						"repeat-element": "^1.1.2"
 					}
 				},
 				"expand-brackets": {
 					"version": "0.1.5",
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+					"dev": true,
 					"requires": {
-						"is-posix-bracket": "0.1.1"
+						"is-posix-bracket": "^0.1.0"
 					}
 				},
 				"extglob": {
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+					"dev": true,
 					"requires": {
-						"is-extglob": "1.0.0"
+						"is-extglob": "^1.0.0"
 					}
 				},
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
 					"requires": {
-						"is-extglob": "1.0.0"
+						"is-extglob": "^1.0.0"
 					}
 				},
 				"micromatch": {
 					"version": "2.3.11",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+					"dev": true,
 					"requires": {
-						"arr-diff": "2.0.0",
-						"array-unique": "0.2.1",
-						"braces": "1.8.5",
-						"expand-brackets": "0.1.5",
-						"extglob": "0.3.2",
-						"filename-regex": "2.0.1",
-						"is-extglob": "1.0.0",
-						"is-glob": "2.0.1",
-						"kind-of": "3.2.2",
-						"normalize-path": "2.1.1",
-						"object.omit": "2.0.1",
-						"parse-glob": "3.0.4",
-						"regex-cache": "0.4.4"
+						"arr-diff": "^2.0.0",
+						"array-unique": "^0.2.1",
+						"braces": "^1.8.2",
+						"expand-brackets": "^0.1.4",
+						"extglob": "^0.3.1",
+						"filename-regex": "^2.0.0",
+						"is-extglob": "^1.0.0",
+						"is-glob": "^2.0.1",
+						"kind-of": "^3.0.2",
+						"normalize-path": "^2.0.1",
+						"object.omit": "^2.0.0",
+						"parse-glob": "^3.0.4",
+						"regex-cache": "^0.4.2"
 					}
 				}
 			}
@@ -4283,39 +4815,43 @@
 			"version": "20.0.4",
 			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-20.0.4.tgz",
 			"integrity": "sha1-/MWxQReA2RHQQpAu8YWehS5g1eE=",
+			"dev": true,
 			"requires": {
-				"chalk": "1.1.3",
-				"graceful-fs": "4.1.11",
-				"jest-diff": "20.0.3",
-				"jest-matcher-utils": "20.0.3",
-				"jest-matchers": "20.0.3",
-				"jest-message-util": "20.0.3",
-				"jest-snapshot": "20.0.3",
-				"once": "1.4.0",
-				"p-map": "1.2.0"
+				"chalk": "^1.1.3",
+				"graceful-fs": "^4.1.11",
+				"jest-diff": "^20.0.3",
+				"jest-matcher-utils": "^20.0.3",
+				"jest-matchers": "^20.0.3",
+				"jest-message-util": "^20.0.3",
+				"jest-snapshot": "^20.0.3",
+				"once": "^1.4.0",
+				"p-map": "^1.1.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					}
 				},
 				"supports-color": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
 				}
 			}
 		},
@@ -4323,32 +4859,36 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-20.0.3.tgz",
 			"integrity": "sha1-s6a443yld4A7CDKpixZPRLeBVhI=",
+			"dev": true,
 			"requires": {
-				"chalk": "1.1.3",
-				"pretty-format": "20.0.3"
+				"chalk": "^1.1.3",
+				"pretty-format": "^20.0.3"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					}
 				},
 				"supports-color": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
 				}
 			}
 		},
@@ -4356,280 +4896,312 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-matchers/-/jest-matchers-20.0.3.tgz",
 			"integrity": "sha1-ymnbHDLbWm9wf6XgQBq7VXAN/WA=",
+			"dev": true,
 			"requires": {
-				"jest-diff": "20.0.3",
-				"jest-matcher-utils": "20.0.3",
-				"jest-message-util": "20.0.3",
-				"jest-regex-util": "20.0.3"
+				"jest-diff": "^20.0.3",
+				"jest-matcher-utils": "^20.0.3",
+				"jest-message-util": "^20.0.3",
+				"jest-regex-util": "^20.0.3"
 			}
 		},
 		"jest-message-util": {
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-20.0.3.tgz",
 			"integrity": "sha1-auwoRDBvyw5udNV5bBAG2W/dgxw=",
+			"dev": true,
 			"requires": {
-				"chalk": "1.1.3",
-				"micromatch": "2.3.11",
-				"slash": "1.0.0"
+				"chalk": "^1.1.3",
+				"micromatch": "^2.3.11",
+				"slash": "^1.0.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"arr-diff": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+					"dev": true,
 					"requires": {
-						"arr-flatten": "1.1.0"
+						"arr-flatten": "^1.0.1"
 					}
 				},
 				"array-unique": {
 					"version": "0.2.1",
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+					"dev": true
 				},
 				"braces": {
 					"version": "1.8.5",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+					"dev": true,
 					"requires": {
-						"expand-range": "1.8.2",
-						"preserve": "0.2.0",
-						"repeat-element": "1.1.2"
+						"expand-range": "^1.8.1",
+						"preserve": "^0.2.0",
+						"repeat-element": "^1.1.2"
 					}
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					}
 				},
 				"expand-brackets": {
 					"version": "0.1.5",
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+					"dev": true,
 					"requires": {
-						"is-posix-bracket": "0.1.1"
+						"is-posix-bracket": "^0.1.0"
 					}
 				},
 				"extglob": {
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+					"dev": true,
 					"requires": {
-						"is-extglob": "1.0.0"
+						"is-extglob": "^1.0.0"
 					}
 				},
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
 					"requires": {
-						"is-extglob": "1.0.0"
+						"is-extglob": "^1.0.0"
 					}
 				},
 				"micromatch": {
 					"version": "2.3.11",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+					"dev": true,
 					"requires": {
-						"arr-diff": "2.0.0",
-						"array-unique": "0.2.1",
-						"braces": "1.8.5",
-						"expand-brackets": "0.1.5",
-						"extglob": "0.3.2",
-						"filename-regex": "2.0.1",
-						"is-extglob": "1.0.0",
-						"is-glob": "2.0.1",
-						"kind-of": "3.2.2",
-						"normalize-path": "2.1.1",
-						"object.omit": "2.0.1",
-						"parse-glob": "3.0.4",
-						"regex-cache": "0.4.4"
+						"arr-diff": "^2.0.0",
+						"array-unique": "^0.2.1",
+						"braces": "^1.8.2",
+						"expand-brackets": "^0.1.4",
+						"extglob": "^0.3.1",
+						"filename-regex": "^2.0.0",
+						"is-extglob": "^1.0.0",
+						"is-glob": "^2.0.1",
+						"kind-of": "^3.0.2",
+						"normalize-path": "^2.0.1",
+						"object.omit": "^2.0.0",
+						"parse-glob": "^3.0.4",
+						"regex-cache": "^0.4.2"
 					}
 				},
 				"supports-color": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
 				}
 			}
 		},
 		"jest-mock": {
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-20.0.3.tgz",
-			"integrity": "sha1-i8Bw6QQUqhVcEajWTIaaDVxx2lk="
+			"integrity": "sha1-i8Bw6QQUqhVcEajWTIaaDVxx2lk=",
+			"dev": true
 		},
 		"jest-regex-util": {
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-20.0.3.tgz",
-			"integrity": "sha1-hburXRM+RGJbGfr4xqpRItCF12I="
+			"integrity": "sha1-hburXRM+RGJbGfr4xqpRItCF12I=",
+			"dev": true
 		},
 		"jest-resolve": {
 			"version": "20.0.4",
 			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-20.0.4.tgz",
 			"integrity": "sha1-lEiz6La6/BVHlETGSZBFt//ll6U=",
+			"dev": true,
 			"requires": {
-				"browser-resolve": "1.11.2",
-				"is-builtin-module": "1.0.0",
-				"resolve": "1.7.1"
+				"browser-resolve": "^1.11.2",
+				"is-builtin-module": "^1.0.0",
+				"resolve": "^1.3.2"
 			}
 		},
 		"jest-resolve-dependencies": {
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-20.0.3.tgz",
 			"integrity": "sha1-bhSntxevDyyzZnxUneQK8Bexcjo=",
+			"dev": true,
 			"requires": {
-				"jest-regex-util": "20.0.3"
+				"jest-regex-util": "^20.0.3"
 			}
 		},
 		"jest-runtime": {
 			"version": "20.0.4",
 			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-20.0.4.tgz",
 			"integrity": "sha1-osgCIZxCA/dU3xQE5JAYYWnRJNg=",
+			"dev": true,
 			"requires": {
-				"babel-core": "6.26.0",
-				"babel-jest": "20.0.3",
-				"babel-plugin-istanbul": "4.1.6",
-				"chalk": "1.1.3",
-				"convert-source-map": "1.5.1",
-				"graceful-fs": "4.1.11",
-				"jest-config": "20.0.4",
-				"jest-haste-map": "20.0.5",
-				"jest-regex-util": "20.0.3",
-				"jest-resolve": "20.0.4",
-				"jest-util": "20.0.3",
-				"json-stable-stringify": "1.0.1",
-				"micromatch": "2.3.11",
+				"babel-core": "^6.0.0",
+				"babel-jest": "^20.0.3",
+				"babel-plugin-istanbul": "^4.0.0",
+				"chalk": "^1.1.3",
+				"convert-source-map": "^1.4.0",
+				"graceful-fs": "^4.1.11",
+				"jest-config": "^20.0.4",
+				"jest-haste-map": "^20.0.4",
+				"jest-regex-util": "^20.0.3",
+				"jest-resolve": "^20.0.4",
+				"jest-util": "^20.0.3",
+				"json-stable-stringify": "^1.0.1",
+				"micromatch": "^2.3.11",
 				"strip-bom": "3.0.0",
-				"yargs": "7.1.0"
+				"yargs": "^7.0.2"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"arr-diff": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+					"dev": true,
 					"requires": {
-						"arr-flatten": "1.1.0"
+						"arr-flatten": "^1.0.1"
 					}
 				},
 				"array-unique": {
 					"version": "0.2.1",
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+					"dev": true
 				},
 				"braces": {
 					"version": "1.8.5",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+					"dev": true,
 					"requires": {
-						"expand-range": "1.8.2",
-						"preserve": "0.2.0",
-						"repeat-element": "1.1.2"
+						"expand-range": "^1.8.1",
+						"preserve": "^0.2.0",
+						"repeat-element": "^1.1.2"
 					}
 				},
 				"camelcase": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					}
 				},
 				"cliui": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"dev": true,
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wrap-ansi": "2.1.0"
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wrap-ansi": "^2.0.0"
 					}
 				},
 				"expand-brackets": {
 					"version": "0.1.5",
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+					"dev": true,
 					"requires": {
-						"is-posix-bracket": "0.1.1"
+						"is-posix-bracket": "^0.1.0"
 					}
 				},
 				"extglob": {
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+					"dev": true,
 					"requires": {
-						"is-extglob": "1.0.0"
+						"is-extglob": "^1.0.0"
 					}
 				},
 				"find-up": {
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"dev": true,
 					"requires": {
-						"path-exists": "2.1.0",
-						"pinkie-promise": "2.0.1"
+						"path-exists": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
 					"requires": {
-						"is-extglob": "1.0.0"
+						"is-extglob": "^1.0.0"
 					}
 				},
 				"load-json-file": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
 					},
 					"dependencies": {
 						"strip-bom": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 							"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+							"dev": true,
 							"requires": {
-								"is-utf8": "0.2.1"
+								"is-utf8": "^0.2.0"
 							}
 						}
 					}
@@ -4638,103 +5210,113 @@
 					"version": "2.3.11",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+					"dev": true,
 					"requires": {
-						"arr-diff": "2.0.0",
-						"array-unique": "0.2.1",
-						"braces": "1.8.5",
-						"expand-brackets": "0.1.5",
-						"extglob": "0.3.2",
-						"filename-regex": "2.0.1",
-						"is-extglob": "1.0.0",
-						"is-glob": "2.0.1",
-						"kind-of": "3.2.2",
-						"normalize-path": "2.1.1",
-						"object.omit": "2.0.1",
-						"parse-glob": "3.0.4",
-						"regex-cache": "0.4.4"
+						"arr-diff": "^2.0.0",
+						"array-unique": "^0.2.1",
+						"braces": "^1.8.2",
+						"expand-brackets": "^0.1.4",
+						"extglob": "^0.3.1",
+						"filename-regex": "^2.0.0",
+						"is-extglob": "^1.0.0",
+						"is-glob": "^2.0.1",
+						"kind-of": "^3.0.2",
+						"normalize-path": "^2.0.1",
+						"object.omit": "^2.0.0",
+						"parse-glob": "^3.0.4",
+						"regex-cache": "^0.4.2"
 					}
 				},
 				"os-locale": {
 					"version": "1.4.0",
 					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+					"dev": true,
 					"requires": {
-						"lcid": "1.0.0"
+						"lcid": "^1.0.0"
 					}
 				},
 				"path-exists": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"dev": true,
 					"requires": {
-						"pinkie-promise": "2.0.1"
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"path-type": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"read-pkg": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+					"dev": true,
 					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
 					}
 				},
 				"read-pkg-up": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+					"dev": true,
 					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
 					}
 				},
 				"supports-color": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
 				},
 				"which-module": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+					"dev": true
 				},
 				"yargs": {
 					"version": "7.1.0",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
 					"integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+					"dev": true,
 					"requires": {
-						"camelcase": "3.0.0",
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "1.4.0",
-						"read-pkg-up": "1.0.1",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "1.0.2",
-						"which-module": "1.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "5.0.0"
+						"camelcase": "^3.0.0",
+						"cliui": "^3.2.0",
+						"decamelize": "^1.1.1",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^1.4.0",
+						"read-pkg-up": "^1.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^1.0.2",
+						"which-module": "^1.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^5.0.0"
 					}
 				},
 				"yargs-parser": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
 					"integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+					"dev": true,
 					"requires": {
-						"camelcase": "3.0.0"
+						"camelcase": "^3.0.0"
 					}
 				}
 			}
@@ -4743,36 +5325,40 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-20.0.3.tgz",
 			"integrity": "sha1-W4R+GtsaTZCFKn+fElCG4YfHZWY=",
+			"dev": true,
 			"requires": {
-				"chalk": "1.1.3",
-				"jest-diff": "20.0.3",
-				"jest-matcher-utils": "20.0.3",
-				"jest-util": "20.0.3",
-				"natural-compare": "1.4.0",
-				"pretty-format": "20.0.3"
+				"chalk": "^1.1.3",
+				"jest-diff": "^20.0.3",
+				"jest-matcher-utils": "^20.0.3",
+				"jest-util": "^20.0.3",
+				"natural-compare": "^1.4.0",
+				"pretty-format": "^20.0.3"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					}
 				},
 				"supports-color": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
 				}
 			}
 		},
@@ -4780,37 +5366,41 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-20.0.3.tgz",
 			"integrity": "sha1-DAf32A2C9OWmfG+LnD/n9lz9Mq0=",
+			"dev": true,
 			"requires": {
-				"chalk": "1.1.3",
-				"graceful-fs": "4.1.11",
-				"jest-message-util": "20.0.3",
-				"jest-mock": "20.0.3",
-				"jest-validate": "20.0.3",
-				"leven": "2.1.0",
-				"mkdirp": "0.5.1"
+				"chalk": "^1.1.3",
+				"graceful-fs": "^4.1.11",
+				"jest-message-util": "^20.0.3",
+				"jest-mock": "^20.0.3",
+				"jest-validate": "^20.0.3",
+				"leven": "^2.1.0",
+				"mkdirp": "^0.5.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					}
 				},
 				"supports-color": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
 				}
 			}
 		},
@@ -4818,41 +5408,46 @@
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-20.0.3.tgz",
 			"integrity": "sha1-0M/R3k9XnymEhJJcKA+PHZTsPKs=",
+			"dev": true,
 			"requires": {
-				"chalk": "1.1.3",
-				"jest-matcher-utils": "20.0.3",
-				"leven": "2.1.0",
-				"pretty-format": "20.0.3"
+				"chalk": "^1.1.3",
+				"jest-matcher-utils": "^20.0.3",
+				"leven": "^2.1.0",
+				"pretty-format": "^20.0.3"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					}
 				},
 				"supports-color": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
 				}
 			}
 		},
 		"js-base64": {
 			"version": "2.4.3",
 			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
-			"integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw=="
+			"integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw==",
+			"dev": true
 		},
 		"js-tokens": {
 			"version": "3.0.2",
@@ -4863,105 +5458,119 @@
 			"version": "3.7.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
 			"integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
+			"dev": true,
 			"requires": {
-				"argparse": "1.0.10",
-				"esprima": "2.7.3"
+				"argparse": "^1.0.7",
+				"esprima": "^2.6.0"
 			}
 		},
 		"jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"dev": true,
 			"optional": true
 		},
 		"jsdom": {
 			"version": "9.12.0",
 			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz",
 			"integrity": "sha1-6MVG//ywbADUgzyoRBD+1/igl9Q=",
+			"dev": true,
 			"requires": {
-				"abab": "1.0.4",
-				"acorn": "4.0.13",
-				"acorn-globals": "3.1.0",
-				"array-equal": "1.0.0",
-				"content-type-parser": "1.0.2",
-				"cssom": "0.3.2",
-				"cssstyle": "0.2.37",
-				"escodegen": "1.9.1",
-				"html-encoding-sniffer": "1.0.2",
-				"nwmatcher": "1.4.4",
-				"parse5": "1.5.1",
-				"request": "2.85.0",
-				"sax": "1.2.4",
-				"symbol-tree": "3.2.2",
-				"tough-cookie": "2.3.4",
-				"webidl-conversions": "4.0.2",
-				"whatwg-encoding": "1.0.3",
-				"whatwg-url": "4.8.0",
-				"xml-name-validator": "2.0.1"
+				"abab": "^1.0.3",
+				"acorn": "^4.0.4",
+				"acorn-globals": "^3.1.0",
+				"array-equal": "^1.0.0",
+				"content-type-parser": "^1.0.1",
+				"cssom": ">= 0.3.2 < 0.4.0",
+				"cssstyle": ">= 0.2.37 < 0.3.0",
+				"escodegen": "^1.6.1",
+				"html-encoding-sniffer": "^1.0.1",
+				"nwmatcher": ">= 1.3.9 < 2.0.0",
+				"parse5": "^1.5.1",
+				"request": "^2.79.0",
+				"sax": "^1.2.1",
+				"symbol-tree": "^3.2.1",
+				"tough-cookie": "^2.3.2",
+				"webidl-conversions": "^4.0.0",
+				"whatwg-encoding": "^1.0.1",
+				"whatwg-url": "^4.3.0",
+				"xml-name-validator": "^2.0.1"
 			},
 			"dependencies": {
 				"acorn": {
 					"version": "4.0.13",
 					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+					"dev": true
 				}
 			}
 		},
 		"jsesc": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-			"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+			"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+			"dev": true
 		},
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+			"dev": true
 		},
 		"json-schema-traverse": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+			"dev": true
 		},
 		"json-stable-stringify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
 			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+			"dev": true,
 			"requires": {
-				"jsonify": "0.0.0"
+				"jsonify": "~0.0.0"
 			}
 		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"dev": true
 		},
 		"json5": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+			"dev": true
 		},
 		"jsonfile": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
 			"integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11"
+				"graceful-fs": "^4.1.6"
 			}
 		},
 		"jsonify": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+			"dev": true
 		},
 		"jsonpointer": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-			"integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
+			"integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+			"dev": true
 		},
 		"jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
 			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
@@ -4973,246 +5582,280 @@
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"dev": true,
 			"requires": {
-				"is-buffer": "1.1.6"
+				"is-buffer": "^1.1.5"
 			}
 		},
 		"lazy-cache": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
 			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+			"dev": true,
 			"optional": true
 		},
 		"lcid": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+			"dev": true,
 			"requires": {
-				"invert-kv": "1.0.0"
+				"invert-kv": "^1.0.0"
 			}
 		},
 		"leven": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-			"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
+			"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+			"dev": true
 		},
 		"levn": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"dev": true,
 			"requires": {
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2"
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2"
 			}
 		},
 		"locate-character": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/locate-character/-/locate-character-2.0.5.tgz",
-			"integrity": "sha512-n2GmejDXtOPBAZdIiEFy5dJ5N38xBCXLNOtw2WpB9kGh6pnrEuKlwYI+Tkpofc4wDtVXHtoAOJaMRlYG/oYaxg=="
+			"integrity": "sha512-n2GmejDXtOPBAZdIiEFy5dJ5N38xBCXLNOtw2WpB9kGh6pnrEuKlwYI+Tkpofc4wDtVXHtoAOJaMRlYG/oYaxg==",
+			"dev": true
 		},
 		"locate-path": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+			"dev": true,
 			"requires": {
-				"p-locate": "2.0.0",
-				"path-exists": "3.0.0"
+				"p-locate": "^2.0.0",
+				"path-exists": "^3.0.0"
 			}
 		},
 		"lodash": {
 			"version": "4.17.10",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-			"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+			"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+			"dev": true
 		},
 		"lodash.assign": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+			"dev": true
 		},
 		"lodash.clonedeep": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+			"dev": true
 		},
 		"lodash.memoize": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
+			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+			"dev": true
 		},
 		"lodash.mergewith": {
 			"version": "4.6.1",
 			"resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
-			"integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ=="
+			"integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
+			"dev": true
 		},
 		"lodash.uniq": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+			"dev": true
 		},
 		"longest": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+			"dev": true
 		},
 		"loose-envify": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
 			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
 			"requires": {
-				"js-tokens": "3.0.2"
+				"js-tokens": "^3.0.0"
 			}
 		},
 		"loud-rejection": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
 			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+			"dev": true,
 			"requires": {
-				"currently-unhandled": "0.4.1",
-				"signal-exit": "3.0.2"
+				"currently-unhandled": "^0.4.1",
+				"signal-exit": "^3.0.0"
 			}
 		},
 		"lower-case": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-			"integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+			"integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
+			"dev": true
 		},
 		"lower-case-first": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz",
 			"integrity": "sha1-5dp8JvKacHO+AtUrrJmA5ZIq36E=",
+			"dev": true,
 			"requires": {
-				"lower-case": "1.1.4"
+				"lower-case": "^1.1.2"
 			}
 		},
 		"lru-cache": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
 			"integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
+			"dev": true,
 			"requires": {
-				"pseudomap": "1.0.2",
-				"yallist": "2.1.2"
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
 			}
 		},
 		"macaddress": {
 			"version": "0.2.8",
 			"resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
-			"integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI="
+			"integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI=",
+			"dev": true
 		},
 		"magic-string": {
 			"version": "0.22.5",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
 			"integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
+			"dev": true,
 			"requires": {
-				"vlq": "0.2.3"
+				"vlq": "^0.2.2"
 			}
 		},
 		"makeerror": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
 			"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+			"dev": true,
 			"requires": {
-				"tmpl": "1.0.4"
+				"tmpl": "1.0.x"
 			}
 		},
 		"map-cache": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+			"dev": true
 		},
 		"map-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
 			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+			"dev": true,
 			"requires": {
-				"object-visit": "1.0.1"
+				"object-visit": "^1.0.0"
 			}
 		},
 		"math-expression-evaluator": {
 			"version": "1.2.17",
 			"resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
-			"integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw="
+			"integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw=",
+			"dev": true
 		},
 		"merge": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-			"integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
+			"integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
+			"dev": true
 		},
 		"merge-source-map": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
 			"integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
+			"dev": true,
 			"requires": {
-				"source-map": "0.6.1"
+				"source-map": "^0.6.1"
 			}
 		},
 		"micromatch": {
 			"version": "3.1.10",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
 			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+			"dev": true,
 			"requires": {
-				"arr-diff": "4.0.0",
-				"array-unique": "0.3.2",
-				"braces": "2.3.2",
-				"define-property": "2.0.2",
-				"extend-shallow": "3.0.2",
-				"extglob": "2.0.4",
-				"fragment-cache": "0.2.1",
-				"kind-of": "6.0.2",
-				"nanomatch": "1.2.9",
-				"object.pick": "1.3.0",
-				"regex-not": "1.0.2",
-				"snapdragon": "0.8.2",
-				"to-regex": "3.0.2"
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"braces": "^2.3.1",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"extglob": "^2.0.4",
+				"fragment-cache": "^0.2.1",
+				"kind-of": "^6.0.2",
+				"nanomatch": "^1.2.9",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.2"
 			},
 			"dependencies": {
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
 				}
 			}
 		},
 		"mime-db": {
 			"version": "1.33.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+			"dev": true
 		},
 		"mime-types": {
 			"version": "2.1.18",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
 			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+			"dev": true,
 			"requires": {
-				"mime-db": "1.33.0"
+				"mime-db": "~1.33.0"
 			}
 		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
 			"requires": {
-				"brace-expansion": "1.1.11"
+				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+			"dev": true
 		},
 		"mixin-deep": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
 			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+			"dev": true,
 			"requires": {
-				"for-in": "1.0.2",
-				"is-extendable": "1.0.1"
+				"for-in": "^1.0.2",
+				"is-extendable": "^1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"dev": true,
 					"requires": {
-						"is-plain-object": "2.0.4"
+						"is-plain-object": "^2.0.4"
 					}
 				}
 			}
@@ -5221,6 +5864,7 @@
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			}
@@ -5228,50 +5872,56 @@
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
 		},
 		"nan": {
 			"version": "2.10.0",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-			"integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+			"integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+			"dev": true
 		},
 		"nanomatch": {
 			"version": "1.2.9",
 			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
 			"integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+			"dev": true,
 			"requires": {
-				"arr-diff": "4.0.0",
-				"array-unique": "0.3.2",
-				"define-property": "2.0.2",
-				"extend-shallow": "3.0.2",
-				"fragment-cache": "0.2.1",
-				"is-odd": "2.0.0",
-				"is-windows": "1.0.2",
-				"kind-of": "6.0.2",
-				"object.pick": "1.3.0",
-				"regex-not": "1.0.2",
-				"snapdragon": "0.8.2",
-				"to-regex": "3.0.2"
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"fragment-cache": "^0.2.1",
+				"is-odd": "^2.0.0",
+				"is-windows": "^1.0.2",
+				"kind-of": "^6.0.2",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
 			},
 			"dependencies": {
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
 				}
 			}
 		},
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"dev": true
 		},
 		"no-case": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
 			"integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+			"dev": true,
 			"requires": {
-				"lower-case": "1.1.4"
+				"lower-case": "^1.1.1"
 			}
 		},
 		"node-fetch": {
@@ -5279,369 +5929,408 @@
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
 			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
 			"requires": {
-				"encoding": "0.1.12",
-				"is-stream": "1.1.0"
+				"encoding": "^0.1.11",
+				"is-stream": "^1.0.1"
 			}
 		},
 		"node-gyp": {
 			"version": "3.6.2",
 			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
 			"integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
+			"dev": true,
 			"requires": {
-				"fstream": "1.0.11",
-				"glob": "7.1.2",
-				"graceful-fs": "4.1.11",
-				"minimatch": "3.0.4",
-				"mkdirp": "0.5.1",
-				"nopt": "3.0.6",
-				"npmlog": "4.1.2",
-				"osenv": "0.1.5",
-				"request": "2.85.0",
-				"rimraf": "2.6.2",
-				"semver": "5.3.0",
-				"tar": "2.2.1",
-				"which": "1.3.0"
+				"fstream": "^1.0.0",
+				"glob": "^7.0.3",
+				"graceful-fs": "^4.1.2",
+				"minimatch": "^3.0.2",
+				"mkdirp": "^0.5.0",
+				"nopt": "2 || 3",
+				"npmlog": "0 || 1 || 2 || 3 || 4",
+				"osenv": "0",
+				"request": "2",
+				"rimraf": "2",
+				"semver": "~5.3.0",
+				"tar": "^2.0.0",
+				"which": "1"
 			},
 			"dependencies": {
 				"semver": {
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+					"dev": true
 				}
 			}
 		},
 		"node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
+			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+			"dev": true
 		},
 		"node-notifier": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
 			"integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
+			"dev": true,
 			"requires": {
-				"growly": "1.3.0",
-				"semver": "5.5.0",
-				"shellwords": "0.1.1",
-				"which": "1.3.0"
+				"growly": "^1.3.0",
+				"semver": "^5.4.1",
+				"shellwords": "^0.1.1",
+				"which": "^1.3.0"
 			}
 		},
 		"node-sass": {
 			"version": "4.8.3",
 			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.8.3.tgz",
 			"integrity": "sha512-tfFWhUsCk/Y19zarDcPo5xpj+IW3qCfOjVdHtYeG6S1CKbQOh1zqylnQK6cV3z9k80yxAnFX9Y+a9+XysDhhfg==",
+			"dev": true,
 			"requires": {
-				"async-foreach": "0.1.3",
-				"chalk": "1.1.3",
-				"cross-spawn": "3.0.1",
-				"gaze": "1.1.2",
-				"get-stdin": "4.0.1",
-				"glob": "7.1.2",
-				"in-publish": "2.0.0",
-				"lodash.assign": "4.2.0",
-				"lodash.clonedeep": "4.5.0",
-				"lodash.mergewith": "4.6.1",
-				"meow": "3.7.0",
-				"mkdirp": "0.5.1",
-				"nan": "2.10.0",
-				"node-gyp": "3.6.2",
-				"npmlog": "4.1.2",
-				"request": "2.79.0",
-				"sass-graph": "2.2.4",
-				"stdout-stream": "1.4.0",
-				"true-case-path": "1.0.2"
+				"async-foreach": "^0.1.3",
+				"chalk": "^1.1.1",
+				"cross-spawn": "^3.0.0",
+				"gaze": "^1.0.0",
+				"get-stdin": "^4.0.1",
+				"glob": "^7.0.3",
+				"in-publish": "^2.0.0",
+				"lodash.assign": "^4.2.0",
+				"lodash.clonedeep": "^4.3.2",
+				"lodash.mergewith": "^4.6.0",
+				"meow": "^3.7.0",
+				"mkdirp": "^0.5.1",
+				"nan": "^2.10.0",
+				"node-gyp": "^3.3.1",
+				"npmlog": "^4.0.0",
+				"request": "~2.79.0",
+				"sass-graph": "^2.2.4",
+				"stdout-stream": "^1.4.0",
+				"true-case-path": "^1.0.2"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"assert-plus": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-					"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+					"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+					"dev": true
 				},
 				"aws-sign2": {
 					"version": "0.6.0",
 					"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-					"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+					"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+					"dev": true
 				},
 				"boom": {
 					"version": "2.10.1",
 					"resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
 					"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+					"dev": true,
 					"requires": {
-						"hoek": "2.16.3"
+						"hoek": "2.x.x"
 					}
 				},
 				"camelcase": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+					"dev": true
 				},
 				"camelcase-keys": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
 					"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+					"dev": true,
 					"requires": {
-						"camelcase": "2.1.1",
-						"map-obj": "1.0.1"
+						"camelcase": "^2.0.0",
+						"map-obj": "^1.0.0"
 					}
 				},
 				"caseless": {
 					"version": "0.11.0",
 					"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-					"integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
+					"integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					}
 				},
 				"cross-spawn": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
 					"integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
+					"dev": true,
 					"requires": {
-						"lru-cache": "4.1.2",
-						"which": "1.3.0"
+						"lru-cache": "^4.0.1",
+						"which": "^1.2.9"
 					}
 				},
 				"cryptiles": {
 					"version": "2.0.5",
 					"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
 					"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+					"dev": true,
 					"requires": {
-						"boom": "2.10.1"
+						"boom": "2.x.x"
 					}
 				},
 				"find-up": {
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"dev": true,
 					"requires": {
-						"path-exists": "2.1.0",
-						"pinkie-promise": "2.0.1"
+						"path-exists": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"form-data": {
 					"version": "2.1.4",
 					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
 					"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+					"dev": true,
 					"requires": {
-						"asynckit": "0.4.0",
-						"combined-stream": "1.0.6",
-						"mime-types": "2.1.18"
+						"asynckit": "^0.4.0",
+						"combined-stream": "^1.0.5",
+						"mime-types": "^2.1.12"
 					}
 				},
 				"har-validator": {
 					"version": "2.0.6",
 					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
 					"integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+					"dev": true,
 					"requires": {
-						"chalk": "1.1.3",
-						"commander": "2.15.1",
-						"is-my-json-valid": "2.17.2",
-						"pinkie-promise": "2.0.1"
+						"chalk": "^1.1.1",
+						"commander": "^2.9.0",
+						"is-my-json-valid": "^2.12.4",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"hawk": {
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
 					"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+					"dev": true,
 					"requires": {
-						"boom": "2.10.1",
-						"cryptiles": "2.0.5",
-						"hoek": "2.16.3",
-						"sntp": "1.0.9"
+						"boom": "2.x.x",
+						"cryptiles": "2.x.x",
+						"hoek": "2.x.x",
+						"sntp": "1.x.x"
 					}
 				},
 				"hoek": {
 					"version": "2.16.3",
 					"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-					"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+					"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+					"dev": true
 				},
 				"http-signature": {
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
 					"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+					"dev": true,
 					"requires": {
-						"assert-plus": "0.2.0",
-						"jsprim": "1.4.1",
-						"sshpk": "1.14.1"
+						"assert-plus": "^0.2.0",
+						"jsprim": "^1.2.2",
+						"sshpk": "^1.7.0"
 					}
 				},
 				"indent-string": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
 					"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+					"dev": true,
 					"requires": {
-						"repeating": "2.0.1"
+						"repeating": "^2.0.0"
 					}
 				},
 				"load-json-file": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
 					}
 				},
 				"map-obj": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+					"dev": true
 				},
 				"meow": {
 					"version": "3.7.0",
 					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
 					"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+					"dev": true,
 					"requires": {
-						"camelcase-keys": "2.1.0",
-						"decamelize": "1.2.0",
-						"loud-rejection": "1.6.0",
-						"map-obj": "1.0.1",
-						"minimist": "1.2.0",
-						"normalize-package-data": "2.4.0",
-						"object-assign": "4.1.1",
-						"read-pkg-up": "1.0.1",
-						"redent": "1.0.0",
-						"trim-newlines": "1.0.0"
+						"camelcase-keys": "^2.0.0",
+						"decamelize": "^1.1.2",
+						"loud-rejection": "^1.0.0",
+						"map-obj": "^1.0.1",
+						"minimist": "^1.1.3",
+						"normalize-package-data": "^2.3.4",
+						"object-assign": "^4.0.1",
+						"read-pkg-up": "^1.0.1",
+						"redent": "^1.0.0",
+						"trim-newlines": "^1.0.0"
 					}
 				},
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
 				},
 				"path-exists": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"dev": true,
 					"requires": {
-						"pinkie-promise": "2.0.1"
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"path-type": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"qs": {
 					"version": "6.3.2",
 					"resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-					"integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw="
+					"integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+					"dev": true
 				},
 				"read-pkg": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+					"dev": true,
 					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
 					}
 				},
 				"read-pkg-up": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+					"dev": true,
 					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
 					}
 				},
 				"redent": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
 					"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+					"dev": true,
 					"requires": {
-						"indent-string": "2.1.0",
-						"strip-indent": "1.0.1"
+						"indent-string": "^2.1.0",
+						"strip-indent": "^1.0.1"
 					}
 				},
 				"request": {
 					"version": "2.79.0",
 					"resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
 					"integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+					"dev": true,
 					"requires": {
-						"aws-sign2": "0.6.0",
-						"aws4": "1.7.0",
-						"caseless": "0.11.0",
-						"combined-stream": "1.0.6",
-						"extend": "3.0.1",
-						"forever-agent": "0.6.1",
-						"form-data": "2.1.4",
-						"har-validator": "2.0.6",
-						"hawk": "3.1.3",
-						"http-signature": "1.1.1",
-						"is-typedarray": "1.0.0",
-						"isstream": "0.1.2",
-						"json-stringify-safe": "5.0.1",
-						"mime-types": "2.1.18",
-						"oauth-sign": "0.8.2",
-						"qs": "6.3.2",
-						"stringstream": "0.0.5",
-						"tough-cookie": "2.3.4",
-						"tunnel-agent": "0.4.3",
-						"uuid": "3.2.1"
+						"aws-sign2": "~0.6.0",
+						"aws4": "^1.2.1",
+						"caseless": "~0.11.0",
+						"combined-stream": "~1.0.5",
+						"extend": "~3.0.0",
+						"forever-agent": "~0.6.1",
+						"form-data": "~2.1.1",
+						"har-validator": "~2.0.6",
+						"hawk": "~3.1.3",
+						"http-signature": "~1.1.0",
+						"is-typedarray": "~1.0.0",
+						"isstream": "~0.1.2",
+						"json-stringify-safe": "~5.0.1",
+						"mime-types": "~2.1.7",
+						"oauth-sign": "~0.8.1",
+						"qs": "~6.3.0",
+						"stringstream": "~0.0.4",
+						"tough-cookie": "~2.3.0",
+						"tunnel-agent": "~0.4.1",
+						"uuid": "^3.0.0"
 					}
 				},
 				"sntp": {
 					"version": "1.0.9",
 					"resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
 					"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+					"dev": true,
 					"requires": {
-						"hoek": "2.16.3"
+						"hoek": "2.x.x"
 					}
 				},
 				"strip-bom": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
 					"requires": {
-						"is-utf8": "0.2.1"
+						"is-utf8": "^0.2.0"
 					}
 				},
 				"strip-indent": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
 					"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+					"dev": true,
 					"requires": {
-						"get-stdin": "4.0.1"
+						"get-stdin": "^4.0.1"
 					}
 				},
 				"supports-color": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
 				},
 				"trim-newlines": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-					"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
+					"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+					"dev": true
 				},
 				"tunnel-agent": {
 					"version": "0.4.3",
 					"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-					"integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
+					"integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+					"dev": true
 				}
 			}
 		},
@@ -5649,75 +6338,85 @@
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
 			"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+			"dev": true,
 			"requires": {
-				"abbrev": "1.1.1"
+				"abbrev": "1"
 			}
 		},
 		"normalize-package-data": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+			"dev": true,
 			"requires": {
-				"hosted-git-info": "2.6.0",
-				"is-builtin-module": "1.0.0",
-				"semver": "5.5.0",
-				"validate-npm-package-license": "3.0.3"
+				"hosted-git-info": "^2.1.4",
+				"is-builtin-module": "^1.0.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
 			}
 		},
 		"normalize-path": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"dev": true,
 			"requires": {
-				"remove-trailing-separator": "1.1.0"
+				"remove-trailing-separator": "^1.0.1"
 			}
 		},
 		"normalize-range": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-			"integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
+			"integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
+			"dev": true
 		},
 		"normalize-url": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
 			"integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
+			"dev": true,
 			"requires": {
-				"object-assign": "4.1.1",
-				"prepend-http": "1.0.4",
-				"query-string": "4.3.4",
-				"sort-keys": "1.1.2"
+				"object-assign": "^4.0.1",
+				"prepend-http": "^1.0.0",
+				"query-string": "^4.1.0",
+				"sort-keys": "^1.0.0"
 			}
 		},
 		"npmlog": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
 			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+			"dev": true,
 			"requires": {
-				"are-we-there-yet": "1.1.4",
-				"console-control-strings": "1.1.0",
-				"gauge": "2.7.4",
-				"set-blocking": "2.0.0"
+				"are-we-there-yet": "~1.1.2",
+				"console-control-strings": "~1.1.0",
+				"gauge": "~2.7.3",
+				"set-blocking": "~2.0.0"
 			}
 		},
 		"num2fraction": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
-			"integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
+			"integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
+			"dev": true
 		},
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+			"dev": true
 		},
 		"nwmatcher": {
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
-			"integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ=="
+			"integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ==",
+			"dev": true
 		},
 		"oauth-sign": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+			"dev": true
 		},
 		"object-assign": {
 			"version": "4.1.1",
@@ -5728,18 +6427,20 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
 			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+			"dev": true,
 			"requires": {
-				"copy-descriptor": "0.1.1",
-				"define-property": "0.2.5",
-				"kind-of": "3.2.2"
+				"copy-descriptor": "^0.1.0",
+				"define-property": "^0.2.5",
+				"kind-of": "^3.0.3"
 			},
 			"dependencies": {
 				"define-property": {
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
 					}
 				}
 			}
@@ -5748,149 +6449,168 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+			"dev": true,
 			"requires": {
-				"isobject": "3.0.1"
+				"isobject": "^3.0.0"
 			}
 		},
 		"object.omit": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+			"dev": true,
 			"requires": {
-				"for-own": "0.1.5",
-				"is-extendable": "0.1.1"
+				"for-own": "^0.1.4",
+				"is-extendable": "^0.1.1"
 			}
 		},
 		"object.pick": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
 			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+			"dev": true,
 			"requires": {
-				"isobject": "3.0.1"
+				"isobject": "^3.0.1"
 			}
 		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
 			"requires": {
-				"wrappy": "1.0.2"
+				"wrappy": "1"
 			}
 		},
 		"optimist": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+			"dev": true,
 			"requires": {
-				"minimist": "0.0.8",
-				"wordwrap": "0.0.2"
+				"minimist": "~0.0.1",
+				"wordwrap": "~0.0.2"
 			}
 		},
 		"optionator": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"dev": true,
 			"requires": {
-				"deep-is": "0.1.3",
-				"fast-levenshtein": "2.0.6",
-				"levn": "0.3.0",
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2",
-				"wordwrap": "1.0.0"
+				"deep-is": "~0.1.3",
+				"fast-levenshtein": "~2.0.4",
+				"levn": "~0.3.0",
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2",
+				"wordwrap": "~1.0.0"
 			},
 			"dependencies": {
 				"wordwrap": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+					"dev": true
 				}
 			}
 		},
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+			"dev": true
 		},
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+			"dev": true
 		},
 		"osenv": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
 			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+			"dev": true,
 			"requires": {
-				"os-homedir": "1.0.2",
-				"os-tmpdir": "1.0.2"
+				"os-homedir": "^1.0.0",
+				"os-tmpdir": "^1.0.0"
 			}
 		},
 		"output-file-sync": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
 			"integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"mkdirp": "0.5.1",
-				"object-assign": "4.1.1"
+				"graceful-fs": "^4.1.4",
+				"mkdirp": "^0.5.1",
+				"object-assign": "^4.1.0"
 			}
 		},
 		"p-limit": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
 			"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+			"dev": true,
 			"requires": {
-				"p-try": "1.0.0"
+				"p-try": "^1.0.0"
 			}
 		},
 		"p-locate": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+			"dev": true,
 			"requires": {
-				"p-limit": "1.2.0"
+				"p-limit": "^1.1.0"
 			}
 		},
 		"p-map": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
-			"integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA=="
+			"integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+			"dev": true
 		},
 		"p-try": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+			"dev": true
 		},
 		"param-case": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
 			"integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+			"dev": true,
 			"requires": {
-				"no-case": "2.3.2"
+				"no-case": "^2.2.0"
 			}
 		},
 		"parse-glob": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+			"dev": true,
 			"requires": {
-				"glob-base": "0.3.0",
-				"is-dotfile": "1.0.3",
-				"is-extglob": "1.0.0",
-				"is-glob": "2.0.1"
+				"glob-base": "^0.3.0",
+				"is-dotfile": "^1.0.0",
+				"is-extglob": "^1.0.0",
+				"is-glob": "^2.0.0"
 			},
 			"dependencies": {
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
 					"requires": {
-						"is-extglob": "1.0.0"
+						"is-extglob": "^1.0.0"
 					}
 				}
 			}
@@ -5899,164 +6619,188 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"dev": true,
 			"requires": {
-				"error-ex": "1.3.1"
+				"error-ex": "^1.2.0"
 			}
 		},
 		"parse-ms": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
-			"integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0="
+			"integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0=",
+			"dev": true
 		},
 		"parse5": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
-			"integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ="
+			"integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=",
+			"dev": true
 		},
 		"pascal-case": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-2.0.1.tgz",
 			"integrity": "sha1-LVeNNFX2YNpl7KGO+VtODekSdh4=",
+			"dev": true,
 			"requires": {
-				"camel-case": "3.0.0",
-				"upper-case-first": "1.1.2"
+				"camel-case": "^3.0.0",
+				"upper-case-first": "^1.1.0"
 			}
 		},
 		"pascalcase": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+			"dev": true
 		},
 		"path-case": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/path-case/-/path-case-2.1.1.tgz",
 			"integrity": "sha1-lLgDfDctP+KQbkZbtF4l0ibo7qU=",
+			"dev": true,
 			"requires": {
-				"no-case": "2.3.2"
+				"no-case": "^2.2.0"
 			}
 		},
 		"path-exists": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+			"dev": true
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
 		},
 		"path-parse": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+			"dev": true
 		},
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+			"dev": true
 		},
 		"pify": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+			"dev": true
 		},
 		"pinkie": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+			"dev": true
 		},
 		"pinkie-promise": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"dev": true,
 			"requires": {
-				"pinkie": "2.0.4"
+				"pinkie": "^2.0.0"
 			}
 		},
 		"plur": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
 			"integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
+			"dev": true,
 			"requires": {
-				"irregular-plurals": "1.4.0"
+				"irregular-plurals": "^1.0.0"
 			}
 		},
 		"posix-character-classes": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+			"dev": true
 		},
 		"postcss": {
 			"version": "6.0.21",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
 			"integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
+			"dev": true,
 			"requires": {
-				"chalk": "2.4.0",
-				"source-map": "0.6.1",
-				"supports-color": "5.4.0"
+				"chalk": "^2.3.2",
+				"source-map": "^0.6.1",
+				"supports-color": "^5.3.0"
 			}
 		},
 		"postcss-calc": {
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
 			"integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
+			"dev": true,
 			"requires": {
-				"postcss": "5.2.18",
-				"postcss-message-helpers": "2.0.0",
-				"reduce-css-calc": "1.3.0"
+				"postcss": "^5.0.2",
+				"postcss-message-helpers": "^2.0.0",
+				"reduce-css-calc": "^1.2.6"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					},
 					"dependencies": {
 						"supports-color": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+							"dev": true
 						}
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
 				},
 				"postcss": {
 					"version": "5.2.18",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
 					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"dev": true,
 					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.3",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
+						"chalk": "^1.1.3",
+						"js-base64": "^2.1.9",
+						"source-map": "^0.5.6",
+						"supports-color": "^3.2.3"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -6065,63 +6809,71 @@
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
 			"integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
+			"dev": true,
 			"requires": {
-				"colormin": "1.1.2",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
+				"colormin": "^1.0.5",
+				"postcss": "^5.0.13",
+				"postcss-value-parser": "^3.2.3"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					},
 					"dependencies": {
 						"supports-color": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+							"dev": true
 						}
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
 				},
 				"postcss": {
 					"version": "5.2.18",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
 					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"dev": true,
 					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.3",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
+						"chalk": "^1.1.3",
+						"js-base64": "^2.1.9",
+						"source-map": "^0.5.6",
+						"supports-color": "^3.2.3"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -6130,62 +6882,70 @@
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
 			"integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
+			"dev": true,
 			"requires": {
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
+				"postcss": "^5.0.11",
+				"postcss-value-parser": "^3.1.2"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					},
 					"dependencies": {
 						"supports-color": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+							"dev": true
 						}
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
 				},
 				"postcss": {
 					"version": "5.2.18",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
 					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"dev": true,
 					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.3",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
+						"chalk": "^1.1.3",
+						"js-base64": "^2.1.9",
+						"source-map": "^0.5.6",
+						"supports-color": "^3.2.3"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -6194,61 +6954,69 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
 			"integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
+			"dev": true,
 			"requires": {
-				"postcss": "5.2.18"
+				"postcss": "^5.0.14"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					},
 					"dependencies": {
 						"supports-color": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+							"dev": true
 						}
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
 				},
 				"postcss": {
 					"version": "5.2.18",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
 					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"dev": true,
 					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.3",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
+						"chalk": "^1.1.3",
+						"js-base64": "^2.1.9",
+						"source-map": "^0.5.6",
+						"supports-color": "^3.2.3"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -6257,61 +7025,69 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
 			"integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
+			"dev": true,
 			"requires": {
-				"postcss": "5.2.18"
+				"postcss": "^5.0.4"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					},
 					"dependencies": {
 						"supports-color": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+							"dev": true
 						}
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
 				},
 				"postcss": {
 					"version": "5.2.18",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
 					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"dev": true,
 					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.3",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
+						"chalk": "^1.1.3",
+						"js-base64": "^2.1.9",
+						"source-map": "^0.5.6",
+						"supports-color": "^3.2.3"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -6320,61 +7096,69 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
 			"integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
+			"dev": true,
 			"requires": {
-				"postcss": "5.2.18"
+				"postcss": "^5.0.14"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					},
 					"dependencies": {
 						"supports-color": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+							"dev": true
 						}
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
 				},
 				"postcss": {
 					"version": "5.2.18",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
 					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"dev": true,
 					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.3",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
+						"chalk": "^1.1.3",
+						"js-base64": "^2.1.9",
+						"source-map": "^0.5.6",
+						"supports-color": "^3.2.3"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -6383,61 +7167,69 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
 			"integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
+			"dev": true,
 			"requires": {
-				"postcss": "5.2.18"
+				"postcss": "^5.0.16"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					},
 					"dependencies": {
 						"supports-color": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+							"dev": true
 						}
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
 				},
 				"postcss": {
 					"version": "5.2.18",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
 					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"dev": true,
 					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.3",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
+						"chalk": "^1.1.3",
+						"js-base64": "^2.1.9",
+						"source-map": "^0.5.6",
+						"supports-color": "^3.2.3"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -6446,62 +7238,70 @@
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
 			"integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
+			"dev": true,
 			"requires": {
-				"postcss": "5.2.18",
-				"uniqs": "2.0.0"
+				"postcss": "^5.0.14",
+				"uniqs": "^2.0.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					},
 					"dependencies": {
 						"supports-color": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+							"dev": true
 						}
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
 				},
 				"postcss": {
 					"version": "5.2.18",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
 					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"dev": true,
 					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.3",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
+						"chalk": "^1.1.3",
+						"js-base64": "^2.1.9",
+						"source-map": "^0.5.6",
+						"supports-color": "^3.2.3"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -6510,62 +7310,70 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
 			"integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
+			"dev": true,
 			"requires": {
-				"postcss": "5.2.18",
-				"uniqid": "4.1.1"
+				"postcss": "^5.0.4",
+				"uniqid": "^4.0.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					},
 					"dependencies": {
 						"supports-color": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+							"dev": true
 						}
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
 				},
 				"postcss": {
 					"version": "5.2.18",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
 					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"dev": true,
 					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.3",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
+						"chalk": "^1.1.3",
+						"js-base64": "^2.1.9",
+						"source-map": "^0.5.6",
+						"supports-color": "^3.2.3"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -6574,92 +7382,103 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz",
 			"integrity": "sha1-U56a/J3chiASHr+djDZz4M5Q0oo=",
+			"dev": true,
 			"requires": {
-				"cosmiconfig": "2.2.2",
-				"object-assign": "4.1.1",
-				"postcss-load-options": "1.2.0",
-				"postcss-load-plugins": "2.3.0"
+				"cosmiconfig": "^2.1.0",
+				"object-assign": "^4.1.0",
+				"postcss-load-options": "^1.2.0",
+				"postcss-load-plugins": "^2.3.0"
 			}
 		},
 		"postcss-load-options": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/postcss-load-options/-/postcss-load-options-1.2.0.tgz",
 			"integrity": "sha1-sJixVZ3awt8EvAuzdfmaXP4rbYw=",
+			"dev": true,
 			"requires": {
-				"cosmiconfig": "2.2.2",
-				"object-assign": "4.1.1"
+				"cosmiconfig": "^2.1.0",
+				"object-assign": "^4.1.0"
 			}
 		},
 		"postcss-load-plugins": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/postcss-load-plugins/-/postcss-load-plugins-2.3.0.tgz",
 			"integrity": "sha1-dFdoEWWZrKLwCfrUJrABdQSdjZI=",
+			"dev": true,
 			"requires": {
-				"cosmiconfig": "2.2.2",
-				"object-assign": "4.1.1"
+				"cosmiconfig": "^2.1.1",
+				"object-assign": "^4.1.0"
 			}
 		},
 		"postcss-merge-idents": {
 			"version": "2.1.7",
 			"resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
 			"integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
+			"dev": true,
 			"requires": {
-				"has": "1.0.1",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
+				"has": "^1.0.1",
+				"postcss": "^5.0.10",
+				"postcss-value-parser": "^3.1.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					},
 					"dependencies": {
 						"supports-color": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+							"dev": true
 						}
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
 				},
 				"postcss": {
 					"version": "5.2.18",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
 					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"dev": true,
 					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.3",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
+						"chalk": "^1.1.3",
+						"js-base64": "^2.1.9",
+						"source-map": "^0.5.6",
+						"supports-color": "^3.2.3"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -6668,61 +7487,69 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
 			"integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
+			"dev": true,
 			"requires": {
-				"postcss": "5.2.18"
+				"postcss": "^5.0.4"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					},
 					"dependencies": {
 						"supports-color": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+							"dev": true
 						}
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
 				},
 				"postcss": {
 					"version": "5.2.18",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
 					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"dev": true,
 					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.3",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
+						"chalk": "^1.1.3",
+						"js-base64": "^2.1.9",
+						"source-map": "^0.5.6",
+						"supports-color": "^3.2.3"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -6731,74 +7558,83 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
 			"integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
+			"dev": true,
 			"requires": {
-				"browserslist": "1.7.7",
-				"caniuse-api": "1.6.1",
-				"postcss": "5.2.18",
-				"postcss-selector-parser": "2.2.3",
-				"vendors": "1.0.2"
+				"browserslist": "^1.5.2",
+				"caniuse-api": "^1.5.2",
+				"postcss": "^5.0.4",
+				"postcss-selector-parser": "^2.2.2",
+				"vendors": "^1.0.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"browserslist": {
 					"version": "1.7.7",
 					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
 					"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+					"dev": true,
 					"requires": {
-						"caniuse-db": "1.0.30000830",
-						"electron-to-chromium": "1.3.42"
+						"caniuse-db": "^1.0.30000639",
+						"electron-to-chromium": "^1.2.7"
 					}
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					},
 					"dependencies": {
 						"supports-color": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+							"dev": true
 						}
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
 				},
 				"postcss": {
 					"version": "5.2.18",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
 					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"dev": true,
 					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.3",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
+						"chalk": "^1.1.3",
+						"js-base64": "^2.1.9",
+						"source-map": "^0.5.6",
+						"supports-color": "^3.2.3"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -6806,69 +7642,78 @@
 		"postcss-message-helpers": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
-			"integrity": "sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4="
+			"integrity": "sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4=",
+			"dev": true
 		},
 		"postcss-minify-font-values": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
 			"integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
+			"dev": true,
 			"requires": {
-				"object-assign": "4.1.1",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
+				"object-assign": "^4.0.1",
+				"postcss": "^5.0.4",
+				"postcss-value-parser": "^3.0.2"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					},
 					"dependencies": {
 						"supports-color": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+							"dev": true
 						}
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
 				},
 				"postcss": {
 					"version": "5.2.18",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
 					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"dev": true,
 					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.3",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
+						"chalk": "^1.1.3",
+						"js-base64": "^2.1.9",
+						"source-map": "^0.5.6",
+						"supports-color": "^3.2.3"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -6877,62 +7722,70 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
 			"integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
+			"dev": true,
 			"requires": {
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
+				"postcss": "^5.0.12",
+				"postcss-value-parser": "^3.3.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					},
 					"dependencies": {
 						"supports-color": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+							"dev": true
 						}
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
 				},
 				"postcss": {
 					"version": "5.2.18",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
 					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"dev": true,
 					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.3",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
+						"chalk": "^1.1.3",
+						"js-base64": "^2.1.9",
+						"source-map": "^0.5.6",
+						"supports-color": "^3.2.3"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -6941,64 +7794,72 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
 			"integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
+			"dev": true,
 			"requires": {
-				"alphanum-sort": "1.0.2",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0",
-				"uniqs": "2.0.0"
+				"alphanum-sort": "^1.0.1",
+				"postcss": "^5.0.2",
+				"postcss-value-parser": "^3.0.2",
+				"uniqs": "^2.0.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					},
 					"dependencies": {
 						"supports-color": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+							"dev": true
 						}
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
 				},
 				"postcss": {
 					"version": "5.2.18",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
 					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"dev": true,
 					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.3",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
+						"chalk": "^1.1.3",
+						"js-base64": "^2.1.9",
+						"source-map": "^0.5.6",
+						"supports-color": "^3.2.3"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -7007,64 +7868,72 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
 			"integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
+			"dev": true,
 			"requires": {
-				"alphanum-sort": "1.0.2",
-				"has": "1.0.1",
-				"postcss": "5.2.18",
-				"postcss-selector-parser": "2.2.3"
+				"alphanum-sort": "^1.0.2",
+				"has": "^1.0.1",
+				"postcss": "^5.0.14",
+				"postcss-selector-parser": "^2.0.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					},
 					"dependencies": {
 						"supports-color": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+							"dev": true
 						}
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
 				},
 				"postcss": {
 					"version": "5.2.18",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
 					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"dev": true,
 					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.3",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
+						"chalk": "^1.1.3",
+						"js-base64": "^2.1.9",
+						"source-map": "^0.5.6",
+						"supports-color": "^3.2.3"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -7073,64 +7942,72 @@
 			"version": "0.7.1",
 			"resolved": "https://registry.npmjs.org/postcss-modules/-/postcss-modules-0.7.1.tgz",
 			"integrity": "sha1-yjViyi6WlglfG8ggupdsPP6WkIY=",
+			"dev": true,
 			"requires": {
-				"css-modules-loader-core": "1.1.0",
-				"generic-names": "1.0.3",
-				"postcss": "5.2.18",
-				"string-hash": "1.1.3"
+				"css-modules-loader-core": "^1.0.1",
+				"generic-names": "^1.0.2",
+				"postcss": "^5.2.8",
+				"string-hash": "^1.1.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					},
 					"dependencies": {
 						"supports-color": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+							"dev": true
 						}
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
 				},
 				"postcss": {
 					"version": "5.2.18",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
 					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"dev": true,
 					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.3",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
+						"chalk": "^1.1.3",
+						"js-base64": "^2.1.9",
+						"source-map": "^0.5.6",
+						"supports-color": "^3.2.3"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -7139,88 +8016,99 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
 			"integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
+			"dev": true,
 			"requires": {
-				"css-selector-tokenizer": "0.7.0",
-				"postcss": "6.0.21"
+				"css-selector-tokenizer": "^0.7.0",
+				"postcss": "^6.0.1"
 			}
 		},
 		"postcss-modules-scope": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
 			"integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
+			"dev": true,
 			"requires": {
-				"css-selector-tokenizer": "0.7.0",
-				"postcss": "6.0.21"
+				"css-selector-tokenizer": "^0.7.0",
+				"postcss": "^6.0.1"
 			}
 		},
 		"postcss-modules-values": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
 			"integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
+			"dev": true,
 			"requires": {
-				"icss-replace-symbols": "1.1.0",
-				"postcss": "6.0.21"
+				"icss-replace-symbols": "^1.1.0",
+				"postcss": "^6.0.1"
 			}
 		},
 		"postcss-normalize-charset": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
 			"integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
+			"dev": true,
 			"requires": {
-				"postcss": "5.2.18"
+				"postcss": "^5.0.5"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					},
 					"dependencies": {
 						"supports-color": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+							"dev": true
 						}
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
 				},
 				"postcss": {
 					"version": "5.2.18",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
 					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"dev": true,
 					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.3",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
+						"chalk": "^1.1.3",
+						"js-base64": "^2.1.9",
+						"source-map": "^0.5.6",
+						"supports-color": "^3.2.3"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -7229,64 +8117,72 @@
 			"version": "3.0.8",
 			"resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
 			"integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
+			"dev": true,
 			"requires": {
-				"is-absolute-url": "2.1.0",
-				"normalize-url": "1.9.1",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
+				"is-absolute-url": "^2.0.0",
+				"normalize-url": "^1.4.0",
+				"postcss": "^5.0.14",
+				"postcss-value-parser": "^3.2.3"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					},
 					"dependencies": {
 						"supports-color": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+							"dev": true
 						}
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
 				},
 				"postcss": {
 					"version": "5.2.18",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
 					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"dev": true,
 					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.3",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
+						"chalk": "^1.1.3",
+						"js-base64": "^2.1.9",
+						"source-map": "^0.5.6",
+						"supports-color": "^3.2.3"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -7295,62 +8191,70 @@
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
 			"integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
+			"dev": true,
 			"requires": {
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
+				"postcss": "^5.0.4",
+				"postcss-value-parser": "^3.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					},
 					"dependencies": {
 						"supports-color": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+							"dev": true
 						}
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
 				},
 				"postcss": {
 					"version": "5.2.18",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
 					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"dev": true,
 					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.3",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
+						"chalk": "^1.1.3",
+						"js-base64": "^2.1.9",
+						"source-map": "^0.5.6",
+						"supports-color": "^3.2.3"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -7359,62 +8263,70 @@
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
 			"integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
+			"dev": true,
 			"requires": {
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
+				"postcss": "^5.0.4",
+				"postcss-value-parser": "^3.0.2"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					},
 					"dependencies": {
 						"supports-color": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+							"dev": true
 						}
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
 				},
 				"postcss": {
 					"version": "5.2.18",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
 					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"dev": true,
 					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.3",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
+						"chalk": "^1.1.3",
+						"js-base64": "^2.1.9",
+						"source-map": "^0.5.6",
+						"supports-color": "^3.2.3"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -7423,61 +8335,69 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
 			"integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
+			"dev": true,
 			"requires": {
-				"postcss": "5.2.18"
+				"postcss": "^5.0.4"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					},
 					"dependencies": {
 						"supports-color": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+							"dev": true
 						}
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
 				},
 				"postcss": {
 					"version": "5.2.18",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
 					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"dev": true,
 					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.3",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
+						"chalk": "^1.1.3",
+						"js-base64": "^2.1.9",
+						"source-map": "^0.5.6",
+						"supports-color": "^3.2.3"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -7486,63 +8406,71 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
 			"integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
+			"dev": true,
 			"requires": {
-				"has": "1.0.1",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
+				"has": "^1.0.1",
+				"postcss": "^5.0.8",
+				"postcss-value-parser": "^3.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					},
 					"dependencies": {
 						"supports-color": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+							"dev": true
 						}
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
 				},
 				"postcss": {
 					"version": "5.2.18",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
 					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"dev": true,
 					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.3",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
+						"chalk": "^1.1.3",
+						"js-base64": "^2.1.9",
+						"source-map": "^0.5.6",
+						"supports-color": "^3.2.3"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -7551,74 +8479,83 @@
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
 			"integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
+			"dev": true,
 			"requires": {
-				"flatten": "1.0.2",
-				"indexes-of": "1.0.1",
-				"uniq": "1.0.1"
+				"flatten": "^1.0.2",
+				"indexes-of": "^1.0.1",
+				"uniq": "^1.0.1"
 			}
 		},
 		"postcss-svgo": {
 			"version": "2.1.6",
 			"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
 			"integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
+			"dev": true,
 			"requires": {
-				"is-svg": "2.1.0",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0",
-				"svgo": "0.7.2"
+				"is-svg": "^2.0.0",
+				"postcss": "^5.0.14",
+				"postcss-value-parser": "^3.2.3",
+				"svgo": "^0.7.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					},
 					"dependencies": {
 						"supports-color": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+							"dev": true
 						}
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
 				},
 				"postcss": {
 					"version": "5.2.18",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
 					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"dev": true,
 					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.3",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
+						"chalk": "^1.1.3",
+						"js-base64": "^2.1.9",
+						"source-map": "^0.5.6",
+						"supports-color": "^3.2.3"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -7627,63 +8564,71 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
 			"integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
+			"dev": true,
 			"requires": {
-				"alphanum-sort": "1.0.2",
-				"postcss": "5.2.18",
-				"uniqs": "2.0.0"
+				"alphanum-sort": "^1.0.1",
+				"postcss": "^5.0.4",
+				"uniqs": "^2.0.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					},
 					"dependencies": {
 						"supports-color": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+							"dev": true
 						}
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
 				},
 				"postcss": {
 					"version": "5.2.18",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
 					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"dev": true,
 					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.3",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
+						"chalk": "^1.1.3",
+						"js-base64": "^2.1.9",
+						"source-map": "^0.5.6",
+						"supports-color": "^3.2.3"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -7691,69 +8636,78 @@
 		"postcss-value-parser": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
-			"integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU="
+			"integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU=",
+			"dev": true
 		},
 		"postcss-zindex": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
 			"integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
+			"dev": true,
 			"requires": {
-				"has": "1.0.1",
-				"postcss": "5.2.18",
-				"uniqs": "2.0.0"
+				"has": "^1.0.1",
+				"postcss": "^5.0.4",
+				"uniqs": "^2.0.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					},
 					"dependencies": {
 						"supports-color": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+							"dev": true
 						}
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
 				},
 				"postcss": {
 					"version": "5.2.18",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
 					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"dev": true,
 					"requires": {
-						"chalk": "1.1.3",
-						"js-base64": "2.4.3",
-						"source-map": "0.5.7",
-						"supports-color": "3.2.3"
+						"chalk": "^1.1.3",
+						"js-base64": "^2.1.9",
+						"source-map": "^0.5.6",
+						"supports-color": "^3.2.3"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -7761,118 +8715,134 @@
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"dev": true
 		},
 		"prepend-http": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+			"dev": true
 		},
 		"preserve": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+			"dev": true
 		},
 		"prettier": {
 			"version": "1.12.1",
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.12.1.tgz",
-			"integrity": "sha1-wa0g6APndJ+vkFpAnSNn4Gu+cyU="
+			"integrity": "sha1-wa0g6APndJ+vkFpAnSNn4Gu+cyU=",
+			"dev": true
 		},
 		"pretty-format": {
 			"version": "20.0.3",
 			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-20.0.3.tgz",
 			"integrity": "sha1-Ag41ClYKH+GpjcO+tsz/s4beixQ=",
+			"dev": true,
 			"requires": {
-				"ansi-regex": "2.1.1",
-				"ansi-styles": "3.2.1"
+				"ansi-regex": "^2.1.1",
+				"ansi-styles": "^3.0.0"
 			}
 		},
 		"pretty-ms": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-3.1.0.tgz",
 			"integrity": "sha1-6crJx2v27lL+lC3ZxsQhMVOxKIE=",
+			"dev": true,
 			"requires": {
-				"parse-ms": "1.0.1",
-				"plur": "2.1.2"
+				"parse-ms": "^1.0.0",
+				"plur": "^2.1.2"
 			}
 		},
 		"private": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+			"dev": true
 		},
 		"process-nextick-args": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+			"dev": true
 		},
 		"promise": {
 			"version": "7.3.1",
 			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
 			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
 			"requires": {
-				"asap": "2.0.6"
+				"asap": "~2.0.3"
 			}
 		},
 		"promise.series": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/promise.series/-/promise.series-0.2.0.tgz",
-			"integrity": "sha1-LMfr6Vn8OmYZwEq029yeRS2GS70="
+			"integrity": "sha1-LMfr6Vn8OmYZwEq029yeRS2GS70=",
+			"dev": true
 		},
 		"prop-types": {
 			"version": "15.6.1",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
 			"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
 			"requires": {
-				"fbjs": "0.8.16",
-				"loose-envify": "1.3.1",
-				"object-assign": "4.1.1"
+				"fbjs": "^0.8.16",
+				"loose-envify": "^1.3.1",
+				"object-assign": "^4.1.1"
 			}
 		},
 		"prr": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+			"dev": true
 		},
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+			"dev": true
 		},
 		"q": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+			"dev": true
 		},
 		"qs": {
 			"version": "6.5.1",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-			"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+			"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+			"dev": true
 		},
 		"query-string": {
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
 			"integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+			"dev": true,
 			"requires": {
-				"object-assign": "4.1.1",
-				"strict-uri-encode": "1.1.0"
+				"object-assign": "^4.1.0",
+				"strict-uri-encode": "^1.0.0"
 			}
 		},
 		"randomatic": {
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
 			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+			"dev": true,
 			"requires": {
-				"is-number": "3.0.0",
-				"kind-of": "4.0.0"
+				"is-number": "^3.0.0",
+				"kind-of": "^4.0.0"
 			},
 			"dependencies": {
 				"kind-of": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"dev": true,
 					"requires": {
-						"is-buffer": "1.1.6"
+						"is-buffer": "^1.1.5"
 					}
 				}
 			}
@@ -7882,10 +8852,10 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-16.3.2.tgz",
 			"integrity": "sha512-o5GPdkhciQ3cEph6qgvYB7LTOHw/GB0qRI6ZFNugj49qJCFfgHwVNjZ5u+b7nif4vOeMIOuYj3CeYe2IBD74lg==",
 			"requires": {
-				"fbjs": "0.8.16",
-				"loose-envify": "1.3.1",
-				"object-assign": "4.1.1",
-				"prop-types": "15.6.1"
+				"fbjs": "^0.8.16",
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.0"
 			}
 		},
 		"react-day-picker": {
@@ -7893,8 +8863,8 @@
 			"resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-6.2.1.tgz",
 			"integrity": "sha1-/CK4Cdt5I4bRRo0/RtclrZHgTbk=",
 			"requires": {
-				"object-assign": "4.1.1",
-				"prop-types": "15.6.1"
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.0"
 			}
 		},
 		"react-dom": {
@@ -7902,10 +8872,10 @@
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.3.2.tgz",
 			"integrity": "sha512-MMPko3zYncNrz/7gG17wJWUREZDvskZHXOwbttzl0F0L3wDmToyuETuo/r8Y5yvDejwYcRyWI1lvVBjLJWFwKA==",
 			"requires": {
-				"fbjs": "0.8.16",
-				"loose-envify": "1.3.1",
-				"object-assign": "4.1.1",
-				"prop-types": "15.6.1"
+				"fbjs": "^0.8.16",
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.0"
 			}
 		},
 		"react-transition-group": {
@@ -7913,251 +8883,280 @@
 			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.3.1.tgz",
 			"integrity": "sha512-hu4/LAOFSKjWt1+1hgnOv3ldxmt6lvZGTWz4KUkFrqzXrNDIVSu6txIcPszw7PNduR8en9YTN55JLRyd/L1ZiQ==",
 			"requires": {
-				"dom-helpers": "3.3.1",
-				"loose-envify": "1.3.1",
-				"prop-types": "15.6.1"
+				"dom-helpers": "^3.3.1",
+				"loose-envify": "^1.3.1",
+				"prop-types": "^15.6.1"
 			}
 		},
 		"readable-stream": {
 			"version": "2.3.6",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+			"dev": true,
 			"requires": {
-				"core-util-is": "1.0.2",
-				"inherits": "2.0.3",
-				"isarray": "1.0.0",
-				"process-nextick-args": "2.0.0",
-				"safe-buffer": "5.1.1",
-				"string_decoder": "1.1.1",
-				"util-deprecate": "1.0.2"
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
 			}
 		},
 		"readdirp": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
 			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+			"dev": true,
 			"optional": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"minimatch": "3.0.4",
-				"readable-stream": "2.3.6",
-				"set-immediate-shim": "1.0.1"
+				"graceful-fs": "^4.1.2",
+				"minimatch": "^3.0.2",
+				"readable-stream": "^2.0.2",
+				"set-immediate-shim": "^1.0.1"
 			}
 		},
 		"reduce-css-calc": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
 			"integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
+			"dev": true,
 			"requires": {
-				"balanced-match": "0.4.2",
-				"math-expression-evaluator": "1.2.17",
-				"reduce-function-call": "1.0.2"
+				"balanced-match": "^0.4.2",
+				"math-expression-evaluator": "^1.2.14",
+				"reduce-function-call": "^1.0.1"
 			}
 		},
 		"reduce-function-call": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
 			"integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
+			"dev": true,
 			"requires": {
-				"balanced-match": "0.4.2"
+				"balanced-match": "^0.4.2"
 			}
 		},
 		"regenerate": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-			"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
+			"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
+			"dev": true
 		},
 		"regenerator-runtime": {
 			"version": "0.11.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+			"dev": true
 		},
 		"regenerator-transform": {
 			"version": "0.10.1",
 			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
 			"integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"private": "0.1.8"
+				"babel-runtime": "^6.18.0",
+				"babel-types": "^6.19.0",
+				"private": "^0.1.6"
 			}
 		},
 		"regex-cache": {
 			"version": "0.4.4",
 			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+			"dev": true,
 			"requires": {
-				"is-equal-shallow": "0.1.3"
+				"is-equal-shallow": "^0.1.3"
 			}
 		},
 		"regex-not": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
 			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+			"dev": true,
 			"requires": {
-				"extend-shallow": "3.0.2",
-				"safe-regex": "1.1.0"
+				"extend-shallow": "^3.0.2",
+				"safe-regex": "^1.1.0"
 			}
 		},
 		"regexpu-core": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
 			"integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
+			"dev": true,
 			"requires": {
-				"regenerate": "1.3.3",
-				"regjsgen": "0.2.0",
-				"regjsparser": "0.1.5"
+				"regenerate": "^1.2.1",
+				"regjsgen": "^0.2.0",
+				"regjsparser": "^0.1.4"
 			}
 		},
 		"regjsgen": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+			"dev": true
 		},
 		"regjsparser": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+			"dev": true,
 			"requires": {
-				"jsesc": "0.5.0"
+				"jsesc": "~0.5.0"
 			}
 		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+			"dev": true
 		},
 		"repeat-element": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+			"dev": true
 		},
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+			"dev": true
 		},
 		"repeating": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+			"dev": true,
 			"requires": {
-				"is-finite": "1.0.2"
+				"is-finite": "^1.0.0"
 			}
 		},
 		"request": {
 			"version": "2.85.0",
 			"resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
 			"integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+			"dev": true,
 			"requires": {
-				"aws-sign2": "0.7.0",
-				"aws4": "1.7.0",
-				"caseless": "0.12.0",
-				"combined-stream": "1.0.6",
-				"extend": "3.0.1",
-				"forever-agent": "0.6.1",
-				"form-data": "2.3.2",
-				"har-validator": "5.0.3",
-				"hawk": "6.0.2",
-				"http-signature": "1.2.0",
-				"is-typedarray": "1.0.0",
-				"isstream": "0.1.2",
-				"json-stringify-safe": "5.0.1",
-				"mime-types": "2.1.18",
-				"oauth-sign": "0.8.2",
-				"performance-now": "2.1.0",
-				"qs": "6.5.1",
-				"safe-buffer": "5.1.1",
-				"stringstream": "0.0.5",
-				"tough-cookie": "2.3.4",
-				"tunnel-agent": "0.6.0",
-				"uuid": "3.2.1"
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.6.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.5",
+				"extend": "~3.0.1",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.1",
+				"har-validator": "~5.0.3",
+				"hawk": "~6.0.2",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.17",
+				"oauth-sign": "~0.8.2",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.1",
+				"safe-buffer": "^5.1.1",
+				"stringstream": "~0.0.5",
+				"tough-cookie": "~2.3.3",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.1.0"
 			}
 		},
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+			"dev": true
 		},
 		"require-from-string": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
-			"integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg="
+			"integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
+			"dev": true
 		},
 		"require-main-filename": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+			"dev": true
 		},
 		"require-relative": {
 			"version": "0.8.7",
 			"resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
-			"integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4="
+			"integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
+			"dev": true
 		},
 		"reserved-words": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/reserved-words/-/reserved-words-0.1.2.tgz",
-			"integrity": "sha1-AKCUD5jNUBrqqsMWQR2a3FKzGrE="
+			"integrity": "sha1-AKCUD5jNUBrqqsMWQR2a3FKzGrE=",
+			"dev": true
 		},
 		"resolve": {
 			"version": "1.7.1",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
 			"integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+			"dev": true,
 			"requires": {
-				"path-parse": "1.0.5"
+				"path-parse": "^1.0.5"
 			}
 		},
 		"resolve-url": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+			"dev": true
 		},
 		"ret": {
 			"version": "0.1.15",
 			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+			"dev": true
 		},
 		"right-align": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
 			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+			"dev": true,
 			"optional": true,
 			"requires": {
-				"align-text": "0.1.4"
+				"align-text": "^0.1.1"
 			}
 		},
 		"rimraf": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+			"dev": true,
 			"requires": {
-				"glob": "7.1.2"
+				"glob": "^7.0.5"
 			}
 		},
 		"rollup": {
 			"version": "0.57.1",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-0.57.1.tgz",
 			"integrity": "sha512-I18GBqP0qJoJC1K1osYjreqA8VAKovxuI3I81RSk0Dmr4TgloI0tAULjZaox8OsJ+n7XRrhH6i0G2By/pj1LCA==",
+			"dev": true,
 			"requires": {
-				"@types/acorn": "4.0.3",
-				"acorn": "5.5.3",
-				"acorn-dynamic-import": "3.0.0",
-				"date-time": "2.1.0",
-				"is-reference": "1.1.0",
-				"locate-character": "2.0.5",
-				"pretty-ms": "3.1.0",
-				"require-relative": "0.8.7",
-				"rollup-pluginutils": "2.0.1",
-				"signal-exit": "3.0.2",
-				"sourcemap-codec": "1.4.1"
+				"@types/acorn": "^4.0.3",
+				"acorn": "^5.5.3",
+				"acorn-dynamic-import": "^3.0.0",
+				"date-time": "^2.1.0",
+				"is-reference": "^1.1.0",
+				"locate-character": "^2.0.5",
+				"pretty-ms": "^3.1.0",
+				"require-relative": "^0.8.7",
+				"rollup-pluginutils": "^2.0.1",
+				"signal-exit": "^3.0.2",
+				"sourcemap-codec": "^1.4.1"
 			},
 			"dependencies": {
 				"acorn-dynamic-import": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
 					"integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
+					"dev": true,
 					"requires": {
-						"acorn": "5.5.3"
+						"acorn": "^5.0.0"
 					}
 				}
 			}
@@ -8166,22 +9165,25 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-3.0.4.tgz",
 			"integrity": "sha512-TGhQbliTZnRoUhd2214K3r4KJUBu9J1DPzcrAnkluVXOVrveU9OvAaYQ16KyOmujAoq+LMC1+x6YF2xBrU7t+g==",
+			"dev": true,
 			"requires": {
-				"rollup-pluginutils": "1.5.2"
+				"rollup-pluginutils": "^1.5.0"
 			},
 			"dependencies": {
 				"estree-walker": {
 					"version": "0.2.1",
 					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.2.1.tgz",
-					"integrity": "sha1-va/oCVOD2EFNXcLs9MkXO225QS4="
+					"integrity": "sha1-va/oCVOD2EFNXcLs9MkXO225QS4=",
+					"dev": true
 				},
 				"rollup-pluginutils": {
 					"version": "1.5.2",
 					"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz",
 					"integrity": "sha1-HhVud4+UtyVb+hs9AXi+j1xVJAg=",
+					"dev": true,
 					"requires": {
-						"estree-walker": "0.2.1",
-						"minimatch": "3.0.4"
+						"estree-walker": "^0.2.1",
+						"minimatch": "^3.0.2"
 					}
 				}
 			}
@@ -8190,17 +9192,19 @@
 			"version": "9.1.3",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-9.1.3.tgz",
 			"integrity": "sha512-g91ZZKZwTW7F7vL6jMee38I8coj/Q9GBdTmXXeFL7ldgC1Ky5WJvHgbKlAiXXTh762qvohhExwUgeQGFh9suGg==",
+			"dev": true,
 			"requires": {
-				"estree-walker": "0.5.1",
-				"magic-string": "0.22.5",
-				"resolve": "1.7.1",
-				"rollup-pluginutils": "2.0.1"
+				"estree-walker": "^0.5.1",
+				"magic-string": "^0.22.4",
+				"resolve": "^1.5.0",
+				"rollup-pluginutils": "^2.0.1"
 			},
 			"dependencies": {
 				"estree-walker": {
 					"version": "0.5.1",
 					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.1.tgz",
-					"integrity": "sha512-7HgCgz1axW7w5aOvgOQkoR1RMBkllygJrssU3BvymKQ95lxXYv6Pon17fBRDm9qhkvXZGijOULoSF9ShOk/ZLg=="
+					"integrity": "sha512-7HgCgz1axW7w5aOvgOQkoR1RMBkllygJrssU3BvymKQ95lxXYv6Pon17fBRDm9qhkvXZGijOULoSF9ShOk/ZLg==",
+					"dev": true
 				}
 			}
 		},
@@ -8208,16 +9212,18 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.3.0.tgz",
 			"integrity": "sha512-9zHGr3oUJq6G+X0oRMYlzid9fXicBdiydhwGChdyeNRGPcN/majtegApRKHLR5drboUvEWU+QeUmGTyEZQs3WA==",
+			"dev": true,
 			"requires": {
-				"builtin-modules": "2.0.0",
-				"is-module": "1.0.0",
-				"resolve": "1.7.1"
+				"builtin-modules": "^2.0.0",
+				"is-module": "^1.0.0",
+				"resolve": "^1.1.6"
 			},
 			"dependencies": {
 				"builtin-modules": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-2.0.0.tgz",
-					"integrity": "sha512-3U5kUA5VPsRUA3nofm/BXX7GVHKfxz0hOBAPxXrIvHzlDRkQVqEn6yi8QJegxl4LzOHLdvb7XF5dVawa/VVYBg=="
+					"integrity": "sha512-3U5kUA5VPsRUA3nofm/BXX7GVHKfxz0hOBAPxXrIvHzlDRkQVqEn6yi8QJegxl4LzOHLdvb7XF5dVawa/VVYBg==",
+					"dev": true
 				}
 			}
 		},
@@ -8225,56 +9231,61 @@
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-postcss/-/rollup-plugin-postcss-1.6.1.tgz",
 			"integrity": "sha512-I0z5F3S9PgaIkNKwJ9O98eQBT1ZXvtIAXTtqBTe1mETGWf/4WijVhw2f+aETGMbuEM7iJqyP0ZCP7oFyMzkZwQ==",
+			"dev": true,
 			"requires": {
-				"@vue/component-compiler-utils": "1.1.0",
-				"chalk": "2.4.0",
-				"concat-with-sourcemaps": "1.0.5",
-				"cssnano": "3.10.0",
-				"fs-extra": "5.0.0",
-				"import-cwd": "2.1.0",
-				"pify": "3.0.0",
-				"postcss": "6.0.21",
-				"postcss-load-config": "1.2.0",
-				"postcss-modules": "1.1.0",
-				"promise.series": "0.2.0",
-				"reserved-words": "0.1.2",
-				"resolve": "1.7.1",
-				"rollup-pluginutils": "2.0.1",
-				"style-inject": "0.3.0"
+				"@vue/component-compiler-utils": "^1.0.0",
+				"chalk": "^2.0.0",
+				"concat-with-sourcemaps": "^1.0.5",
+				"cssnano": "^3.10.0",
+				"fs-extra": "^5.0.0",
+				"import-cwd": "^2.1.0",
+				"pify": "^3.0.0",
+				"postcss": "^6.0.21",
+				"postcss-load-config": "^1.2.0",
+				"postcss-modules": "^1.1.0",
+				"promise.series": "^0.2.0",
+				"reserved-words": "^0.1.2",
+				"resolve": "^1.5.0",
+				"rollup-pluginutils": "^2.0.1",
+				"style-inject": "^0.3.0"
 			},
 			"dependencies": {
 				"fs-extra": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
 					"integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"jsonfile": "4.0.0",
-						"universalify": "0.1.1"
+						"graceful-fs": "^4.1.2",
+						"jsonfile": "^4.0.0",
+						"universalify": "^0.1.0"
 					}
 				},
 				"jsonfile": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
 					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11"
+						"graceful-fs": "^4.1.6"
 					}
 				},
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
 				},
 				"postcss-modules": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/postcss-modules/-/postcss-modules-1.1.0.tgz",
 					"integrity": "sha512-aCsAgyllAsHfzEJI+gIRu03k3hD2/mOqQ5cZKRNbz7V0YeBkoVmmkNaXRm4rMUc1grbBGlNs0EGw0I7tyxi0QQ==",
+					"dev": true,
 					"requires": {
-						"css-modules-loader-core": "1.1.0",
-						"generic-names": "1.0.3",
-						"postcss": "6.0.21",
-						"string-hash": "1.1.3"
+						"css-modules-loader-core": "^1.1.0",
+						"generic-names": "^1.0.2",
+						"postcss": "^6.0.1",
+						"string-hash": "^1.1.1"
 					}
 				}
 			}
@@ -8283,22 +9294,25 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/rollup-plugin-uglify/-/rollup-plugin-uglify-3.0.0.tgz",
 			"integrity": "sha512-dehLu9eRRoV4l09aC+ySntRw1OAfoyKdbk8Nelblj03tHoynkSybqyEpgavemi1LBOH6S1vzI58/mpxkZIe1iQ==",
+			"dev": true,
 			"requires": {
-				"uglify-es": "3.3.9"
+				"uglify-es": "^3.3.7"
 			},
 			"dependencies": {
 				"commander": {
 					"version": "2.13.0",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-					"integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
+					"integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+					"dev": true
 				},
 				"uglify-es": {
 					"version": "3.3.9",
 					"resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
 					"integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
+					"dev": true,
 					"requires": {
-						"commander": "2.13.0",
-						"source-map": "0.6.1"
+						"commander": "~2.13.0",
+						"source-map": "~0.6.1"
 					}
 				}
 			}
@@ -8307,81 +9321,90 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.0.1.tgz",
 			"integrity": "sha1-fslbNXP2VDpGpkYb2afFRFJdD8A=",
+			"dev": true,
 			"requires": {
-				"estree-walker": "0.3.1",
-				"micromatch": "2.3.11"
+				"estree-walker": "^0.3.0",
+				"micromatch": "^2.3.11"
 			},
 			"dependencies": {
 				"arr-diff": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+					"dev": true,
 					"requires": {
-						"arr-flatten": "1.1.0"
+						"arr-flatten": "^1.0.1"
 					}
 				},
 				"array-unique": {
 					"version": "0.2.1",
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+					"dev": true
 				},
 				"braces": {
 					"version": "1.8.5",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+					"dev": true,
 					"requires": {
-						"expand-range": "1.8.2",
-						"preserve": "0.2.0",
-						"repeat-element": "1.1.2"
+						"expand-range": "^1.8.1",
+						"preserve": "^0.2.0",
+						"repeat-element": "^1.1.2"
 					}
 				},
 				"expand-brackets": {
 					"version": "0.1.5",
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+					"dev": true,
 					"requires": {
-						"is-posix-bracket": "0.1.1"
+						"is-posix-bracket": "^0.1.0"
 					}
 				},
 				"extglob": {
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+					"dev": true,
 					"requires": {
-						"is-extglob": "1.0.0"
+						"is-extglob": "^1.0.0"
 					}
 				},
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
 					"requires": {
-						"is-extglob": "1.0.0"
+						"is-extglob": "^1.0.0"
 					}
 				},
 				"micromatch": {
 					"version": "2.3.11",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+					"dev": true,
 					"requires": {
-						"arr-diff": "2.0.0",
-						"array-unique": "0.2.1",
-						"braces": "1.8.5",
-						"expand-brackets": "0.1.5",
-						"extglob": "0.3.2",
-						"filename-regex": "2.0.1",
-						"is-extglob": "1.0.0",
-						"is-glob": "2.0.1",
-						"kind-of": "3.2.2",
-						"normalize-path": "2.1.1",
-						"object.omit": "2.0.1",
-						"parse-glob": "3.0.4",
-						"regex-cache": "0.4.4"
+						"arr-diff": "^2.0.0",
+						"array-unique": "^0.2.1",
+						"braces": "^1.8.2",
+						"expand-brackets": "^0.1.4",
+						"extglob": "^0.3.1",
+						"filename-regex": "^2.0.0",
+						"is-extglob": "^1.0.0",
+						"is-glob": "^2.0.1",
+						"kind-of": "^3.0.2",
+						"normalize-path": "^2.0.1",
+						"object.omit": "^2.0.0",
+						"parse-glob": "^3.0.4",
+						"regex-cache": "^0.4.2"
 					}
 				}
 			}
@@ -8389,14 +9412,16 @@
 		"safe-buffer": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+			"dev": true
 		},
 		"safe-regex": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+			"dev": true,
 			"requires": {
-				"ret": "0.1.15"
+				"ret": "~0.1.10"
 			}
 		},
 		"safer-buffer": {
@@ -8408,76 +9433,85 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/sane/-/sane-1.6.0.tgz",
 			"integrity": "sha1-lhDEUjB6E10pwf3+JUcDQYDEZ3U=",
+			"dev": true,
 			"requires": {
-				"anymatch": "1.3.2",
-				"exec-sh": "0.2.1",
-				"fb-watchman": "1.9.2",
-				"minimatch": "3.0.4",
-				"minimist": "1.2.0",
-				"walker": "1.0.7",
-				"watch": "0.10.0"
+				"anymatch": "^1.3.0",
+				"exec-sh": "^0.2.0",
+				"fb-watchman": "^1.8.0",
+				"minimatch": "^3.0.2",
+				"minimist": "^1.1.1",
+				"walker": "~1.0.5",
+				"watch": "~0.10.0"
 			},
 			"dependencies": {
 				"anymatch": {
 					"version": "1.3.2",
 					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
 					"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+					"dev": true,
 					"requires": {
-						"micromatch": "2.3.11",
-						"normalize-path": "2.1.1"
+						"micromatch": "^2.1.5",
+						"normalize-path": "^2.0.0"
 					}
 				},
 				"arr-diff": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+					"dev": true,
 					"requires": {
-						"arr-flatten": "1.1.0"
+						"arr-flatten": "^1.0.1"
 					}
 				},
 				"array-unique": {
 					"version": "0.2.1",
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+					"dev": true
 				},
 				"braces": {
 					"version": "1.8.5",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+					"dev": true,
 					"requires": {
-						"expand-range": "1.8.2",
-						"preserve": "0.2.0",
-						"repeat-element": "1.1.2"
+						"expand-range": "^1.8.1",
+						"preserve": "^0.2.0",
+						"repeat-element": "^1.1.2"
 					}
 				},
 				"bser": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/bser/-/bser-1.0.2.tgz",
 					"integrity": "sha1-OBEWlwsqbe6lZG3RXdcnhES1YWk=",
+					"dev": true,
 					"requires": {
-						"node-int64": "0.4.0"
+						"node-int64": "^0.4.0"
 					}
 				},
 				"expand-brackets": {
 					"version": "0.1.5",
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+					"dev": true,
 					"requires": {
-						"is-posix-bracket": "0.1.1"
+						"is-posix-bracket": "^0.1.0"
 					}
 				},
 				"extglob": {
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+					"dev": true,
 					"requires": {
-						"is-extglob": "1.0.0"
+						"is-extglob": "^1.0.0"
 					}
 				},
 				"fb-watchman": {
 					"version": "1.9.2",
 					"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-1.9.2.tgz",
 					"integrity": "sha1-okz0eCf4LTj7Waaa1wt247auc4M=",
+					"dev": true,
 					"requires": {
 						"bser": "1.0.2"
 					}
@@ -8485,40 +9519,44 @@
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
 					"requires": {
-						"is-extglob": "1.0.0"
+						"is-extglob": "^1.0.0"
 					}
 				},
 				"micromatch": {
 					"version": "2.3.11",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+					"dev": true,
 					"requires": {
-						"arr-diff": "2.0.0",
-						"array-unique": "0.2.1",
-						"braces": "1.8.5",
-						"expand-brackets": "0.1.5",
-						"extglob": "0.3.2",
-						"filename-regex": "2.0.1",
-						"is-extglob": "1.0.0",
-						"is-glob": "2.0.1",
-						"kind-of": "3.2.2",
-						"normalize-path": "2.1.1",
-						"object.omit": "2.0.1",
-						"parse-glob": "3.0.4",
-						"regex-cache": "0.4.4"
+						"arr-diff": "^2.0.0",
+						"array-unique": "^0.2.1",
+						"braces": "^1.8.2",
+						"expand-brackets": "^0.1.4",
+						"extglob": "^0.3.1",
+						"filename-regex": "^2.0.0",
+						"is-extglob": "^1.0.0",
+						"is-glob": "^2.0.1",
+						"kind-of": "^3.0.2",
+						"normalize-path": "^2.0.1",
+						"object.omit": "^2.0.0",
+						"parse-glob": "^3.0.4",
+						"regex-cache": "^0.4.2"
 					}
 				},
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
 				}
 			}
 		},
@@ -8526,133 +9564,147 @@
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
 			"integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
+			"dev": true,
 			"requires": {
-				"glob": "7.1.2",
-				"lodash": "4.17.10",
-				"scss-tokenizer": "0.2.3",
-				"yargs": "7.1.0"
+				"glob": "^7.0.0",
+				"lodash": "^4.0.0",
+				"scss-tokenizer": "^0.2.3",
+				"yargs": "^7.0.0"
 			},
 			"dependencies": {
 				"camelcase": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+					"dev": true
 				},
 				"cliui": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"dev": true,
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wrap-ansi": "2.1.0"
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wrap-ansi": "^2.0.0"
 					}
 				},
 				"find-up": {
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"dev": true,
 					"requires": {
-						"path-exists": "2.1.0",
-						"pinkie-promise": "2.0.1"
+						"path-exists": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"load-json-file": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
 					}
 				},
 				"os-locale": {
 					"version": "1.4.0",
 					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+					"dev": true,
 					"requires": {
-						"lcid": "1.0.0"
+						"lcid": "^1.0.0"
 					}
 				},
 				"path-exists": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"dev": true,
 					"requires": {
-						"pinkie-promise": "2.0.1"
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"path-type": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"read-pkg": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+					"dev": true,
 					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
 					}
 				},
 				"read-pkg-up": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+					"dev": true,
 					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
 					}
 				},
 				"strip-bom": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
 					"requires": {
-						"is-utf8": "0.2.1"
+						"is-utf8": "^0.2.0"
 					}
 				},
 				"which-module": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+					"dev": true
 				},
 				"yargs": {
 					"version": "7.1.0",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
 					"integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+					"dev": true,
 					"requires": {
-						"camelcase": "3.0.0",
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "1.4.0",
-						"read-pkg-up": "1.0.1",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "1.0.2",
-						"which-module": "1.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "5.0.0"
+						"camelcase": "^3.0.0",
+						"cliui": "^3.2.0",
+						"decamelize": "^1.1.1",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^1.4.0",
+						"read-pkg-up": "^1.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^1.0.2",
+						"which-module": "^1.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^5.0.0"
 					}
 				},
 				"yargs-parser": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
 					"integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+					"dev": true,
 					"requires": {
-						"camelcase": "3.0.0"
+						"camelcase": "^3.0.0"
 					}
 				}
 			}
@@ -8660,23 +9712,26 @@
 		"sax": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+			"dev": true
 		},
 		"scss-tokenizer": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
 			"integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
+			"dev": true,
 			"requires": {
-				"js-base64": "2.4.3",
-				"source-map": "0.4.4"
+				"js-base64": "^2.1.8",
+				"source-map": "^0.4.2"
 			},
 			"dependencies": {
 				"source-map": {
 					"version": "0.4.4",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
 					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+					"dev": true,
 					"requires": {
-						"amdefine": "1.0.1"
+						"amdefine": ">=0.0.4"
 					}
 				}
 			}
@@ -8684,45 +9739,51 @@
 		"semver": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+			"dev": true
 		},
 		"sentence-case": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-2.1.1.tgz",
 			"integrity": "sha1-H24t2jnBaL+S0T+G1KkYkz9mftQ=",
+			"dev": true,
 			"requires": {
-				"no-case": "2.3.2",
-				"upper-case-first": "1.1.2"
+				"no-case": "^2.2.0",
+				"upper-case-first": "^1.1.2"
 			}
 		},
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+			"dev": true
 		},
 		"set-immediate-shim": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
 			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+			"dev": true,
 			"optional": true
 		},
 		"set-value": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
 			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+			"dev": true,
 			"requires": {
-				"extend-shallow": "2.0.1",
-				"is-extendable": "0.1.1",
-				"is-plain-object": "2.0.4",
-				"split-string": "3.1.0"
+				"extend-shallow": "^2.0.1",
+				"is-extendable": "^0.1.1",
+				"is-plain-object": "^2.0.3",
+				"split-string": "^3.0.1"
 			},
 			"dependencies": {
 				"extend-shallow": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
 					"requires": {
-						"is-extendable": "0.1.1"
+						"is-extendable": "^0.1.0"
 					}
 				}
 			}
@@ -8735,61 +9796,69 @@
 		"shellwords": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
+			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+			"dev": true
 		},
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+			"dev": true
 		},
 		"slash": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+			"dev": true
 		},
 		"snake-case": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/snake-case/-/snake-case-2.1.0.tgz",
 			"integrity": "sha1-Qb2xtz8w7GagTU4srRt2OH1NbZ8=",
+			"dev": true,
 			"requires": {
-				"no-case": "2.3.2"
+				"no-case": "^2.2.0"
 			}
 		},
 		"snapdragon": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
 			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+			"dev": true,
 			"requires": {
-				"base": "0.11.2",
-				"debug": "2.6.9",
-				"define-property": "0.2.5",
-				"extend-shallow": "2.0.1",
-				"map-cache": "0.2.2",
-				"source-map": "0.5.7",
-				"source-map-resolve": "0.5.1",
-				"use": "3.1.0"
+				"base": "^0.11.1",
+				"debug": "^2.2.0",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"map-cache": "^0.2.2",
+				"source-map": "^0.5.6",
+				"source-map-resolve": "^0.5.0",
+				"use": "^3.1.0"
 			},
 			"dependencies": {
 				"define-property": {
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
 					}
 				},
 				"extend-shallow": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
 					"requires": {
-						"is-extendable": "0.1.1"
+						"is-extendable": "^0.1.0"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				}
 			}
 		},
@@ -8797,50 +9866,56 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
 			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+			"dev": true,
 			"requires": {
-				"define-property": "1.0.0",
-				"isobject": "3.0.1",
-				"snapdragon-util": "3.0.1"
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.0",
+				"snapdragon-util": "^3.0.1"
 			},
 			"dependencies": {
 				"define-property": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
 					"requires": {
-						"is-descriptor": "1.0.2"
+						"is-descriptor": "^1.0.0"
 					}
 				},
 				"is-accessor-descriptor": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-data-descriptor": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-descriptor": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
 					}
 				},
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
 				}
 			}
 		},
@@ -8848,139 +9923,157 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
 			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.2.0"
 			}
 		},
 		"sntp": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
 			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+			"dev": true,
 			"requires": {
-				"hoek": "4.2.1"
+				"hoek": "4.x.x"
 			}
 		},
 		"sort-keys": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
 			"integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+			"dev": true,
 			"requires": {
-				"is-plain-obj": "1.1.0"
+				"is-plain-obj": "^1.0.0"
 			}
 		},
 		"source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true
 		},
 		"source-map-resolve": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
 			"integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+			"dev": true,
 			"requires": {
-				"atob": "2.1.0",
-				"decode-uri-component": "0.2.0",
-				"resolve-url": "0.2.1",
-				"source-map-url": "0.4.0",
-				"urix": "0.1.0"
+				"atob": "^2.0.0",
+				"decode-uri-component": "^0.2.0",
+				"resolve-url": "^0.2.1",
+				"source-map-url": "^0.4.0",
+				"urix": "^0.1.0"
 			}
 		},
 		"source-map-support": {
 			"version": "0.4.18",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
 			"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+			"dev": true,
 			"requires": {
-				"source-map": "0.5.7"
+				"source-map": "^0.5.6"
 			},
 			"dependencies": {
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				}
 			}
 		},
 		"source-map-url": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+			"dev": true
 		},
 		"sourcemap-codec": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.1.tgz",
-			"integrity": "sha512-hX1eNBNuilj8yfFnECh0DzLgwKpBLMIvmhgEhixXNui8lMLBInTI8Kyxt++RwJnMNu7cAUo635L2+N1TxMJCzA=="
+			"integrity": "sha512-hX1eNBNuilj8yfFnECh0DzLgwKpBLMIvmhgEhixXNui8lMLBInTI8Kyxt++RwJnMNu7cAUo635L2+N1TxMJCzA==",
+			"dev": true
 		},
 		"spdx-correct": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
 			"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+			"dev": true,
 			"requires": {
-				"spdx-expression-parse": "3.0.0",
-				"spdx-license-ids": "3.0.0"
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-license-ids": "^3.0.0"
 			}
 		},
 		"spdx-exceptions": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-			"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+			"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+			"dev": true
 		},
 		"spdx-expression-parse": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
 			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+			"dev": true,
 			"requires": {
-				"spdx-exceptions": "2.1.0",
-				"spdx-license-ids": "3.0.0"
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
 			}
 		},
 		"spdx-license-ids": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
+			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+			"dev": true
 		},
 		"split-string": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
 			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+			"dev": true,
 			"requires": {
-				"extend-shallow": "3.0.2"
+				"extend-shallow": "^3.0.0"
 			}
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
 		},
 		"sshpk": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
 			"integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+			"dev": true,
 			"requires": {
-				"asn1": "0.2.3",
-				"assert-plus": "1.0.0",
-				"bcrypt-pbkdf": "1.0.1",
-				"dashdash": "1.14.1",
-				"ecc-jsbn": "0.1.1",
-				"getpass": "0.1.7",
-				"jsbn": "0.1.1",
-				"tweetnacl": "0.14.5"
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"tweetnacl": "~0.14.0"
 			}
 		},
 		"static-extend": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
 			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+			"dev": true,
 			"requires": {
-				"define-property": "0.2.5",
-				"object-copy": "0.1.0"
+				"define-property": "^0.2.5",
+				"object-copy": "^0.1.0"
 			},
 			"dependencies": {
 				"define-property": {
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
 					}
 				}
 			}
@@ -8989,191 +10082,214 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz",
 			"integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
+			"dev": true,
 			"requires": {
-				"readable-stream": "2.3.6"
+				"readable-stream": "^2.0.1"
 			}
 		},
 		"strict-uri-encode": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+			"dev": true
 		},
 		"string-hash": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
-			"integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs="
+			"integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=",
+			"dev": true
 		},
 		"string-length": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
 			"integrity": "sha1-VpcPscOFWOnnC3KL894mmsRa36w=",
+			"dev": true,
 			"requires": {
-				"strip-ansi": "3.0.1"
+				"strip-ansi": "^3.0.0"
 			}
 		},
 		"string-width": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+			"dev": true,
 			"requires": {
-				"code-point-at": "1.1.0",
-				"is-fullwidth-code-point": "1.0.0",
-				"strip-ansi": "3.0.1"
+				"code-point-at": "^1.0.0",
+				"is-fullwidth-code-point": "^1.0.0",
+				"strip-ansi": "^3.0.0"
 			}
 		},
 		"string_decoder": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
 			"requires": {
-				"safe-buffer": "5.1.1"
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"stringstream": {
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+			"dev": true
 		},
 		"strip-ansi": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"dev": true,
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"strip-bom": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+			"dev": true
 		},
 		"style-inject": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/style-inject/-/style-inject-0.3.0.tgz",
-			"integrity": "sha512-IezA2qp+vcdlhJaVm5SOdPPTUu0FCEqfNSli2vRuSIBbu5Nq5UvygTk/VzeCqfLz2Atj3dVII5QBKGZRZ0edzw=="
+			"integrity": "sha512-IezA2qp+vcdlhJaVm5SOdPPTUu0FCEqfNSli2vRuSIBbu5Nq5UvygTk/VzeCqfLz2Atj3dVII5QBKGZRZ0edzw==",
+			"dev": true
 		},
 		"supports-color": {
 			"version": "5.4.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+			"dev": true,
 			"requires": {
-				"has-flag": "3.0.0"
+				"has-flag": "^3.0.0"
 			}
 		},
 		"svgo": {
 			"version": "0.7.2",
 			"resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
 			"integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
+			"dev": true,
 			"requires": {
-				"coa": "1.0.4",
-				"colors": "1.1.2",
-				"csso": "2.3.2",
-				"js-yaml": "3.7.0",
-				"mkdirp": "0.5.1",
-				"sax": "1.2.4",
-				"whet.extend": "0.9.9"
+				"coa": "~1.0.1",
+				"colors": "~1.1.2",
+				"csso": "~2.3.1",
+				"js-yaml": "~3.7.0",
+				"mkdirp": "~0.5.1",
+				"sax": "~1.2.1",
+				"whet.extend": "~0.9.9"
 			}
 		},
 		"swap-case": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz",
 			"integrity": "sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=",
+			"dev": true,
 			"requires": {
-				"lower-case": "1.1.4",
-				"upper-case": "1.1.3"
+				"lower-case": "^1.1.1",
+				"upper-case": "^1.1.1"
 			}
 		},
 		"symbol-tree": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
+			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+			"dev": true
 		},
 		"tar": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
 			"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+			"dev": true,
 			"requires": {
-				"block-stream": "0.0.9",
-				"fstream": "1.0.11",
-				"inherits": "2.0.3"
+				"block-stream": "*",
+				"fstream": "^1.0.2",
+				"inherits": "2"
 			}
 		},
 		"test-exclude": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.1.tgz",
 			"integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
+			"dev": true,
 			"requires": {
-				"arrify": "1.0.1",
-				"micromatch": "3.1.10",
-				"object-assign": "4.1.1",
-				"read-pkg-up": "1.0.1",
-				"require-main-filename": "1.0.1"
+				"arrify": "^1.0.1",
+				"micromatch": "^3.1.8",
+				"object-assign": "^4.1.0",
+				"read-pkg-up": "^1.0.1",
+				"require-main-filename": "^1.0.1"
 			},
 			"dependencies": {
 				"find-up": {
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"dev": true,
 					"requires": {
-						"path-exists": "2.1.0",
-						"pinkie-promise": "2.0.1"
+						"path-exists": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"load-json-file": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
 					}
 				},
 				"path-exists": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"dev": true,
 					"requires": {
-						"pinkie-promise": "2.0.1"
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"path-type": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"read-pkg": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+					"dev": true,
 					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
 					}
 				},
 				"read-pkg-up": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+					"dev": true,
 					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
 					}
 				},
 				"strip-bom": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
 					"requires": {
-						"is-utf8": "0.2.1"
+						"is-utf8": "^0.2.0"
 					}
 				}
 			}
@@ -9181,103 +10297,117 @@
 		"throat": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/throat/-/throat-3.2.0.tgz",
-			"integrity": "sha512-/EY8VpvlqJ+sFtLPeOgc8Pl7kQVOWv0woD87KTXVHPIAE842FGT+rokxIhe8xIUP1cfgrkt0as0vDLjDiMtr8w=="
+			"integrity": "sha512-/EY8VpvlqJ+sFtLPeOgc8Pl7kQVOWv0woD87KTXVHPIAE842FGT+rokxIhe8xIUP1cfgrkt0as0vDLjDiMtr8w==",
+			"dev": true
 		},
 		"time-zone": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
-			"integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0="
+			"integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0=",
+			"dev": true
 		},
 		"title-case": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/title-case/-/title-case-2.1.1.tgz",
 			"integrity": "sha1-PhJyFtpY0rxb7PE3q5Ha46fNj6o=",
+			"dev": true,
 			"requires": {
-				"no-case": "2.3.2",
-				"upper-case": "1.1.3"
+				"no-case": "^2.2.0",
+				"upper-case": "^1.0.3"
 			}
 		},
 		"tmpl": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-			"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
+			"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+			"dev": true
 		},
 		"to-fast-properties": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+			"dev": true
 		},
 		"to-object-path": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
 			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.0.2"
 			}
 		},
 		"to-regex": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
 			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+			"dev": true,
 			"requires": {
-				"define-property": "2.0.2",
-				"extend-shallow": "3.0.2",
-				"regex-not": "1.0.2",
-				"safe-regex": "1.1.0"
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"regex-not": "^1.0.2",
+				"safe-regex": "^1.1.0"
 			}
 		},
 		"to-regex-range": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
 			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+			"dev": true,
 			"requires": {
-				"is-number": "3.0.0",
-				"repeat-string": "1.6.1"
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1"
 			}
 		},
 		"tough-cookie": {
 			"version": "2.3.4",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
 			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+			"dev": true,
 			"requires": {
-				"punycode": "1.4.1"
+				"punycode": "^1.4.1"
 			},
 			"dependencies": {
 				"punycode": {
 					"version": "1.4.1",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+					"dev": true
 				}
 			}
 		},
 		"tr46": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+			"dev": true
 		},
 		"trim-right": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+			"dev": true
 		},
 		"true-case-path": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.2.tgz",
 			"integrity": "sha1-fskRMJJHZsf1c74wIMNPj9/QDWI=",
+			"dev": true,
 			"requires": {
-				"glob": "6.0.4"
+				"glob": "^6.0.4"
 			},
 			"dependencies": {
 				"glob": {
 					"version": "6.0.4",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
 					"integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+					"dev": true,
 					"requires": {
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "2 || 3",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				}
 			}
@@ -9286,22 +10416,25 @@
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"dev": true,
 			"requires": {
-				"safe-buffer": "5.1.1"
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"tweetnacl": {
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"dev": true,
 			"optional": true
 		},
 		"type-check": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"dev": true,
 			"requires": {
-				"prelude-ls": "1.1.2"
+				"prelude-ls": "~1.1.2"
 			}
 		},
 		"ua-parser-js": {
@@ -9313,28 +10446,31 @@
 			"version": "2.8.29",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
 			"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+			"dev": true,
 			"optional": true,
 			"requires": {
-				"source-map": "0.5.7",
-				"uglify-to-browserify": "1.0.2",
-				"yargs": "3.10.0"
+				"source-map": "~0.5.1",
+				"uglify-to-browserify": "~1.0.0",
+				"yargs": "~3.10.0"
 			},
 			"dependencies": {
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
 					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true,
 					"optional": true
 				},
 				"yargs": {
 					"version": "3.10.0",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
 					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+					"dev": true,
 					"optional": true,
 					"requires": {
-						"camelcase": "1.2.1",
-						"cliui": "2.1.0",
-						"decamelize": "1.2.0",
+						"camelcase": "^1.0.2",
+						"cliui": "^2.1.0",
+						"decamelize": "^1.0.0",
 						"window-size": "0.1.0"
 					}
 				}
@@ -9344,36 +10480,40 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
 			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+			"dev": true,
 			"optional": true
 		},
 		"union-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
 			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+			"dev": true,
 			"requires": {
-				"arr-union": "3.1.0",
-				"get-value": "2.0.6",
-				"is-extendable": "0.1.1",
-				"set-value": "0.4.3"
+				"arr-union": "^3.1.0",
+				"get-value": "^2.0.6",
+				"is-extendable": "^0.1.1",
+				"set-value": "^0.4.3"
 			},
 			"dependencies": {
 				"extend-shallow": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
 					"requires": {
-						"is-extendable": "0.1.1"
+						"is-extendable": "^0.1.0"
 					}
 				},
 				"set-value": {
 					"version": "0.4.3",
 					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
 					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+					"dev": true,
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-extendable": "0.1.1",
-						"is-plain-object": "2.0.4",
-						"to-object-path": "0.3.0"
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.1",
+						"to-object-path": "^0.3.0"
 					}
 				}
 			}
@@ -9381,49 +10521,56 @@
 		"uniq": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
-			"integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
+			"integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+			"dev": true
 		},
 		"uniqid": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
 			"integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
+			"dev": true,
 			"requires": {
-				"macaddress": "0.2.8"
+				"macaddress": "^0.2.8"
 			}
 		},
 		"uniqs": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
-			"integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
+			"integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
+			"dev": true
 		},
 		"universalify": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-			"integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
+			"integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
+			"dev": true
 		},
 		"unset-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
 			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+			"dev": true,
 			"requires": {
-				"has-value": "0.3.1",
-				"isobject": "3.0.1"
+				"has-value": "^0.3.1",
+				"isobject": "^3.0.0"
 			},
 			"dependencies": {
 				"has-value": {
 					"version": "0.3.1",
 					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
 					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+					"dev": true,
 					"requires": {
-						"get-value": "2.0.6",
-						"has-values": "0.1.4",
-						"isobject": "2.1.0"
+						"get-value": "^2.0.3",
+						"has-values": "^0.1.4",
+						"isobject": "^2.0.0"
 					},
 					"dependencies": {
 						"isobject": {
 							"version": "2.1.0",
 							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+							"dev": true,
 							"requires": {
 								"isarray": "1.0.0"
 							}
@@ -9433,122 +10580,141 @@
 				"has-values": {
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+					"dev": true
 				}
 			}
 		},
 		"upper-case": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
-			"integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
+			"integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
+			"dev": true
 		},
 		"upper-case-first": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
 			"integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
+			"dev": true,
 			"requires": {
-				"upper-case": "1.1.3"
+				"upper-case": "^1.1.1"
 			}
 		},
 		"urix": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+			"dev": true
 		},
 		"use": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
 			"integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
+			"dev": true,
 			"requires": {
-				"kind-of": "6.0.2"
+				"kind-of": "^6.0.2"
 			},
 			"dependencies": {
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
 				}
 			}
 		},
 		"user-home": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-			"integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
+			"integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+			"dev": true
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
 		},
 		"uuid": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-			"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+			"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+			"dev": true
 		},
 		"v8flags": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
 			"integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+			"dev": true,
 			"requires": {
-				"user-home": "1.1.1"
+				"user-home": "^1.1.1"
 			}
 		},
 		"validate-npm-package-license": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
 			"integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+			"dev": true,
 			"requires": {
-				"spdx-correct": "3.0.0",
-				"spdx-expression-parse": "3.0.0"
+				"spdx-correct": "^3.0.0",
+				"spdx-expression-parse": "^3.0.0"
 			}
 		},
 		"vendors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.2.tgz",
-			"integrity": "sha512-w/hry/368nO21AN9QljsaIhb9ZiZtZARoVH5f3CsFbawdLdayCgKRPup7CggujvySMxx0I91NOyxdVENohprLQ=="
+			"integrity": "sha512-w/hry/368nO21AN9QljsaIhb9ZiZtZARoVH5f3CsFbawdLdayCgKRPup7CggujvySMxx0I91NOyxdVENohprLQ==",
+			"dev": true
 		},
 		"verror": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0",
+				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
-				"extsprintf": "1.3.0"
+				"extsprintf": "^1.2.0"
 			}
 		},
 		"vlq": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
-			"integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow=="
+			"integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
+			"dev": true
 		},
 		"vue-template-es2015-compiler": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.6.0.tgz",
-			"integrity": "sha512-x3LV3wdmmERhVCYy3quqA57NJW7F3i6faas++pJQWtknWT+n7k30F4TVdHvCLn48peTJFRvCpxs3UuFPqgeELg=="
+			"integrity": "sha512-x3LV3wdmmERhVCYy3quqA57NJW7F3i6faas++pJQWtknWT+n7k30F4TVdHvCLn48peTJFRvCpxs3UuFPqgeELg==",
+			"dev": true
 		},
 		"walker": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
 			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+			"dev": true,
 			"requires": {
-				"makeerror": "1.0.11"
+				"makeerror": "1.0.x"
 			}
 		},
 		"watch": {
 			"version": "0.10.0",
 			"resolved": "https://registry.npmjs.org/watch/-/watch-0.10.0.tgz",
-			"integrity": "sha1-d3mLLaD5kQ1ZXxrOWwwiWFIfIdw="
+			"integrity": "sha1-d3mLLaD5kQ1ZXxrOWwwiWFIfIdw=",
+			"dev": true
 		},
 		"webidl-conversions": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+			"dev": true
 		},
 		"whatwg-encoding": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
 			"integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
+			"dev": true,
 			"requires": {
 				"iconv-lite": "0.4.19"
 			},
@@ -9556,7 +10722,8 @@
 				"iconv-lite": {
 					"version": "0.4.19",
 					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+					"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+					"dev": true
 				}
 			}
 		},
@@ -9569,91 +10736,105 @@
 			"version": "4.8.0",
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
 			"integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
+			"dev": true,
 			"requires": {
-				"tr46": "0.0.3",
-				"webidl-conversions": "3.0.1"
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
 			},
 			"dependencies": {
 				"webidl-conversions": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-					"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+					"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+					"dev": true
 				}
 			}
 		},
 		"whet.extend": {
 			"version": "0.9.9",
 			"resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
-			"integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE="
+			"integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE=",
+			"dev": true
 		},
 		"which": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
 			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+			"dev": true,
 			"requires": {
-				"isexe": "2.0.0"
+				"isexe": "^2.0.0"
 			}
 		},
 		"wide-align": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
 			"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+			"dev": true,
 			"requires": {
-				"string-width": "1.0.2"
+				"string-width": "^1.0.2"
 			}
 		},
 		"window-size": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
 			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+			"dev": true,
 			"optional": true
 		},
 		"wordwrap": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-			"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
+			"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+			"dev": true
 		},
 		"worker-farm": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
 			"integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
+			"dev": true,
 			"requires": {
-				"errno": "0.1.7"
+				"errno": "~0.1.7"
 			}
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+			"dev": true,
 			"requires": {
-				"string-width": "1.0.2",
-				"strip-ansi": "3.0.1"
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1"
 			}
 		},
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
 		},
 		"xml-name-validator": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
-			"integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU="
+			"integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
+			"dev": true
 		},
 		"xtend": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+			"dev": true
 		},
 		"y18n": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+			"dev": true
 		},
 		"yallist": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+			"dev": true
 		}
 	}
 }

--- a/packages/matchbox/src/components/ActionList/ActionList.js
+++ b/packages/matchbox/src/components/ActionList/ActionList.js
@@ -36,7 +36,7 @@ class ActionList extends Component {
     /**
       * Actions
       * e.g. [{ content: 'action label', onClick: callback() }]
-      * 
+      *
       * Note: each item can include an optional "section" key that will be used to auto group into sections, declaratively
       */
     actions: PropTypes.arrayOf(PropTypes.shape({ content: PropTypes.node.isRequired })),
@@ -54,7 +54,7 @@ class ActionList extends Component {
     /**
      * Group by key used to auto group actions into sections, defaults to "section"
      */
-    groupByKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.symbol])
+    groupByKey: PropTypes.string
   };
 
   render() {
@@ -66,14 +66,10 @@ class ActionList extends Component {
       ...rest
     } = this.props;
 
-    console.log('found actions', actions);
-
     let list = actions.length ? groupByValues(actions, groupByKey) : [];
     if (sections.length) {
       list = list.concat(sections);
     }
-
-    console.log('grouped', list);
 
     const listMarkup = list.map((section, index) => <Section section={section} key={index} />);
 

--- a/packages/matchbox/src/components/ActionList/ActionList.js
+++ b/packages/matchbox/src/components/ActionList/ActionList.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-
+import { groupByValues } from '../../helpers/array';
 import { linkFrom } from '../UnstyledLink';
 import { Check } from '@sparkpost/matchbox-icons';
 import styles from './ActionList.module.scss';
@@ -36,6 +36,8 @@ class ActionList extends Component {
     /**
       * Actions
       * e.g. [{ content: 'action label', onClick: callback() }]
+      * 
+      * Note: each item can include an optional "section" key that will be used to auto group into sections, declaratively
       */
     actions: PropTypes.arrayOf(PropTypes.shape({ content: PropTypes.node.isRequired })),
     /**
@@ -47,7 +49,12 @@ class ActionList extends Component {
     /**
       * Max height of list
       */
-    maxHeight: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+    maxHeight: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+
+    /**
+     * Group by key used to auto group actions into sections, defaults to "section"
+     */
+    groupByKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.symbol])
   };
 
   render() {
@@ -55,13 +62,18 @@ class ActionList extends Component {
       actions = [],
       sections = [],
       maxHeight = 'none',
+      groupByKey = 'section',
       ...rest
     } = this.props;
 
-    let list = actions.length ? [actions] : [];
+    console.log('found actions', actions);
+
+    let list = actions.length ? groupByValues(actions, groupByKey) : [];
     if (sections.length) {
       list = list.concat(sections);
     }
+
+    console.log('grouped', list);
 
     const listMarkup = list.map((section, index) => <Section section={section} key={index} />);
 

--- a/packages/matchbox/src/components/ActionList/ActionList.js
+++ b/packages/matchbox/src/components/ActionList/ActionList.js
@@ -57,12 +57,17 @@ class ActionList extends Component {
     groupByKey: PropTypes.string
   };
 
+  static defaultProps = {
+    maxHeight: 'none',
+    groupByKey: 'section'
+  };
+
   render() {
     const {
       actions = [],
       sections = [],
-      maxHeight = 'none',
-      groupByKey = 'section',
+      maxHeight,
+      groupByKey,
       ...rest
     } = this.props;
 

--- a/packages/matchbox/src/helpers/array.js
+++ b/packages/matchbox/src/helpers/array.js
@@ -1,0 +1,6 @@
+export const groupBy = (list, groupingKey) => list.reduce((acc, item) => {
+  const index = item[groupingKey];
+  return { ...acc, [index]: [ ...(acc[index] || []), item ] };
+}
+
+export const groupByValues = (list, groupingKey) => Object.values(groupBy(list, groupingKey))

--- a/packages/matchbox/src/helpers/array.js
+++ b/packages/matchbox/src/helpers/array.js
@@ -1,6 +1,23 @@
+/**
+ * Group a list of items into sub groups based on the value of each item's groupingKey
+ * 
+ * @param {Array} list List of items to group
+ * @param {String} groupingKey Key to use for grouping each item by this value
+ * 
+ * @example
+ * const list = [{ name: 'a', section: 1 }, { name: 'b', section: 2 }, { name: 'c', section: 1 }]
+ * 
+ * groupBy(list, 'section')
+ * 
+ * // returns
+ * {
+ *   1: [ { name: 'a', section: 1 }, { name: 'c', section: 1 } ],
+ *   2: [ { name: 'b', section: 2 } ]
+ * }
+ */
 export const groupBy = (list, groupingKey) => list.reduce((acc, item) => {
   const index = item[groupingKey];
   return { ...acc, [index]: [ ...(acc[index] || []), item ] };
-}
+}, {})
 
 export const groupByValues = (list, groupingKey) => Object.values(groupBy(list, groupingKey))

--- a/packages/matchbox/src/helpers/tests/__snapshots__/array.test.js.snap
+++ b/packages/matchbox/src/helpers/tests/__snapshots__/array.test.js.snap
@@ -1,0 +1,113 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Helper: Array helpers groupBy should group a list by a given key 1`] = `
+Object {
+  "1": Array [
+    Object {
+      "name": "a",
+      "section": 1,
+    },
+    Object {
+      "name": "c",
+      "section": 1,
+    },
+  ],
+  "4": Array [
+    Object {
+      "name": "b",
+      "section": 4,
+    },
+  ],
+  "mixed whoa": Array [
+    Object {
+      "name": "d",
+      "section": "mixed whoa",
+    },
+  ],
+}
+`;
+
+exports[`Helper: Array helpers groupBy should group items into a single group when the group by key is not present in any item 1`] = `
+Object {
+  "undefined": Array [
+    Object {
+      "name": "a",
+      "section": 1,
+    },
+    Object {
+      "name": "b",
+      "section": 4,
+    },
+    Object {
+      "name": "c",
+      "section": 1,
+    },
+    Object {
+      "name": "d",
+      "section": "mixed whoa",
+    },
+  ],
+}
+`;
+
+exports[`Helper: Array helpers groupBy should group items without a key into an undefined group 1`] = `
+Object {
+  "1": Array [
+    Object {
+      "name": "a",
+      "section": 1,
+    },
+    Object {
+      "name": "c",
+      "section": 1,
+    },
+  ],
+  "4": Array [
+    Object {
+      "name": "b",
+      "section": 4,
+    },
+  ],
+  "mixed whoa": Array [
+    Object {
+      "name": "d",
+      "section": "mixed whoa",
+    },
+  ],
+  "undefined": Array [
+    Object {
+      "name": "no section 1",
+    },
+    Object {
+      "name": "no section 2",
+    },
+  ],
+}
+`;
+
+exports[`Helper: Array helpers groupByValues should return a grouped array 1`] = `
+Array [
+  Array [
+    Object {
+      "name": "a",
+      "section": 1,
+    },
+    Object {
+      "name": "c",
+      "section": 1,
+    },
+  ],
+  Array [
+    Object {
+      "name": "b",
+      "section": 4,
+    },
+  ],
+  Array [
+    Object {
+      "name": "d",
+      "section": "mixed whoa",
+    },
+  ],
+]
+`;

--- a/packages/matchbox/src/helpers/tests/array.test.js
+++ b/packages/matchbox/src/helpers/tests/array.test.js
@@ -1,0 +1,58 @@
+import { groupBy, groupByValues } from '../array';
+
+describe('Helper: Array helpers', () => {
+
+  let list;
+
+  beforeEach(() => {
+    list = [
+      {
+        name: 'a',
+        section: 1
+      },
+      {
+        name: 'b',
+        section: 4
+      },
+      {
+        name: 'c',
+        section: 1
+      },
+      {
+        name: 'd',
+        section: 'mixed whoa'
+      }
+    ];
+  });
+
+  describe('groupBy', () => {
+
+    it('should group a list by a given key', () => {
+      expect(groupBy(list, 'section')).toMatchSnapshot();
+    });
+
+    it('should group items without a key into an undefined group', () => {
+      list.push({ name: 'no section 1' });
+      list.push({ name: 'no section 2' });
+      const grouped = groupBy(list, 'section');
+      expect(grouped).toMatchSnapshot();
+      expect(grouped.undefined).toHaveLength(2);
+    });
+
+    it('should group items into a single group when the group by key is not present in any item', () => {
+      const grouped = groupBy(list, 'zerp');
+      expect(Object.keys(grouped)).toHaveLength(1);
+      expect(grouped).toMatchSnapshot();
+    });
+
+  });
+
+  describe('groupByValues', () => {
+
+    it('should return a grouped array', () => {
+      expect(groupByValues(list, 'section')).toMatchSnapshot();
+    });
+
+  });
+
+});


### PR DESCRIPTION
Oftentimes you want to declaratively specify sections rather than pushing the items into separate arrays. This change lets you do
```js
actions={[
  {
    content: 'whatever',
    section: 1
  },
  {
    content: 'whatever 2',
    section: 2
  }
]}
```
and have it work exactly the same as
```js
sections={[
  [
    {
      content: 'whatever'
    }
  ],
  [
    {
      content: 'whatever 2'
    }
  ]
]}
```
