### PR TITLE
EO-624 Update pagination lifecycle methods

### DIFF
--- a/packages/matchbox/src/components/Pagination/Pagination.js
+++ b/packages/matchbox/src/components/Pagination/Pagination.js
@@ -58,14 +58,14 @@ class Pagination extends Component {
     hasNext: true
   };
 
-  componentWillMount() {
+  componentDidMount() {
     this.handlePageChange(this.props.currentPage - 1);
   }
 
-  componentWillReceiveProps(nextProps) {
+  componentDidUpdate(prevProps) {
     const { pages, pageRange, currentPage } = this.props;
-    if (pages !== nextProps.pages || pageRange !== nextProps.pageRange || currentPage !== nextProps.currentPage) {
-      this.handlePageChange(nextProps.currentPage - 1);
+    if (pages !== prevProps.pages || pageRange !== prevProps.pageRange || currentPage !== prevProps.currentPage) {
+      this.handlePageChange(currentPage - 1);
     }
   }
 

--- a/packages/matchbox/src/components/Pagination/tests/Pagination.test.js
+++ b/packages/matchbox/src/components/Pagination/tests/Pagination.test.js
@@ -29,6 +29,30 @@ describe('Pagination', () => {
     expect(fn).toHaveBeenCalledTimes(1);
   });
 
+  describe('invokes onChange when props change', () => {
+    let fn;
+
+    beforeEach(() => {
+      fn = jest.fn();
+      wrapper.setProps({ onChange: fn });
+    });
+
+    it('page', () => {
+      wrapper.setProps({ pages: 11 });
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('currentPage', () => {
+      wrapper.setProps({ currentPage: 4 });
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('pageRange', () => {
+      wrapper.setProps({ pageRange: 6 });
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it('renders pagination with marginsHidden true', () => {
     wrapper.setProps({ marginsHidden: true });
     expect(wrapper).toMatchSnapshot();


### PR DESCRIPTION
Pagination's `cWRP` method triggered `setState`, which was referencing stale props. This caused `hasNext` to be incorrectly evaluated.