### PR TITLE
Visible action key

### DIFF
--- a/packages/matchbox/package-lock.json
+++ b/packages/matchbox/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sparkpost/matchbox",
-	"version": "3.1.2",
+	"version": "3.2.3-beta.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/matchbox/package.json
+++ b/packages/matchbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sparkpost/matchbox",
-  "version": "3.2.3-beta.1",
+  "version": "3.2.3-beta.2",
   "description": "A React UI component library",
   "main": "matchbox.js",
   "module": "matchbox.es.js",

--- a/packages/matchbox/package.json
+++ b/packages/matchbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sparkpost/matchbox",
-  "version": "3.2.3-beta.0",
+  "version": "3.2.3-beta.1",
   "description": "A React UI component library",
   "main": "matchbox.js",
   "module": "matchbox.es.js",

--- a/packages/matchbox/package.json
+++ b/packages/matchbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sparkpost/matchbox",
-  "version": "3.2.3-beta.2",
+  "version": "3.2.3",
   "description": "A React UI component library",
   "main": "matchbox.js",
   "module": "matchbox.es.js",

--- a/packages/matchbox/package.json
+++ b/packages/matchbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sparkpost/matchbox",
-  "version": "3.2.2",
+  "version": "3.2.3-beta.0",
   "description": "A React UI component library",
   "main": "matchbox.js",
   "module": "matchbox.es.js",

