### PR TITLE
FE-633 Replace radios with SVGs

### DIFF
--- a/packages/matchbox/src/components/Radio/Radio.js
+++ b/packages/matchbox/src/components/Radio/Radio.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Label } from '../Label';
 import { Error } from '../Error';
+import { RadioButtonChecked, RadioButtonUnchecked } from '@sparkpost/matchbox-icons';
 import Group from './Group';
 
 import styles from './Radio.module.scss';
@@ -77,8 +78,12 @@ class Radio extends Component {
           type='radio'
           {...rest}/>
         <label htmlFor={id} className={styles.Control}>
-          <div className={styles.Outline} />
-          <div className={styles.Fill} />
+          <div className={styles.SvgUnchecked}>
+            <RadioButtonUnchecked size={21} style={{ verticalAlign: 'top' }}/>
+          </div>
+          <div className={styles.SvgChecked}>
+            <RadioButtonChecked size={21} style={{ verticalAlign: 'top' }}/>
+          </div>
         </label>
         {errorMarkup}
         {helpMarkup}

--- a/packages/matchbox/src/components/Radio/Radio.module.scss
+++ b/packages/matchbox/src/components/Radio/Radio.module.scss
@@ -10,40 +10,28 @@
 .Input {
   @include visually-hidden;
 
-  &:hover{
-    & ~ .Control .Outline {
-      border: 1px solid color(gray, 5);
+  &:hover:not(:disabled) {
+    & ~ .Control .SvgUnchecked svg {
+      fill: color(gray, 4);
     }
-  }
-
-  &:focus ~ .Control .Outline {
-    box-shadow: 0 0 0 1px color(blue);
-    border: 1px solid color(blue);
   }
 
   &:checked {
-    & ~ .Control .Outline {
-      border: 1px solid color(blue);
+    & ~ .Control .SvgUnchecked {
+      opacity: 0;
     }
 
-    & ~ .Control .Fill {
+    & ~ .Control .SvgChecked {
       opacity: 1;
-      transform: scale(1);
-    }
-
-    &:focus ~ .Control .Outline,
-    &:active ~ .Control .Outline {
-      box-shadow: 0 0 0 1px color(blue);
-      border: 1px solid color(blue);
     }
   }
 
-  &:disabled  ~ .Control .Outline {
-    background: color(gray, 9);
-  }
-  &:disabled  ~ .Control .Outline,
-  &:disabled  ~ .Control .Fill {
+  &:disabled  ~ .Control .SvgChecked,
+  &:disabled  ~ .Control .SvgUnchecked {
     cursor: not-allowed;
+    svg {
+      fill: color(gray, 5);
+    }
   }
 }
 
@@ -51,31 +39,31 @@
   cursor: pointer;
 }
 
-.Outline, .Fill {
-  transition: 0.15s;
-}
-
-.Outline {
-  position: relative;
-  top: 1px;
-  left: 1px;
-  width: 18px;
-  height: 18px;
-  border: 1px solid color(gray, 6);
-  border-radius: 50%;
-}
-
-.Fill {
+.SvgUnchecked, .SvgChecked {
   position: absolute;
-  top: 5px;
-  left: 5px;
-  width: 10px;
-  height: 10px;
-  background: color(blue);
-  border-radius: 50%;
+  top: 0;
+  left: 0;
 
+  &, & > svg {
+    transition: 0.15s;
+  }
+}
+
+.Control {
+  display: block;
+  position: relative;
+  height: 21px;
+  width: 21px;
+}
+
+.SvgUnchecked {
+  opacity: 1;
+  svg { fill: color(gray, 6) }
+}
+
+.SvgChecked {
   opacity: 0;
-  transform: scale(0.3);
+  svg { fill: color(blue) }
 }
 
 .Label {

--- a/packages/matchbox/src/components/Radio/tests/__snapshots__/Radio.test.js.snap
+++ b/packages/matchbox/src/components/Radio/tests/__snapshots__/Radio.test.js.snap
@@ -13,11 +13,29 @@ exports[`Radio renders radio checked 1`] = `
     className="Control"
   >
     <div
-      className="Outline"
-    />
+      className="SvgUnchecked"
+    >
+      <RadioButtonUnchecked
+        size={21}
+        style={
+          Object {
+            "verticalAlign": "top",
+          }
+        }
+      />
+    </div>
     <div
-      className="Fill"
-    />
+      className="SvgChecked"
+    >
+      <RadioButtonChecked
+        size={21}
+        style={
+          Object {
+            "verticalAlign": "top",
+          }
+        }
+      />
+    </div>
   </label>
 </fieldset>
 `;
@@ -35,11 +53,29 @@ exports[`Radio renders radio disabled 1`] = `
     className="Control"
   >
     <div
-      className="Outline"
-    />
+      className="SvgUnchecked"
+    >
+      <RadioButtonUnchecked
+        size={21}
+        style={
+          Object {
+            "verticalAlign": "top",
+          }
+        }
+      />
+    </div>
     <div
-      className="Fill"
-    />
+      className="SvgChecked"
+    >
+      <RadioButtonChecked
+        size={21}
+        style={
+          Object {
+            "verticalAlign": "top",
+          }
+        }
+      />
+    </div>
   </label>
 </fieldset>
 `;
@@ -56,11 +92,29 @@ exports[`Radio renders radio error 1`] = `
     className="Control"
   >
     <div
-      className="Outline"
-    />
+      className="SvgUnchecked"
+    >
+      <RadioButtonUnchecked
+        size={21}
+        style={
+          Object {
+            "verticalAlign": "top",
+          }
+        }
+      />
+    </div>
     <div
-      className="Fill"
-    />
+      className="SvgChecked"
+    >
+      <RadioButtonChecked
+        size={21}
+        style={
+          Object {
+            "verticalAlign": "top",
+          }
+        }
+      />
+    </div>
   </label>
   <Error
     error="There is an error"
@@ -80,11 +134,29 @@ exports[`Radio renders radio helpText 1`] = `
     className="Control"
   >
     <div
-      className="Outline"
-    />
+      className="SvgUnchecked"
+    >
+      <RadioButtonUnchecked
+        size={21}
+        style={
+          Object {
+            "verticalAlign": "top",
+          }
+        }
+      />
+    </div>
     <div
-      className="Fill"
-    />
+      className="SvgChecked"
+    >
+      <RadioButtonChecked
+        size={21}
+        style={
+          Object {
+            "verticalAlign": "top",
+          }
+        }
+      />
+    </div>
   </label>
   <div
     className="HelpText"
@@ -111,11 +183,29 @@ exports[`Radio renders radio label 1`] = `
     className="Control"
   >
     <div
-      className="Outline"
-    />
+      className="SvgUnchecked"
+    >
+      <RadioButtonUnchecked
+        size={21}
+        style={
+          Object {
+            "verticalAlign": "top",
+          }
+        }
+      />
+    </div>
     <div
-      className="Fill"
-    />
+      className="SvgChecked"
+    >
+      <RadioButtonChecked
+        size={21}
+        style={
+          Object {
+            "verticalAlign": "top",
+          }
+        }
+      />
+    </div>
   </label>
 </fieldset>
 `;
@@ -132,11 +222,29 @@ exports[`Radio renders radio label hidden 1`] = `
     className="Control"
   >
     <div
-      className="Outline"
-    />
+      className="SvgUnchecked"
+    >
+      <RadioButtonUnchecked
+        size={21}
+        style={
+          Object {
+            "verticalAlign": "top",
+          }
+        }
+      />
+    </div>
     <div
-      className="Fill"
-    />
+      className="SvgChecked"
+    >
+      <RadioButtonChecked
+        size={21}
+        style={
+          Object {
+            "verticalAlign": "top",
+          }
+        }
+      />
+    </div>
   </label>
 </fieldset>
 `;
@@ -154,11 +262,29 @@ exports[`Radio renders radio value 1`] = `
     className="Control"
   >
     <div
-      className="Outline"
-    />
+      className="SvgUnchecked"
+    >
+      <RadioButtonUnchecked
+        size={21}
+        style={
+          Object {
+            "verticalAlign": "top",
+          }
+        }
+      />
+    </div>
     <div
-      className="Fill"
-    />
+      className="SvgChecked"
+    >
+      <RadioButtonChecked
+        size={21}
+        style={
+          Object {
+            "verticalAlign": "top",
+          }
+        }
+      />
+    </div>
   </label>
 </fieldset>
 `;
@@ -178,11 +304,29 @@ exports[`Radio renders radio with name & id 1`] = `
     htmlFor="label1Id"
   >
     <div
-      className="Outline"
-    />
+      className="SvgUnchecked"
+    >
+      <RadioButtonUnchecked
+        size={21}
+        style={
+          Object {
+            "verticalAlign": "top",
+          }
+        }
+      />
+    </div>
     <div
-      className="Fill"
-    />
+      className="SvgChecked"
+    >
+      <RadioButtonChecked
+        size={21}
+        style={
+          Object {
+            "verticalAlign": "top",
+          }
+        }
+      />
+    </div>
   </label>
 </fieldset>
 `;

--- a/stories/form/Radio.stories.js
+++ b/stories/form/Radio.stories.js
@@ -38,11 +38,19 @@ export default storiesOf('Form|Radio', module)
   )))
 
   .add('Disabled', withInfo()(() => (
-    <Radio
-      id='id'
-      label='Check Me'
-      disabled
-     />
+    <Radio.Group>
+      <Radio
+        id='id'
+        label='Check Me'
+        disabled
+       />
+       <Radio
+         id='id'
+         label='Check Me'
+         checked
+         disabled
+        />
+     </Radio.Group>
   )))
 
   .add('With help text', withInfo()(() => (


### PR DESCRIPTION
Replaces Radio's css circles with SVGs.

#### How to test with 2web2ui
```bash
# 1. build matchbox and link
cd packages/matchbox
npm run build
npm link

# 2. in 2web2ui, link to your local build
npm link @sparkpost/matchbox

# 3. restart 2web2ui dev server
npm run start

# then verify radios are working
```
