### PR TITLE
UX-123 Add Expandable component

### DIFF
--- a/packages/matchbox/package-lock.json
+++ b/packages/matchbox/package-lock.json
@@ -4,6 +4,39 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@sparkpost/matchbox-icons": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/@sparkpost/matchbox-icons/-/matchbox-icons-1.1.12.tgz",
+			"integrity": "sha512-Fuf2sInwWQZ2OETbkvE5S3qw5+7mAh/C5yRQHhzt/1V86sf+9jnrhQXR6Aj+pIpvQ6vOnYv7dXgREp49fXidxQ==",
+			"dev": true,
+			"requires": {
+				"prop-types": "^15.7.2",
+				"react": "^16.8.6",
+				"react-dom": "^16.8.6"
+			},
+			"dependencies": {
+				"loose-envify": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+					"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+					"dev": true,
+					"requires": {
+						"js-tokens": "^3.0.0 || ^4.0.0"
+					}
+				},
+				"prop-types": {
+					"version": "15.7.2",
+					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+					"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+					"dev": true,
+					"requires": {
+						"loose-envify": "^1.4.0",
+						"object-assign": "^4.1.1",
+						"react-is": "^16.8.1"
+					}
+				}
+			}
+		},
 		"@types/acorn": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/@types/acorn/-/acorn-4.0.3.tgz",

