### PR TITLE
Resolve Issue #234 by incorporating icons in to the Snackbar component

### DIFF
--- a/packages/matchbox/src/components/Snackbar/Snackbar.js
+++ b/packages/matchbox/src/components/Snackbar/Snackbar.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { Close, Info, CheckCircle, Warning, Error as ErrorIcon } from '@sparkpost/matchbox-icons';
+import { Close, Info, CheckCircle, Warning, ErrorIcon } from '@sparkpost/matchbox-icons';
 import { onKey } from '../../helpers/keyEvents';
 
 import styles from './Snackbar.module.scss';

--- a/packages/matchbox/src/components/Snackbar/Snackbar.js
+++ b/packages/matchbox/src/components/Snackbar/Snackbar.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { Close } from '@sparkpost/matchbox-icons';
+import { Close, Info, CheckCircle, Warning, Error } from '@sparkpost/matchbox-icons';
 import { onKey } from '../../helpers/keyEvents';
 
 import styles from './Snackbar.module.scss';
@@ -58,7 +58,18 @@ class Snackbar extends Component {
 
     return (
       <div className={snackbarStyles} role="alert" {...rest}>
+        <div className={styles.IconWrapper}>
+          {status === 'default' && <Info/>}
+
+          {status === 'success' && <CheckCircle/>}
+
+          {status === 'warning' && <Warning/>}
+
+          {(status === 'error' || status === 'danger') && <Error/>}
+        </div>
+
         <div className={styles.Content} style={{ maxWidth }}>{children}</div>
+
         <a
           className={styles.Dismiss}
           onClick={onDismiss}

--- a/packages/matchbox/src/components/Snackbar/Snackbar.js
+++ b/packages/matchbox/src/components/Snackbar/Snackbar.js
@@ -59,13 +59,13 @@ class Snackbar extends Component {
     return (
       <div className={snackbarStyles} role="alert" {...rest}>
         <div className={styles.IconWrapper}>
-          {status === 'default' && <Info/>}
+          {status === 'default' && <Info label="Info" />}
 
-          {status === 'success' && <CheckCircle/>}
+          {status === 'success' && <CheckCircle label="Success"/>}
 
-          {status === 'warning' && <Warning/>}
+          {status === 'warning' && <Warning label="Warning" />}
 
-          {(status === 'error' || status === 'danger') && <Error/>}
+          {(status === 'error' || status === 'danger') && <Error label="Error" />}
         </div>
 
         <div className={styles.Content} style={{ maxWidth }}>{children}</div>

--- a/packages/matchbox/src/components/Snackbar/Snackbar.js
+++ b/packages/matchbox/src/components/Snackbar/Snackbar.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { Close, Info, CheckCircle, Warning, Error } from '@sparkpost/matchbox-icons';
+import { Close, Info, CheckCircle, Warning, Error as ErrorIcon } from '@sparkpost/matchbox-icons';
 import { onKey } from '../../helpers/keyEvents';
 
 import styles from './Snackbar.module.scss';
@@ -65,7 +65,7 @@ class Snackbar extends Component {
 
           {status === 'warning' && <Warning label="Warning" />}
 
-          {(status === 'error' || status === 'danger') && <Error label="Error" />}
+          {(status === 'error' || status === 'danger') && <ErrorIcon label="Error" />}
         </div>
 
         <div className={styles.Content} style={{ maxWidth }}>{children}</div>

--- a/packages/matchbox/src/components/Snackbar/Snackbar.module.scss
+++ b/packages/matchbox/src/components/Snackbar/Snackbar.module.scss
@@ -2,7 +2,8 @@
 
 .Snackbar {
   position: relative;
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
 
   border-radius: border-radius(large);
   box-shadow: shadow(deep);
@@ -38,11 +39,16 @@
   }
 }
 
+.IconWrapper {
+  margin: 0 spacing(small) 0 spacing();
+  transform: translateY(-2px); // Used to help vertically center icon to offset content line height
+}
+
 .Content {
   display: inline-block;
   vertical-align: top;
   margin-right: -4px;
-  padding: rem(12) spacing();
+  padding: rem(12) spacing(small);
   min-width: rem(200);
   font-weight: 500;
   font-size: font-size(500);

--- a/packages/matchbox/src/components/Snackbar/tests/Snackbar.test.js
+++ b/packages/matchbox/src/components/Snackbar/tests/Snackbar.test.js
@@ -26,6 +26,49 @@ describe('Snackbar', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('Renders the "Info" icon with the "default" status with a `label` prop value of "Info"', () => {
+    wrapper.setProps({ status: 'default' });
+
+    const infoIcon = wrapper.find('Info');
+
+    expect(infoIcon).toExist();
+    expect(infoIcon.props().label).toEqual('Info');
+  });
+
+  it('Renders the "CheckCircle" icon with the "success" status with a `label` prop value of "Success"', () => {
+    wrapper.setProps({ status: 'success' });
+
+    const infoIcon = wrapper.find('CheckCircle');
+
+    expect(infoIcon).toExist();
+    expect(infoIcon.props().label).toEqual('Success');
+  });
+
+  it('Renders the "Warning" icon with the "warning" status with a `label` prop value of "Warning"', () => {
+    wrapper.setProps({ status: 'warning' });
+
+    const infoIcon = wrapper.find('Warning');
+
+    expect(infoIcon).toExist();
+    expect(infoIcon.props().label).toEqual('Warning');
+  });
+
+  it('Renders the "Error" icon with the "error" or "danger" status with a `label` prop value of "Error"', () => {
+    wrapper.setProps({ status: 'error' });
+
+    const errorIcon = wrapper.find('Error');
+
+    expect(errorIcon).toExist();
+    expect(errorIcon.props().label).toEqual('Error');
+
+    wrapper.setProps({ status: 'danger' });
+
+    const dangerIcons = wrapper.find('Error');
+
+    expect(dangerIcons).toExist();
+    expect(dangerIcons.props().label).toEqual('Error');
+  });
+
   it('invokes onDismiss', () => {
     wrapper.find(`.${styles.Dismiss}`).simulate('click');
     expect(props.onDismiss).toHaveBeenCalledTimes(1);

--- a/packages/matchbox/src/components/Snackbar/tests/__snapshots__/Snackbar.test.js.snap
+++ b/packages/matchbox/src/components/Snackbar/tests/__snapshots__/Snackbar.test.js.snap
@@ -6,6 +6,13 @@ exports[`Snackbar renders Snackbar 1`] = `
   role="alert"
 >
   <div
+    className="IconWrapper"
+  >
+    <Info
+      label="Info"
+    />
+  </div>
+  <div
     className="Content"
     style={
       Object {
@@ -35,6 +42,13 @@ exports[`Snackbar renders Snackbar with different props 1`] = `
   className="Snackbar danger"
   role="alert"
 >
+  <div
+    className="IconWrapper"
+  >
+    <Error
+      label="Error"
+    />
+  </div>
   <div
     className="Content"
     style={

--- a/unreleased.md
+++ b/unreleased.md
@@ -3,3 +3,4 @@
 - #262 - Resolve issue #261 by removing padding right styles from Panel.Section content
 - #252 - Update Tag component styles to vertically center content
 - #240 - Incorporate ScreenReaderOnly component in to Next and Previous Pager components and relevant snapshots
+- #238 - Incorporate icons in to Snackbar component


### PR DESCRIPTION
## What Changed

* Incorporated icons that communicate the Snackbar component instance status in addition to the instance's color
* Incorporated labels for these icons so that screen readers can also interpret the Snackbar status
* Screenshots:

<img width="335" alt="Screen Shot 2019-09-03 at 11 25 24 AM" src="https://user-images.githubusercontent.com/3613392/64186897-a189cb80-ce3d-11e9-9dc1-0d16427d26b8.png">
<img width="353" alt="Screen Shot 2019-09-03 at 11 25 28 AM" src="https://user-images.githubusercontent.com/3613392/64186906-a3ec2580-ce3d-11e9-95c2-f2c724b77dc1.png">
<img width="340" alt="Screen Shot 2019-09-03 at 11 25 32 AM" src="https://user-images.githubusercontent.com/3613392/64186912-a5b5e900-ce3d-11e9-8549-602e5c11b7a9.png">
<img width="346" alt="Screen Shot 2019-09-03 at 11 25 39 AM" src="https://user-images.githubusercontent.com/3613392/64186920-a77fac80-ce3d-11e9-877c-feb5a0d4749f.png">
<img width="873" alt="Screen Shot 2019-09-03 at 11 25 47 AM" src="https://user-images.githubusercontent.com/3613392/64186928-aa7a9d00-ce3d-11e9-9024-d868bc6f517f.png">


## How to Test

1. Visit the [Snackbar Story](http://localhost:9001/?selectedKind=Feedback%7CSnackbar&selectedStory=Default&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel)
1. Check that components render with relevant `aria-label` HTML attributes
1. Check that each status of Snackbar component renders a distinct icon
