### PR TITLE
FE-574 Do not position popovers unless open

### DIFF
--- a/packages/matchbox/src/components/Popover/Popover.module.scss
+++ b/packages/matchbox/src/components/Popover/Popover.module.scss
@@ -27,7 +27,7 @@
   }
 
   &.exiting, &.exited {
-    transition: 0.06s ease-out;
+    transition: 0s;
     opacity: 0;
   }
 

--- a/packages/matchbox/src/components/Popover/PopoverContent.js
+++ b/packages/matchbox/src/components/Popover/PopoverContent.js
@@ -30,7 +30,7 @@ const Content = ({
   const tipStyle = { [left ? 'right' : 'left']: activatorWidth / 2 };
 
   return (
-    <Transition mountOnEnter unmountOnExit in={open} timeout={{ enter: 0, exit: 100 }}>
+    <Transition mountOnEnter unmountOnExit in={open} timeout={{ enter: 0, exit: 0 }}>
       {(state) => (
         <div className={wrapperClasses} ref={popoverRef}>
           <div className={classnames(popoverClasses, state && styles[state])} {...rest}>

--- a/packages/matchbox/src/components/Popover/PopoverOverlay.js
+++ b/packages/matchbox/src/components/Popover/PopoverOverlay.js
@@ -3,10 +3,17 @@ import PropTypes from 'prop-types';
 import { Portal } from '../Portal';
 import { WindowEvent } from '../WindowEvent';
 import { getPositionFor } from '../../helpers/geometry';
-import { debounce } from '../../helpers/event';
 import classnames from 'classnames';
 
 import styles from './PopoverOverlay.module.scss';
+
+const defaultPosition = {
+  top: 0,
+  left: 0,
+  width: 0,
+  height: 0
+};
+
 class PopoverOverlay extends Component {
   static displayName = 'PopoverOverlay';
 
@@ -16,26 +23,27 @@ class PopoverOverlay extends Component {
   }
 
   state = {
-    position: {
-      top: 0,
-      left: 0,
-      width: 0,
-      height: 0
-    }
+    position: defaultPosition
   }
 
   componentDidMount() {
     this.handleMeasurement();
   }
 
-  UNSAFE_componentWillReceiveProps() {
-    this.handleMeasurement();
+  componentDidUpdate({ open: prevOpen }) {
+    if (prevOpen !== this.props.open) {
+      this.handleMeasurement();
+    }
   }
 
   handleMeasurement = () => {
-    this.setState({
-      position: getPositionFor(this.activator, { fixed: this.props.fixed })
-    });
+    if (!this.props.open) {
+      this.setState({ position: defaultPosition });
+    } else {
+      this.setState({
+        position: getPositionFor(this.activator, { fixed: this.props.fixed })
+      });
+    }
   }
 
   render() {
@@ -50,7 +58,7 @@ class PopoverOverlay extends Component {
 
     return (
       <Fragment>
-        <WindowEvent event='resize' handler={debounce(this.handleMeasurement, 2000)} />
+        {open && <WindowEvent event='resize' handler={this.handleMeasurement} />}
         {(!fixed && open) ? <WindowEvent event='scroll' handler={this.handleMeasurement} /> : null}
         {renderActivator(activatorProps)}
         <Portal containerId={portalId}>

--- a/packages/matchbox/src/components/Popover/tests/Popover.test.js
+++ b/packages/matchbox/src/components/Popover/tests/Popover.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Popover from '../Popover';
 import { shallow } from 'enzyme';
 import * as keyEventHelpers from '../../../helpers/keyEvents';
+import * as geometryHelpers from '../../../helpers/geometry';
 
 describe('Popover', () => {
   const Trigger = (props) => <div {...props} />;
@@ -18,6 +19,7 @@ describe('Popover', () => {
     activator = () => shallow(wrapper.instance().renderActivator({ activatorRef: activatorRefMock }));
     popover = () => shallow(wrapper.instance().renderPopover({ activatorWidth: 100 }));
     keyEventHelpers.onKey = jest.fn(() => jest.fn());
+    geometryHelpers.getPositionFor = jest.fn(() => 'mock position');
     toggleSpy = jest.spyOn(wrapper.instance(), 'uncontrolledToggle');
   });
 
@@ -29,6 +31,13 @@ describe('Popover', () => {
   it('should render window events when open', () => {
     wrapper.setProps({ open: true });
     expect(wrapper.find('PopoverOverlay').dive().find('WindowEvent')).toHaveLength(4);
+  });
+
+  it('should measure position when opened and revert to default when closed', () => {
+    wrapper.setProps({ open: true });
+    expect(wrapper.find('PopoverOverlay').dive().find('.PopoverOverlay').prop('style')).toMatchSnapshot();
+    wrapper.setProps({ open: false });
+    expect(wrapper.find('PopoverOverlay').dive().find('.PopoverOverlay').prop('style')).toMatchSnapshot();
   });
 
   it('should use local state if not controlled', () => {

--- a/packages/matchbox/src/components/Popover/tests/__snapshots__/Popover.test.js.snap
+++ b/packages/matchbox/src/components/Popover/tests/__snapshots__/Popover.test.js.snap
@@ -34,7 +34,7 @@ exports[`Popover popover render should render correctly 1`] = `
   timeout={
     Object {
       "enter": 0,
-      "exit": 100,
+      "exit": 0,
     }
   }
   unmountOnExit={true}

--- a/packages/matchbox/src/components/Popover/tests/__snapshots__/Popover.test.js.snap
+++ b/packages/matchbox/src/components/Popover/tests/__snapshots__/Popover.test.js.snap
@@ -76,6 +76,17 @@ exports[`Popover popover render should use correct classnames 1`] = `
 </div>
 `;
 
+exports[`Popover should measure position when opened and revert to default when closed 1`] = `"mock position"`;
+
+exports[`Popover should measure position when opened and revert to default when closed 2`] = `
+Object {
+  "height": 0,
+  "left": 0,
+  "top": 0,
+  "width": 0,
+}
+`;
+
 exports[`Popover should render overlay correctly 1`] = `
 <PopoverOverlay
   open={false}
@@ -87,10 +98,6 @@ exports[`Popover should render overlay correctly 1`] = `
 
 exports[`Popover should render overlay correctly 2`] = `
 <Fragment>
-  <WindowEvent
-    event="resize"
-    handler={[Function]}
-  />
   <span
     className="Activator"
     onClick={[Function]}
@@ -104,14 +111,15 @@ exports[`Popover should render overlay correctly 2`] = `
       className="PopoverOverlay"
       style={
         Object {
-          "height": undefined,
-          "left": NaN,
-          "top": NaN,
-          "width": undefined,
+          "height": 0,
+          "left": 0,
+          "top": 0,
+          "width": 0,
         }
       }
     >
       <Popover.Content
+        activatorWidth={0}
         bottom={true}
         open={false}
         popoverRef={[Function]}


### PR DESCRIPTION
I published a "fix" for this previously in `3.3.8`, but I think this is a more correct solution.