--- a/packages/matchbox/package.json
+++ b/packages/matchbox/package.json
@@ -27,7 +27,7 @@
     "react-transition-group": "^2.3.0"
   },
   "devDependencies": {
-    "@sparkpost/matchbox-icons": "^1.1.10",
+    "@sparkpost/matchbox-icons": "^1.1.12",
     "autoprefixer": "^7.2.5",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",

--- a/packages/matchbox/src/components/Expandable/Expandable.js
+++ b/packages/matchbox/src/components/Expandable/Expandable.js
@@ -9,6 +9,7 @@ function Expandable(props) {
   const {
     children,
     defaultOpen,
+    icon,
     id,
     open,
     onToggle,
@@ -52,8 +53,16 @@ function Expandable(props) {
     })(e);
   }
 
-  const contentClasses = classnames(styles.Content, isOpen && styles.Open);
-  const iconClasses = classnames(styles.Icon, isOpen && styles.Open);
+  const iconMarkup = icon
+    ? <div className={styles.Icon}>{icon}</div>
+    : null;
+
+  const contentSpacer = icon
+    ? <div className={styles.ContentSpacer} />
+    : null;
+
+  const contentClasses = classnames(styles.ContentWrapper, isOpen && styles.Open);
+  const arrowClasses = classnames(styles.Arrow, isOpen && styles.Open);
 
   return (
     <div className={styles.Expandable}>
@@ -67,20 +76,24 @@ function Expandable(props) {
         role='button'
         tabIndex='1'
       >
+        {iconMarkup}
         <div className={styles.HeaderContent}>
           <h3 className={styles.Title}>{title}</h3>
           <h6 className={styles.Subtitle}>{subtitle}</h6>
         </div>
         <div className={styles.HeaderArrow}>
-          <KeyboardArrowRight size={36} className={iconClasses} />
+          <KeyboardArrowRight size={36} className={arrowClasses} />
         </div>
       </div>
       <div
-        aria-hidden={isOpen}
+        aria-hidden={!isOpen}
         className={contentClasses}
         id={id}
       >
-        {children}
+        {contentSpacer}
+        <div className={styles.Content}>
+          {children}
+        </div>
       </div>
     </div>
   );
@@ -90,32 +103,34 @@ Expandable.defaultProps = {
   defaultOpen: false
 };
 
-Expandable.proptypes = {
+Expandable.propTypes = {
   /**
    * Default open state when not controlled
    */
   defaultOpen: Proptypes.bool,
   /**
-   * Optional React node for an image or icon
-   *
+   * Optional React node for an image or icon. Works best with an SVG optimized for 40x40.
    */
   icon: Proptypes.node,
   /**
    * Required for accessilibty between header and content
-   *
    */
   id: Proptypes.string.isRequired,
   /**
    * Pass a boolean to control open state
-   *
    */
   open: Proptypes.bool,
   /**
    * Optional, but required when controlling open state
-   *
    */
   onToggle: Proptypes.func,
+  /**
+   * Optional content area beneath header title
+   */
   subtitle: Proptypes.node,
+  /**
+   * Main header title content
+   */
   title: Proptypes.node.isRequired
 };
 

--- a/packages/matchbox/src/components/Expandable/Expandable.js
+++ b/packages/matchbox/src/components/Expandable/Expandable.js
@@ -26,13 +26,6 @@ function Expandable(props) {
     setIsOpen(open);
   }, [open]);
 
-  // Handles onToggle when open state is uncontrolled
-  React.useEffect(() => {
-    if (!controlled && onToggle) {
-      onToggle();
-    }
-  }, [isOpen]);
-
   function handleToggle() {
     if (controlled) {
       onToggle();

--- a/packages/matchbox/src/components/Expandable/Expandable.js
+++ b/packages/matchbox/src/components/Expandable/Expandable.js
@@ -1,0 +1,122 @@
+import React from 'react';
+import Proptypes from 'prop-types';
+import classnames from 'classnames';
+import { KeyboardArrowRight } from '@sparkpost/matchbox-icons';
+import { onKeys } from '../../helpers/keyEvents';
+import styles from './Expandable.module.scss';
+
+function Expandable(props) {
+  const {
+    children,
+    defaultOpen,
+    id,
+    open,
+    onToggle,
+    subtitle,
+    title
+  } = props;
+
+  const header = React.useRef();
+  const [isOpen, setIsOpen] = React.useState(open || defaultOpen);
+  const controlled = typeof open === 'boolean';
+
+  // Sets internal open state when controlled externally
+  React.useEffect(() => {
+    setIsOpen(open);
+  }, [open]);
+
+  // Handles onToggle when open state is uncontrolled
+  React.useEffect(() => {
+    if (!controlled && onToggle) {
+      onToggle();
+    }
+  }, [isOpen]);
+
+  function handleToggle() {
+    if (controlled) {
+      onToggle();
+    } else {
+      setIsOpen(!isOpen);
+    }
+  }
+
+  function handleClick() {
+    header.current.blur();
+    handleToggle();
+  }
+
+  function handleKeyDown(e) {
+    onKeys(['space', 'enter'], () => {
+      e.preventDefault();
+      handleToggle();
+    })(e);
+  }
+
+  const contentClasses = classnames(styles.Content, isOpen && styles.Open);
+  const iconClasses = classnames(styles.Icon, isOpen && styles.Open);
+
+  return (
+    <div className={styles.Expandable}>
+      <div
+        aria-controls={id}
+        aria-expanded={isOpen}
+        className={styles.Header}
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+        ref={header}
+        role='button'
+        tabIndex='1'
+      >
+        <div className={styles.HeaderContent}>
+          <h3 className={styles.Title}>{title}</h3>
+          <h6 className={styles.Subtitle}>{subtitle}</h6>
+        </div>
+        <div className={styles.HeaderArrow}>
+          <KeyboardArrowRight size={36} className={iconClasses} />
+        </div>
+      </div>
+      <div
+        aria-hidden={isOpen}
+        className={contentClasses}
+        id={id}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+Expandable.defaultProps = {
+  defaultOpen: false
+};
+
+Expandable.proptypes = {
+  /**
+   * Default open state when not controlled
+   */
+  defaultOpen: Proptypes.bool,
+  /**
+   * Optional React node for an image or icon
+   *
+   */
+  icon: Proptypes.node,
+  /**
+   * Required for accessilibty between header and content
+   *
+   */
+  id: Proptypes.string.isRequired,
+  /**
+   * Pass a boolean to control open state
+   *
+   */
+  open: Proptypes.bool,
+  /**
+   * Optional, but required when controlling open state
+   *
+   */
+  onToggle: Proptypes.func,
+  subtitle: Proptypes.node,
+  title: Proptypes.node.isRequired
+};
+
+export default Expandable;

--- a/packages/matchbox/src/components/Expandable/Expandable.module.scss
+++ b/packages/matchbox/src/components/Expandable/Expandable.module.scss
@@ -42,18 +42,40 @@
   font-weight: normal;
 }
 
-.Content {
+.ContentWrapper {
   padding: rem(12);
   visibility: hidden;
   display: none;
 
   &.Open {
     visibility: visible;
-    display: block;
+    display: flex;
   }
 }
 
+.Content {
+  flex: 1;
+}
+
+.ContentSpacer {
+  flex: 0;
+  margin-right: rem(12);
+  min-width: 40px;
+  max-width: 40px;
+}
+
 .Icon {
+  flex: 0;
+  margin-right: rem(12);
+  min-width: 40px;
+  max-width: 40px;
+
+  svg {
+    vertical-align: middle;
+  }
+}
+
+.Arrow {
   border-radius: 50%;
   padding: spacing(small);
   transition: 0.1s ease-in-out;

--- a/packages/matchbox/src/components/Expandable/Expandable.module.scss
+++ b/packages/matchbox/src/components/Expandable/Expandable.module.scss
@@ -1,0 +1,69 @@
+@import '../../styles/config';
+
+.Expandable {
+  margin-bottom: spacing();
+  border: 2px solid color(gray, 8);
+  border-radius: border-radius(large);
+}
+
+.Header {
+  display: flex;
+  align-items: center;
+  padding: rem(12);
+
+  user-select: none;
+  outline: none;
+
+  transition: background 0.1s;
+
+  &:hover {
+    cursor: pointer;
+  }
+
+  &:focus:not(:hover) {
+    background: color(gray, 9);
+  }
+}
+
+.HeaderContent {
+  flex: 1;
+}
+
+.HeaderArrow {
+  flex: 0;
+}
+
+.Title {
+  margin-bottom: 0;
+}
+
+.Subtitle {
+  margin-bottom: 0;
+  font-weight: normal;
+}
+
+.Content {
+  padding: rem(12);
+  visibility: hidden;
+  display: none;
+
+  &.Open {
+    visibility: visible;
+    display: block;
+  }
+}
+
+.Icon {
+  border-radius: 50%;
+  padding: spacing(small);
+  transition: 0.1s ease-in-out;
+  transform-origin: center;
+
+  &.Open {
+    transform: rotate(90deg);
+  }
+
+  .Header:hover & {
+    background: color(gray, 9);
+  }
+}

--- a/packages/matchbox/src/components/Expandable/index.js
+++ b/packages/matchbox/src/components/Expandable/index.js
@@ -1,0 +1,1 @@
+export { default as Expandable } from './Expandable';

--- a/packages/matchbox/src/components/Expandable/tests/Expandable.test.js
+++ b/packages/matchbox/src/components/Expandable/tests/Expandable.test.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import Expandable from '../Expandable';
+import { mount } from 'enzyme';
+
+describe('Slider component', () => {
+  let onToggle;
+
+  beforeEach(() => {
+    onToggle = jest.fn();
+  });
+
+  const testOpen = (wrapper, open) => {
+    expect(wrapper.find('.Header')).toHaveAttributeValue('aria-expanded', open ? 'true' : 'false');
+    expect(wrapper.find('svg.Arrow')).toHaveAttributeValue('class', open ? 'Arrow Open' : 'Arrow');
+    expect(wrapper.find('.ContentWrapper')).toHaveAttributeValue('class', open ? 'ContentWrapper Open' : 'ContentWrapper');
+    expect(wrapper.find('.ContentWrapper')).toHaveAttributeValue('aria-hidden', open ? 'false' : 'true');
+  };
+
+  const subject = (props = {}) => mount(
+    <Expandable title='test-title' id='test-id' {...props}/>
+  );
+
+  it('should render default state with title and id correctly', () => {
+    expect(subject()).toMatchSnapshot();
+  });
+
+  it('should render provided default state with an icon', () => {
+    expect(subject({
+      icon: <svg>test</svg>,
+      defaultOpen: true
+    })).toMatchSnapshot();
+  });
+
+  describe('uncontrolled', () => {
+    it('should toggle open when clicking on header', () => {
+      const wrapper = subject();
+      wrapper.find('.Header').simulate('click');
+      testOpen(wrapper, true);
+    });
+
+    it('should toggle when hitting enter or space', () => {
+      const wrapper = subject({ onToggle });
+      wrapper.find('.Header').simulate('keyDown', { key: 'Enter', shiftKey: false });
+      testOpen(wrapper, true);
+
+      wrapper.find('.Header').simulate('keyDown', { key: ' ', shiftKey: false });
+      testOpen(wrapper, false);
+    });
+  });
+
+  describe('controlled', () => {
+    it('should toggle open when passed open state', () => {
+      const wrapper = subject({ open: true, onToggle });
+      testOpen(wrapper, true);
+    });
+
+    it('should handle toggle when clicking on header', () => {
+      const wrapper = subject({ open: true, onToggle });
+      wrapper.find('.Header').simulate('click');
+      expect(onToggle).toHaveBeenCalled();
+    });
+
+    it('should handle toggle when hitting enter or space', () => {
+      const wrapper = subject({ open: true, onToggle });
+      wrapper.find('.Header').simulate('keyDown', { key: 'Enter', shiftKey: false });
+      wrapper.find('.Header').simulate('keyDown', { key: ' ', shiftKey: false });
+      expect(onToggle).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/packages/matchbox/src/components/Expandable/tests/__snapshots__/Expandable.test.js.snap
+++ b/packages/matchbox/src/components/Expandable/tests/__snapshots__/Expandable.test.js.snap
@@ -1,0 +1,170 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Slider component should render default state with title and id correctly 1`] = `
+<Expandable
+  defaultOpen={false}
+  id="test-id"
+  title="test-title"
+>
+  <div
+    className="Expandable"
+  >
+    <div
+      aria-controls="test-id"
+      aria-expanded={false}
+      className="Header"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+      tabIndex="1"
+    >
+      <div
+        className="HeaderContent"
+      >
+        <h3
+          className="Title"
+        >
+          test-title
+        </h3>
+        <h6
+          className="Subtitle"
+        />
+      </div>
+      <div
+        className="HeaderArrow"
+      >
+        <KeyboardArrowRight
+          className="Arrow"
+          size={36}
+        >
+          <IconBase
+            className="Arrow"
+            size={36}
+          >
+            <svg
+              className="Arrow"
+              fill="currentColor"
+              height={36}
+              preserveAspectRatio="xMidYMid meet"
+              style={
+                Object {
+                  "verticalAlign": "middle",
+                }
+              }
+              viewBox="0 0 24 24"
+              width={36}
+            >
+              <g>
+                <path
+                  d="M8.59 16.34l4.58-4.59-4.58-4.59L10 5.75l6 6-6 6z"
+                />
+              </g>
+            </svg>
+          </IconBase>
+        </KeyboardArrowRight>
+      </div>
+    </div>
+    <div
+      aria-hidden={true}
+      className="ContentWrapper"
+      id="test-id"
+    >
+      <div
+        className="Content"
+      />
+    </div>
+  </div>
+</Expandable>
+`;
+
+exports[`Slider component should render provided default state with an icon 1`] = `
+<Expandable
+  defaultOpen={true}
+  icon={
+    <svg>
+      test
+    </svg>
+  }
+  id="test-id"
+  title="test-title"
+>
+  <div
+    className="Expandable"
+  >
+    <div
+      aria-controls="test-id"
+      aria-expanded={true}
+      className="Header"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+      tabIndex="1"
+    >
+      <div
+        className="Icon"
+      >
+        <svg>
+          test
+        </svg>
+      </div>
+      <div
+        className="HeaderContent"
+      >
+        <h3
+          className="Title"
+        >
+          test-title
+        </h3>
+        <h6
+          className="Subtitle"
+        />
+      </div>
+      <div
+        className="HeaderArrow"
+      >
+        <KeyboardArrowRight
+          className="Arrow Open"
+          size={36}
+        >
+          <IconBase
+            className="Arrow Open"
+            size={36}
+          >
+            <svg
+              className="Arrow Open"
+              fill="currentColor"
+              height={36}
+              preserveAspectRatio="xMidYMid meet"
+              style={
+                Object {
+                  "verticalAlign": "middle",
+                }
+              }
+              viewBox="0 0 24 24"
+              width={36}
+            >
+              <g>
+                <path
+                  d="M8.59 16.34l4.58-4.59-4.58-4.59L10 5.75l6 6-6 6z"
+                />
+              </g>
+            </svg>
+          </IconBase>
+        </KeyboardArrowRight>
+      </div>
+    </div>
+    <div
+      aria-hidden={false}
+      className="ContentWrapper Open"
+      id="test-id"
+    >
+      <div
+        className="ContentSpacer"
+      />
+      <div
+        className="Content"
+      />
+    </div>
+  </div>
+</Expandable>
+`;

--- a/packages/matchbox/src/components/index.js
+++ b/packages/matchbox/src/components/index.js
@@ -6,6 +6,7 @@ export * from './CodeBlock';
 export * from './ComboBox';
 export * from './EmptyState';
 export * from './Error';
+export * from './Expandable';
 export * from './Grid';
 export * from './Label';
 export * from './Modal';

--- a/packages/matchbox/src/helpers/keyEvents.js
+++ b/packages/matchbox/src/helpers/keyEvents.js
@@ -43,6 +43,11 @@ const keys = {
     key: 'End',
     keyCode: 35,
     shiftKey: false
+  },
+  space: {
+    key: ' ',
+    keyCode: 32,
+    shiftKey: false
   }
 };
 

--- a/stories/layout/Expandable.stories.js
+++ b/stories/layout/Expandable.stories.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withInfo } from '@storybook/addon-info';
+import { action } from '@storybook/addon-actions';
+import StoryContainer from '../storyHelpers/StoryContainer';
+
+import { Expandable, Panel } from '@sparkpost/matchbox';
+
+storiesOf('Layout|Expandable', module)
+  .addDecorator((getStory) => (
+    <StoryContainer>{ getStory() }</StoryContainer>
+  ))
+  .add('with image title and subtitle', withInfo({ propTablesExclude: [Panel] })(() => (
+    <Panel sectioned>
+      <Expandable title='Slack' subtitle='Integrate alerts into your teams Slack channels'>
+        Content here
+      </Expandable>
+    </Panel>
+  )))
+
+  .add('controlled open state', (() => {
+    function ControlledExample({ title }) {
+      const [open, setOpen] = React.useState(false);
+      action('test')
+      function onToggle() {
+
+        setOpen(!open);
+        action('Controlling open state:')(open);
+      }
+
+      return (
+          <Expandable
+            open={open}
+            title={title}
+            subtitle={`Integrate alerts into your teams ${title} channels`}
+            onToggle={onToggle}
+          >
+            Content {title} here
+          </Expandable>
+      )
+    }
+
+    return (
+      <Panel sectioned>
+        <ControlledExample title='Foo' />
+        <ControlledExample title='Bar' />
+        <ControlledExample title='Baz' />
+      </Panel>
+    )
+
+  }));

--- a/stories/layout/Expandable.stories.js
+++ b/stories/layout/Expandable.stories.js
@@ -6,13 +6,18 @@ import StoryContainer from '../storyHelpers/StoryContainer';
 
 import { Expandable, Panel } from '@sparkpost/matchbox';
 
+function Slack() {
+  return (
+    <svg width='40' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><path fill="#e01e5a" d="M23.33 62.14a9.67 9.67 0 1 1-9.67-9.67h9.67z"/><path fill="#e01e5a" d="M28.2 62.14a9.67 9.67 0 1 1 19.33 0v24.2a9.67 9.67 0 0 1-19.33 0z"/><path fill="#36c5f0" d="M37.86 23.33a9.67 9.67 0 1 1 9.67-9.67v9.67z"/><path fill="#36c5f0" d="M37.86 28.2a9.67 9.67 0 1 1 0 19.33h-24.2a9.67 9.67 0 0 1 0-19.33z"/><path fill="#2eb67d" d="M76.67 37.86a9.67 9.67 0 1 1 9.67 9.67h-9.67z"/><path fill="#2eb67d" d="M71.8 37.86a9.67 9.67 0 1 1-19.33 0v-24.2a9.67 9.67 0 0 1 19.33 0z"/><path fill="#ecb22e" d="M62.14 76.67a9.67 9.67 0 1 1-9.67 9.67v-9.67z"/><path fill="#ecb22e" d="M62.14 71.8a9.67 9.67 0 1 1 0-19.33h24.2a9.67 9.67 0 0 1 0 19.33z"/></svg>
+  );
+}
 storiesOf('Layout|Expandable', module)
   .addDecorator((getStory) => (
     <StoryContainer>{ getStory() }</StoryContainer>
   ))
   .add('with image title and subtitle', withInfo({ propTablesExclude: [Panel] })(() => (
     <Panel sectioned>
-      <Expandable title='Slack' subtitle='Integrate alerts into your teams Slack channels'>
+      <Expandable icon={<Slack />} title='Slack' id='example' subtitle="Integrate alerts into your team's Slack channels">
         Content here
       </Expandable>
     </Panel>
@@ -32,8 +37,8 @@ storiesOf('Layout|Expandable', module)
           <Expandable
             open={open}
             title={title}
-            subtitle={`Integrate alerts into your teams ${title} channels`}
             onToggle={onToggle}
+            id={title}
           >
             Content {title} here
           </Expandable>
@@ -41,11 +46,12 @@ storiesOf('Layout|Expandable', module)
     }
 
     return (
-      <Panel sectioned>
-        <ControlledExample title='Foo' />
-        <ControlledExample title='Bar' />
+      <div>
+        <Panel sectioned>
+          <ControlledExample title='Foo' />
+          <ControlledExample title='Bar' />
+        </Panel>
         <ControlledExample title='Baz' />
-      </Panel>
+      </div>
     )
-
   }));


### PR DESCRIPTION
Props:
```js
// Default open state when not controlled
defaultOpen: Proptypes.bool,

// Optional React node for an image or icon. Works best with an SVG optimized for 40x40.
icon: Proptypes.node,

// Required for accessilibty between header and content
id: Proptypes.string.isRequired,

// Pass a boolean to control open state
open: Proptypes.bool,

// Optional, but required when controlling open state
onToggle: Proptypes.func,

// Optional content area beneath header title
subtitle: Proptypes.node,

// Main header title content
title: Proptypes.node.isRequired
```

![Expandablegif](https://user-images.githubusercontent.com/3903325/59448561-727e3380-8dd3-11e9-89fd-e27d1ff19d92.gif)
