### PR TITLE
Resolves issue #239 by replacing circled icon with triangle

### DIFF
--- a/packages/matchbox/src/components/Banner/Banner.js
+++ b/packages/matchbox/src/components/Banner/Banner.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { Error as ErrorIcon, CheckCircle, InfoOutline, Close } from '@sparkpost/matchbox-icons';
+import { Error as ErrorIcon, Warning, CheckCircle, InfoOutline, Close } from '@sparkpost/matchbox-icons';
 
 import styles from './Banner.module.scss';
 import { buttonFrom } from '../Button';
@@ -12,7 +12,7 @@ const IconSection = ({ status }) => {
   const icons = {
     success: CheckCircle,
     info: InfoOutline,
-    warning: ErrorIcon,
+    warning: Warning,
     danger: ErrorIcon
   };
 
@@ -30,6 +30,9 @@ const IconSection = ({ status }) => {
   return (
     <div className={styles.IconWrapper}>
       <Icon size={30} className={iconClasses} />
+
+      {status === 'warning' && <div className={styles.IconWarningMiddleground}/>}
+
       <div className={styles.IconBackdrop} />
     </div>
   );

--- a/packages/matchbox/src/components/Banner/Banner.module.scss
+++ b/packages/matchbox/src/components/Banner/Banner.module.scss
@@ -95,13 +95,13 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  z-index: 1;
+  z-index: 3;
 }
 
 .successIcon {
   fill: color(green);
 
-  & + .IconBackdrop {
+  & ~ .IconBackdrop {
     box-shadow: 0 0 0 7px rgba(color(green), 0.25);
   }
 }
@@ -109,29 +109,46 @@
 .infoIcon {
   fill: darken(color(blue), 8);
 
-  & + .IconBackdrop {
+  & ~ .IconBackdrop {
     box-shadow: 0 0 0 7px rgba(color(blue), 0.25);
   }
 }
 
 .warningIcon {
-  fill: lighten(color(yellow), 4);
-
-  & + .IconBackdrop {
-    box-shadow: 0 0 0 7px rgba(color(yellow), 0.25);
+  // sizing and transformations appear hacky, but appear to be necessary when
+  // addressing positioning of the backdrop element
+  & ~ .IconBackdrop {
+    border-radius: initial;
+    background: rgba(color(yellow), 0.4);
+    width: 48px;
+    height: 40px;
+    transform: translate(-50%, -55%);
+    clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
   }
 }
 
 .dangerIcon {
   fill: color(red);
 
-  & + .IconBackdrop {
+  & ~ .IconBackdrop {
     box-shadow: 0 0 0 7px rgba(color(red), 0.25);
   }
 }
 
+.IconWarningMiddleground {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 5px;
+  height: 15px;
+  background: #FFF;
+  z-index: 2;
+}
+
 .IconBackdrop {
   position: absolute;
+  z-index: 1;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);


### PR DESCRIPTION
Resolves #239 

## What Changed?

* Updated icon with `<Warning/>` when the 'warning' variant was using the '<Error/>` icon
* Updated styles for the warning variant specifically
* Leveraged CSS `clip-path` to build a triangle outline
* Added additional decorative element to "fill" the "i" symbol inside of `<Warning/>`

## How to Test

* Go to the ['warning' variant story of the Banner component](http://localhost:9001/?selectedKind=Feedback%7CBanner&selectedStory=Warning&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel) and compare with other variants
* Note that achieving a border radius on a clip-path element is fairly difficult - if so required, we can use an inline SVG to clip the background color instead of using `clip-path` - that might look more consistent visually.

