### PR TITLE
Resolve issue #231 by targeting specific CSS properties with transition-property

### DIFF
--- a/packages/matchbox/src/components/Button/Button.module.scss
+++ b/packages/matchbox/src/components/Button/Button.module.scss
@@ -15,7 +15,8 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 
-  transition: 0.15s;
+  transition-property: background, color, border, box-shadow, outline;
+  transition-duration: .15s;
 
   text-decoration: none;
   white-space: nowrap;


### PR DESCRIPTION
Resolves #231 

## What Changed

- Updated CSS to target specific CSS properties that should be animated

## How to Test

- Verify existing hover states for the button component -> http://localhost:9001/?selectedKind=Action%7CButton&selectedStory=Colors&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel

## Unrelated Stuff

- `transition` doesn't work on `linear-gradient` values, but using a pseudo element this can be accomplished: https://keithjgrant.com/posts/2017/07/transitioning-gradients/

