### PR TITLE
Add FileSearch icon

### DIFF
--- a/packages/matchbox-icons/src/icons/FileSearch.js
+++ b/packages/matchbox-icons/src/icons/FileSearch.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import { createSvgIcon } from '../IconBase';
+
+export default createSvgIcon(
+  <g><path d="M6 2c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h6.3c-.4-.6-.7-1.3-1-2H6V4h7v5h5v2c.7 0 1.4.1 2 .3V8l-6-6H6zm17.2 19.8l-1.5-1.5c.5-.8.8-1.8.8-2.8 0-2.8-2.2-5-5-5-2.7 0-5 2.3-5 5 0 2.8 2.2 5 5 5 1 0 2-.3 2.8-.8l1.5 1.5c.4.4 1 .4 1.4 0 .4-.4.4-1 0-1.4zm-5.7-1.3c-1.7 0-3-1.3-3-3s1.3-3 3-3 3 1.3 3 3-1.3 3-3 3z" /></g>
+  , 'FileSearch');

--- a/packages/matchbox-icons/src/index.js
+++ b/packages/matchbox-icons/src/index.js
@@ -314,6 +314,7 @@ export { default as FiberSmartRecord } from './icons/FiberSmartRecord';
 export { default as FileDownload } from './icons/FileDownload';
 export { default as FileEdit } from './icons/FileEdit';
 export { default as FileUpload } from './icons/FileUpload';
+export { default as FileSearch } from './icons/FileSearch';
 export { default as Filter } from './icons/Filter';
 export { default as Filter1 } from './icons/Filter1';
 export { default as Filter2 } from './icons/Filter2';


### PR DESCRIPTION
Adds a new `FileSearch` Icon

<img width="416" alt="Screen Shot 2019-08-26 at 4 23 51 PM" src="https://user-images.githubusercontent.com/3903325/63720787-eac69380-c81d-11e9-9aba-390d8fb051e2.png">

#### To test
- Run storybook locally, and visit: http://localhost:9001/?selectedKind=Icons%7Cmatchbox-icons&selectedStory=all%20icons&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel
