### PR TITLE
Resolve Issue #251 - Update Tag component styles to vertically center content

### DIFF
--- a/packages/matchbox/src/components/Tag/Tag.module.scss
+++ b/packages/matchbox/src/components/Tag/Tag.module.scss
@@ -125,8 +125,12 @@
   font-size: font-size(300);
   line-height: rem(22);
 
-  > * {
-    word-spacing: 3px;
+  // This margin is a little funky, however, appears to be the best route to take to add
+  // spacing between icons and other tag content. Ideally, if Tag instances do not have bare
+  // strings inside, then the sibling combinator could be used (i.e., `> * + svg { margin-left: 2px; }`),
+  // however, that's not possible as bare strings do not count as sibling elements.
+  > svg {
+    margin: 0 2px;
   }
 }
 

--- a/packages/matchbox/src/components/Tag/Tag.module.scss
+++ b/packages/matchbox/src/components/Tag/Tag.module.scss
@@ -116,8 +116,6 @@
 .Content {
   display: inline-flex;
   align-items: center;
-  justify-content: space-between;
-  vertical-align: middle;
   padding: rem(1) rem(7) rem(1);
   border-radius: border-radius(large);
   background: color(gray, 8);
@@ -136,16 +134,17 @@
 
 .Close, a.Close {
   display: inline-block;
-  vertical-align: middle;
   padding: 0 rem(6);
   border-radius: 0 border-radius(large) border-radius(large) 0;
   background: color(gray, 8);
-
   color: color(gray, 4);
   line-height: rem(24);
   transition: 0.15s;
+  transition: color 0.15s ease-in-out,
+              background 0.15s ease-in-out;
 
-  &:hover, &:active {
+  &:hover,
+  &:active {
     color: color(gray, 1);
     background: color(gray, 7);
   }

--- a/packages/matchbox/src/components/Tag/Tag.module.scss
+++ b/packages/matchbox/src/components/Tag/Tag.module.scss
@@ -114,7 +114,9 @@
 }
 
 .Content {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
   vertical-align: middle;
   padding: rem(1) rem(7) rem(1);
   border-radius: border-radius(large);
@@ -122,6 +124,10 @@
 
   font-size: font-size(300);
   line-height: rem(22);
+
+  > * {
+    word-spacing: 3px;
+  }
 }
 
 .Close, a.Close {


### PR DESCRIPTION
Resolves #251 

## What Changed?
- Updated display of tag `.Content` from `inline-block` to `inline-flex`
- Added some horizontal spacing for child SVG elements

**Before:**
![Screen Shot 2019-09-24 at 8 44 57 AM](https://user-images.githubusercontent.com/3613392/65512923-36fe0580-dea8-11e9-84d4-5c9e8f0dced9.png)

**After:**
![Screen Shot 2019-09-24 at 8 59 48 AM](https://user-images.githubusercontent.com/3613392/65513676-b213eb80-dea9-11e9-93df-90fc1e421d28.png)

## How to Test

Look at variants of `<Tag/>` and verify vertical centering:
http://localhost:9001/?selectedKind=Feedback%7CTag&selectedStory=basic%20tag&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel