### PR TITLE
UX-137 Add Slider ticks

### DIFF
--- a/__mocks__/react.js
+++ b/__mocks__/react.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+// Forces effects to run before each render
+// See: https://github.com/facebook/react/issues/14050
+module.exports = { ...React, useEffect: React.useLayoutEffect }

--- a/packages/matchbox/src/components/Slider/Slider.js
+++ b/packages/matchbox/src/components/Slider/Slider.js
@@ -188,7 +188,7 @@ function Slider(props) {
         id={id}
         aria-valuemin={min}
         aria-valuemax={max}
-        aria-valuenow={value}
+        aria-valuenow={sliderValue}
         aria-disabled={disabled}
         className={styles.Handle}
         onBlur={onBlur}

--- a/packages/matchbox/src/components/Slider/Slider.module.scss
+++ b/packages/matchbox/src/components/Slider/Slider.module.scss
@@ -19,7 +19,7 @@
   height: 4px;
   background: color(gray, 8);
   border-radius: 3px;
-  transition: 0.3s;
+  transition: 0.3s background;
 
   .Slider:hover & {
     background: color(gray, 7);
@@ -61,4 +61,39 @@
   .Slider.Disabled  & {
     border: 2px solid color(gray, 4);
   }
+}
+
+.Tick {
+  position: absolute;
+  height: 10px;
+  width: 10px;
+  border-radius: 50%;
+  transform: translate(-3px, -3px);
+
+  background: color(gray, 8);
+  transition: 0.3s background;
+
+  user-select: none;
+
+  .Slider.Disabled &.Included {
+    background: color(gray, 4);
+  }
+
+  .Slider:not(.Disabled) &.Included {
+    background: color(orange);
+  }
+
+  .Slider:hover:not(.Disabled) &:not(.Included) {
+    background: color(gray, 7);
+  }
+}
+
+.TickLabel {
+  position: absolute;
+  top: 15px;
+  left: 50%;
+  transform: translate(-50%, 0);
+
+  color: color(gray, 4);
+  font-size: font-size(200);
 }

--- a/packages/matchbox/src/components/Slider/tests/Slider.test.js
+++ b/packages/matchbox/src/components/Slider/tests/Slider.test.js
@@ -160,4 +160,11 @@ describe('Slider component', () => {
       expect(onChange).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('ticks', () => {
+    it('should render ticks', () => {
+      const slider = subject({ value: 50, ticks: { 25: 'test tick', 55: 'not included tick' }});
+      expect(slider.find('.Tick')).toMatchSnapshot();
+    });
+  });
 });

--- a/packages/matchbox/src/components/Slider/tests/Slider.test.js
+++ b/packages/matchbox/src/components/Slider/tests/Slider.test.js
@@ -39,6 +39,7 @@ describe('Slider component', () => {
     const slider = subject({ value: 50, onChange });
     expect(slider.find('.Track')).toHaveAttributeValue('style', { width: '100px' });
     expect(slider.find('.Handle')).toHaveAttributeValue('style', { left: '100px' });
+    expect(slider.find('.Handle')).toHaveAttributeValue('aria-valuenow', '50');
     expect(onChange).toHaveBeenCalledWith(50);
   });
 

--- a/packages/matchbox/src/components/Slider/tests/__snapshots__/Slider.test.js.snap
+++ b/packages/matchbox/src/components/Slider/tests/__snapshots__/Slider.test.js.snap
@@ -39,3 +39,38 @@ exports[`Slider component should render default state correctly 1`] = `
   </div>
 </Slider>
 `;
+
+exports[`Slider component ticks should render ticks 1`] = `
+Array [
+  <div
+    className="Tick Included"
+    key="25"
+    style={
+      Object {
+        "left": 50,
+      }
+    }
+  >
+    <div
+      className="TickLabel"
+    >
+      test tick
+    </div>
+  </div>,
+  <div
+    className="Tick"
+    key="55"
+    style={
+      Object {
+        "left": 110.00000000000001,
+      }
+    }
+  >
+    <div
+      className="TickLabel"
+    >
+      not included tick
+    </div>
+  </div>,
+]
+`;

--- a/packages/matchbox/src/components/Slider/tests/__snapshots__/Slider.test.js.snap
+++ b/packages/matchbox/src/components/Slider/tests/__snapshots__/Slider.test.js.snap
@@ -26,6 +26,7 @@ exports[`Slider component should render default state correctly 1`] = `
     <div
       aria-valuemax={100}
       aria-valuemin={0}
+      aria-valuenow={0}
       className="Handle"
       onKeyDown={[Function]}
       role="slider"

--- a/stories/form/Slider.stories.js
+++ b/stories/form/Slider.stories.js
@@ -24,6 +24,23 @@ export default storiesOf('Form|Slider', module)
     )
   }))
 
+  .add('slider width ticks', withInfo({})(() => {
+    return (
+      <div>
+        <Slider value={75} ticks={{
+          0: '0',
+          50: '50',
+          25: 'Recommended',
+          100: '100',
+        }} />
+        <Slider disabled value={33} ticks={{
+          50: '50',
+          25: 'Recommended'
+        }} />
+      </div>
+    )
+  }))
+
   .add('value controlled slider', () => {
 
     function Example() {


### PR DESCRIPTION
What's Changed:
- Add Slider prop `ticks`
- Resolves #201


Sample Usage
```js
<Slider value={75} ticks={{
  0: '0',
  50: '50',
  25: 'Recommended',
  100: '100',
}} />
```