### PR TITLE
Resolve issue #196 by adding relevant href attribute, role button, an…

### DIFF
--- a/packages/matchbox/src/components/Snackbar/Snackbar.js
+++ b/packages/matchbox/src/components/Snackbar/Snackbar.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Close } from '@sparkpost/matchbox-icons';
+import { onKey } from '../../helpers/keyEvents';
 
 import styles from './Snackbar.module.scss';
 
@@ -35,6 +36,12 @@ class Snackbar extends Component {
     maxWidth: 380
   }
 
+  handleKeydown = (e) => {
+    const { onDismiss } = this.props;
+
+    onKey('space', () => onDismiss())(e);
+  }
+
   render() {
     const {
       children,
@@ -52,7 +59,13 @@ class Snackbar extends Component {
     return (
       <div className={snackbarStyles} role="alert" {...rest}>
         <div className={styles.Content} style={{ maxWidth }}>{children}</div>
-        <a className={styles.Dismiss} onClick={onDismiss}>
+        <a
+          className={styles.Dismiss}
+          onClick={onDismiss}
+          onKeyDown={this.handleKeydown}
+          role="button"
+          href="javascript:void(0);"
+        >
           <Close size={21} className={styles.DismissIcon} />
         </a>
       </div>


### PR DESCRIPTION
## What Changed

* Updated Snackbar dismiss link to add a valid `href` attribute with a value
* Added `role="button"` to the dismiss link
* Added `handleKeydown` method that allows the user to use the spacebar as well as the enter key

## How to Test

* Go to http://localhost:9001/?selectedKind=Feedback%7CSnackbar&selectedStory=Default&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel
* Click immediately before the `<Snackbar/>` instance and then hit the tab key
* The dismiss button should visibly have focus, and the `Dismissed` action should show in the Action Logger both when the spacebar and enter key are pressed