--- a/packages/matchbox/src/components/ActionList/ActionList.js
+++ b/packages/matchbox/src/components/ActionList/ActionList.js
@@ -1,13 +1,13 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { groupByValues } from '../../helpers/array';
+import { groupByValues, filterByVisible } from '../../helpers/array';
 import { linkFrom } from '../UnstyledLink';
 import { Check } from '@sparkpost/matchbox-icons';
 import styles from './ActionList.module.scss';
 
 const Section = ({ section }) => {
-  const actions = section.map(({ className, highlighted, selected, content, ...action }, index) => {
+  const actions = filterByVisible(section).map(({ className, highlighted, selected, content, ...action }, index) => {
 
     const classes = classnames(
       styles.Action,

--- a/packages/matchbox/src/components/Button/utils.js
+++ b/packages/matchbox/src/components/Button/utils.js
@@ -1,9 +1,12 @@
 import React from 'react';
 import Button from './Button';
+import { filterByVisible } from '../../helpers/array';
 
 export function buttonsFrom(actions, overrides) {
-  if (actions.length) {
-    return <Button.Group>{actions.map((action, key) => buttonFrom(action, overrides, key))}</Button.Group>;
+  const filteredActions = filterByVisible(actions);
+
+  if (filteredActions.length) {
+    return <Button.Group>{filteredActions.map((action, key) => buttonFrom(action, overrides, key))}</Button.Group>;
   }
 }
 

--- a/packages/matchbox/src/components/Page/Page.js
+++ b/packages/matchbox/src/components/Page/Page.js
@@ -5,6 +5,7 @@ import { buttonFrom } from '../Button';
 import { ChevronLeft } from '@sparkpost/matchbox-icons';
 import { EmptyState } from '../EmptyState';
 import { UnstyledLink, linkFrom } from '../UnstyledLink';
+import { filterByVisible } from '../../helpers/array';
 
 import styles from './Page.module.scss';
 
@@ -94,7 +95,7 @@ class Page extends Component {
       : null;
 
     const secondaryActionsMarkup = secondaryActions
-      ? secondaryActions.map((action, i) => linkFrom({ ...action, className: styles.SecondaryAction }, i))
+      ? filterByVisible(secondaryActions).map((action, i) => linkFrom({ ...action, className: styles.SecondaryAction }, i))
       : null;
 
     const breadcrumbMarkup = breadcrumbAction

--- a/packages/matchbox/src/components/Popover/Popover.js
+++ b/packages/matchbox/src/components/Popover/Popover.js
@@ -142,11 +142,13 @@ class Popover extends Component {
   }
 
   render() {
-    const { fixed } = this.props;
+    const { fixed, open: controlledOpen } = this.props;
+    const shouldBeOpen = controlledOpen || this.state.open;
 
     return (
       <PopoverOverlay
         fixed={fixed}
+        open={shouldBeOpen}
         portalId={this.props.portalId}
         renderActivator={this.renderActivator}
         renderPopover={this.renderPopover} />

--- a/packages/matchbox/src/components/Popover/PopoverOverlay.js
+++ b/packages/matchbox/src/components/Popover/PopoverOverlay.js
@@ -38,7 +38,7 @@ class PopoverOverlay extends Component {
   }
 
   render() {
-    const { renderPopover, renderActivator, portalId, fixed } = this.props;
+    const { renderPopover, renderActivator, portalId, fixed, open } = this.props;
     const { position } = this.state;
 
     const activatorProps = {
@@ -49,8 +49,8 @@ class PopoverOverlay extends Component {
 
     return (
       <Fragment>
-        <WindowEvent event='resize' handler={this.handleMeasurement} />
-        {!fixed ? <WindowEvent event='scroll' handler={this.handleMeasurement} /> : null}
+        {open ? <WindowEvent event='resize' handler={this.handleMeasurement} /> : null}
+        {(!fixed && open) ? <WindowEvent event='scroll' handler={this.handleMeasurement} /> : null}
         {renderActivator(activatorProps)}
         <Portal containerId={portalId}>
           <div className={overlayClasses} style={position}>

--- a/packages/matchbox/src/components/Popover/tests/Popover.test.js
+++ b/packages/matchbox/src/components/Popover/tests/Popover.test.js
@@ -26,6 +26,11 @@ describe('Popover', () => {
     expect(wrapper.find('PopoverOverlay').dive()).toMatchSnapshot();
   });
 
+  it('should render window events when open', () => {
+    wrapper.setProps({ open: true });
+    expect(wrapper.find('PopoverOverlay').dive().find('WindowEvent')).toHaveLength(4);
+  });
+
   it('should use local state if not controlled', () => {
     expect(shallow(<Popover />)).toHaveState({ open: false });
   });

--- a/packages/matchbox/src/components/Popover/tests/__snapshots__/Popover.test.js.snap
+++ b/packages/matchbox/src/components/Popover/tests/__snapshots__/Popover.test.js.snap
@@ -76,6 +76,7 @@ exports[`Popover popover render should use correct classnames 1`] = `
 
 exports[`Popover should render overlay correctly 1`] = `
 <PopoverOverlay
+  open={false}
   portalId="portal"
   renderActivator={[Function]}
   renderPopover={[Function]}

--- a/packages/matchbox/src/components/Popover/tests/__snapshots__/Popover.test.js.snap
+++ b/packages/matchbox/src/components/Popover/tests/__snapshots__/Popover.test.js.snap
@@ -85,14 +85,6 @@ exports[`Popover should render overlay correctly 1`] = `
 
 exports[`Popover should render overlay correctly 2`] = `
 <React.Fragment>
-  <WindowEvent
-    event="resize"
-    handler={[Function]}
-  />
-  <WindowEvent
-    event="scroll"
-    handler={[Function]}
-  />
   <span
     className="Activator"
     onClick={[Function]}

--- a/packages/matchbox/src/components/Tag/Tag.module.scss
+++ b/packages/matchbox/src/components/Tag/Tag.module.scss
@@ -115,7 +115,7 @@
 .Content {
   display: inline-block;
   vertical-align: middle;
-  padding: rem(2) rem(7) 0;
+  padding: rem(1) rem(7) rem(1);
   border-radius: border-radius(large);
   background: color(gray, 8);
 

--- a/packages/matchbox/src/helpers/array.js
+++ b/packages/matchbox/src/helpers/array.js
@@ -1,14 +1,14 @@
 /**
  * Group a list of items into sub groups based on the value of each item's groupingKey
- * 
+ *
  * @param {Array} list List of items to group
  * @param {String} groupingKey Key to use for grouping each item by this value
- * 
+ *
  * @example
  * const list = [{ name: 'a', section: 1 }, { name: 'b', section: 2 }, { name: 'c', section: 1 }]
- * 
+ *
  * groupBy(list, 'section')
- * 
+ *
  * // returns
  * {
  *   1: [ { name: 'a', section: 1 }, { name: 'c', section: 1 } ],
@@ -17,7 +17,24 @@
  */
 export const groupBy = (list, groupingKey) => list.reduce((acc, item) => {
   const index = item[groupingKey];
-  return { ...acc, [index]: [ ...(acc[index] || []), item ] };
-}, {})
+  return { ...acc, [index]: [ ...(acc[index] || []), item ]};
+}, {});
 
-export const groupByValues = (list, groupingKey) => Object.values(groupBy(list, groupingKey))
+export const groupByValues = (list, groupingKey) => Object.values(groupBy(list, groupingKey));
+
+/**
+ * Filters by an array of actions by the visible key
+ * @param {Array} actions - Array of actions
+ *
+ * @example
+ * filterVisible([{ name: 'a', visible: true }, { name: 'b', visible: false }, { name: 'c' }])
+ *
+ * // returns
+ * [{ name: 'a' }, { name: 'c' }]
+ */
+export const filterByVisible = (actions) => actions.reduce((acc, { visible = true, ...action }) => {
+  if (visible) {
+    acc.push(action);
+  }
+  return acc;
+}, []);

--- a/packages/matchbox/src/helpers/tests/__snapshots__/array.test.js.snap
+++ b/packages/matchbox/src/helpers/tests/__snapshots__/array.test.js.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Helper: Array helpers filterByVisible should return only visible actions 1`] = `
+Array [
+  Object {
+    "content": "1",
+  },
+  Object {
+    "content": "2",
+  },
+]
+`;
+
 exports[`Helper: Array helpers groupBy should group a list by a given key 1`] = `
 Object {
   "1": Array [

--- a/packages/matchbox/src/helpers/tests/array.test.js
+++ b/packages/matchbox/src/helpers/tests/array.test.js
@@ -1,4 +1,4 @@
-import { groupBy, groupByValues } from '../array';
+import { groupBy, groupByValues, filterByVisible } from '../array';
 
 describe('Helper: Array helpers', () => {
 
@@ -53,6 +53,16 @@ describe('Helper: Array helpers', () => {
       expect(groupByValues(list, 'section')).toMatchSnapshot();
     });
 
+  });
+
+  describe('filterByVisible', () => {
+    it('should return only visible actions', () => {
+      expect(filterByVisible([
+        { content: '1' },
+        { content: '2', visible: true },
+        { content: '3', visible: false }
+      ])).toMatchSnapshot();
+    });
   });
 
 });

--- a/stories/action/ActionList.stories.js
+++ b/stories/action/ActionList.stories.js
@@ -80,5 +80,21 @@ storiesOf('Action|ActionList', module)
           />
         </Popover>
       </div>
+
+      <div style={{ display: 'inline-block', marginRight: 150 }}>
+        <Popover
+        open
+        trigger={<Button style={{ marginBottom: 250 }}>Actions with Visible Key</Button>}
+        style={{ width: '200px' }}>
+          <ActionList
+            groupByKey='group'
+            actions={[
+              { content: 'Action1', group: 1 },
+              { content: 'Action2', group: 2, visible: true },
+              { content: 'Action3', group: 2, visible: false }
+            ]}
+          />
+        </Popover>
+      </div>
     </div>
   )));

--- a/stories/feedback/Tag.stories.js
+++ b/stories/feedback/Tag.stories.js
@@ -4,13 +4,14 @@ import { withInfo } from '@storybook/addon-info';
 import { action } from '@storybook/addon-actions';
 import StoryContainer from '../storyHelpers/StoryContainer';
 import { Tag } from '@sparkpost/matchbox';
+import { Language } from '@sparkpost/matchbox-icons';
 
 storiesOf('Feedback|Tag', module)
   .addDecorator((getStory) => (
     <StoryContainer>{ getStory() }</StoryContainer>
   ))
   .add('basic tag', withInfo()(() => (
-    <Tag>domain.com</Tag>
+    <Tag>domain.com <Language/></Tag>
   )))
   .add('with remove action', withInfo()(() => (
     <Tag onRemove={action('Tag Remove')}>domain.com</Tag>

--- a/stories/layout/Page.stories.js
+++ b/stories/layout/Page.stories.js
@@ -31,6 +31,10 @@ export default storiesOf('Layout|Page', module)
       {
         content: 'Preview & Send',
         onClick: action('Preview Clicked')
+      },
+      {
+        content: 'Not Visible',
+        visible: false
       }
     ];
     const breadcrumbAction = {

--- a/stories/layout/Panel.stories.js
+++ b/stories/layout/Panel.stories.js
@@ -48,12 +48,20 @@ storiesOf('Layout|Panel', module)
         onClick: action('Delete Clicked'),
         color: 'red'
       },
+      {
+        content: 'Not Visible',
+        visible: false
+      }
     ];
     const sectionActions = [
       {
         content: 'View Details',
         onClick: action('Details Clicked'),
         color: 'red'
+      },
+      {
+        content: 'Not Visible',
+        visible: false
       }
     ];
     return (


### PR DESCRIPTION
**Popover**
- Repositioning event handler is no longer called unless the Popover is open

**Panel**, **ActionList**, **Page**
- Props that accept an array of actions, such as Panel or ActionList `actions` or Page `secondaryActions`, will no longer render any items if the key`visible` is provided with a falsey value.
- Each action will be displayed by default without this key.

```js
// Will only render the actions 'a' and 'c'
<Panel.Section actions={[
  { content: 'a', visible: true },
  { content: 'b', visible: false },
  { content: 'c' }
]} />
```