### PR TITLE
Resolve Issue #220 - Add ErrorIcon

### DIFF
--- a/packages/matchbox-icons/src/icons/ErrorIcon.js
+++ b/packages/matchbox-icons/src/icons/ErrorIcon.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import { createSvgIcon } from '../IconBase';
+
+export default createSvgIcon(
+  <g><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z" /></g>
+  , 'Error');

--- a/packages/matchbox-icons/src/index.js
+++ b/packages/matchbox-icons/src/index.js
@@ -278,6 +278,7 @@ export { default as Email } from './icons/Email';
 export { default as EnhancedEncryption } from './icons/EnhancedEncryption';
 export { default as Equalizer } from './icons/Equalizer';
 export { default as Error } from './icons/Error';
+export { default as ErrorIcon } from './icons/ErrorIcon';
 export { default as ErrorOutline } from './icons/ErrorOutline';
 export { default as EuroSymbol } from './icons/EuroSymbol';
 export { default as Event } from './icons/Event';

--- a/unreleased.md
+++ b/unreleased.md
@@ -4,3 +4,4 @@
 - #237 - Add Log icon 
 - #236 - Resolve issue #231 by targeting specific CSS properties with transition-property
 - #226 - Resolve issue #214 to incorporate modal component keyboard tab trap
+- #250 - Resolve issue #220 by exporting the Error icon as ErrorIcon


### PR DESCRIPTION
Resolves #220

**What's Changed**
Exports `Error` as `ErrorIcon`

**To Test**
http://localhost:9001/?selectedKind=Icons%7Cmatchbox-icons&selectedStory=all%20icons&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel