### PR TITLE
Resolve Issue #242 Add relevant aria attributes, add some explicit tests to ch…

### DIFF
--- a/packages/matchbox/src/components/Modal/Modal.js
+++ b/packages/matchbox/src/components/Modal/Modal.js
@@ -65,7 +65,7 @@ class Modal extends Component {
     );
 
     return (
-      <div className={modalClasses} onClose={onClose} {...rest} ref={(node) => this.container = node}>
+      <div className={modalClasses} onClose={onClose} {...rest} ref={(node) => this.container = node} role="dialog" aria-modal="true">
         <Grid center='xs' middle='xs' className={styles.Grid}>
           <Grid.Column xs={11} md={9} xl={7}>
             <Content contentRef={(node) => this.content = node} open={open}>

--- a/packages/matchbox/src/components/Modal/tests/Modal.test.js
+++ b/packages/matchbox/src/components/Modal/tests/Modal.test.js
@@ -28,6 +28,13 @@ describe('Modal', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('renders with relevant ARIA attributes', () => {
+    const wrapperProps = wrapper.props();
+
+    expect(wrapperProps.role).toEqual('dialog');
+    expect(wrapperProps['aria-modal']).toEqual('true');
+  });
+
   it('should render contents when open', () => {
     wrapper.setProps({ open: true });
     expect(wrapper).toMatchSnapshot();

--- a/packages/matchbox/src/components/Modal/tests/__snapshots__/Modal.test.js.snap
+++ b/packages/matchbox/src/components/Modal/tests/__snapshots__/Modal.test.js.snap
@@ -2,8 +2,10 @@
 
 exports[`Modal should render contents when open 1`] = `
 <div
+  aria-modal="true"
   className="Modal open"
   onClose={[MockFunction]}
+  role="dialog"
 >
   <Grid
     center="xs"
@@ -81,8 +83,10 @@ exports[`Modal should render contents when open 3`] = `
 
 exports[`Modal should render modal 1`] = `
 <div
+  aria-modal="true"
   className="Modal"
   onClose={[MockFunction]}
+  role="dialog"
 >
   <Grid
     center="xs"
@@ -117,8 +121,10 @@ exports[`Modal should render modal 1`] = `
 
 exports[`Modal should render modal with close button 1`] = `
 <div
+  aria-modal="true"
   className="Modal"
   onClose={[MockFunction]}
+  role="dialog"
 >
   <Grid
     center="xs"


### PR DESCRIPTION
Resolves issue #242 

## What Changed?

* Adds `role="dialog"` to the `<Modal/>` component such that screen readers interpret the component as a dialog
* Adds `aria-modal="true"` to the `<Modal/>` component to effectively "hide" other content to screen reader users when the modal is open
* Add relevant tests to check for these attributes explicitly

## How to Test

* Check the DOM for relevant attributes outlined in issue #242 