### PR TITLE
Resolve Issue #205 Update failing test stemming from out of date snapshot

### DIFF
--- a/packages/matchbox/src/components/Tag/Tag.js
+++ b/packages/matchbox/src/components/Tag/Tag.js
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 import { onKey } from '../../helpers/keyEvents';
 import { Close } from '@sparkpost/matchbox-icons';
 import { UnstyledLink } from '../UnstyledLink';
+import { ScreenReaderOnly } from '../ScreenReaderOnly';
 
 import styles from './Tag.module.scss';
 
@@ -55,6 +56,8 @@ class Tag extends Component {
         to="javascript:void(0)"
         role="button">
         <Close size={16} />
+
+        <ScreenReaderOnly>Close</ScreenReaderOnly>
       </UnstyledLink>
       : null;
 


### PR DESCRIPTION
## What Changed
* Leveraged `<ScreenReaderOnly/>` component to add content within the close `<Tag>` close button
* Updated out of date snapshot for the `<Tag/>` with the close button

## How to Test
* Enable Voiceover (https://help.apple.com/voiceover/mac/10.14/#/vo2682) and use the keyboard to focus on the tag component instance close button
* Inspect the DOM to see the 'Close' content, but without the expectation that the content will be visible