### PR TITLE
Resolve issue #256 by adding id attribute to select element

### DIFF
--- a/cypress/integration/Select.spec.js
+++ b/cypress/integration/Select.spec.js
@@ -1,0 +1,14 @@
+/// <reference types="Cypress" />
+
+/* eslint-disable no-undef */
+describe('The Select component', () => {
+  beforeEach(() => {
+    cy.visit('/iframe.html?selectedKind=Form%7CSelect&selectedStory=Basic%20Select&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel');
+  });
+
+  it('focuses on the `<select/>` element when clicking on the `<label>`', () => {
+    cy.get('label').click();
+
+    cy.get('select').should('have.focus');
+  });
+});

--- a/packages/matchbox/src/components/Select/Select.js
+++ b/packages/matchbox/src/components/Select/Select.js
@@ -104,6 +104,7 @@ class Select extends Component {
         {label && labelMarkup}
         <select
           className={inputClasses}
+          id={id}
           disabled={disabled}
           {...rest} >
           {optionMarkup}

--- a/packages/matchbox/src/components/Select/tests/Select.test.js
+++ b/packages/matchbox/src/components/Select/tests/Select.test.js
@@ -19,6 +19,7 @@ describe('Select', () => {
     { name: 'disabled', props: { disabled: true }},
     { name: 'required', props: { required: true, label: 'Select Label' }},
     { name: 'label', props: { label: 'Select Label' }},
+    { name: 'withId', props: { id: 'with-an-id' }},
     { name: 'helpText', props: { helpText: 'Select help text' }},
     { name: 'error', props: { label: 'An error occurred' }},
     { name: 'errorInLabel', props: { error: 'Error occurred', errorInLabel: true }},
@@ -48,5 +49,4 @@ describe('Select', () => {
     const options = wrapper.find('Option');
     options.forEach((option) => expect(option.dive()).toMatchSnapshot());
   });
-
 });

--- a/packages/matchbox/src/components/Select/tests/__snapshots__/Select.test.js.snap
+++ b/packages/matchbox/src/components/Select/tests/__snapshots__/Select.test.js.snap
@@ -145,6 +145,25 @@ exports[`Select renders Select with options 1`] = `
 </div>
 `;
 
+exports[`Select renders Select withId 1`] = `
+<div
+  className="Select"
+>
+  <select
+    className="Input"
+    id="with-an-id"
+  >
+    <Option
+      key="0"
+      option="option 1"
+    />
+  </select>
+  <ArrowDropDown
+    className="Dropdown labelHidden"
+  />
+</div>
+`;
+
 exports[`Select should render Option correctly 1`] = `
 <option
   value="option 1"


### PR DESCRIPTION
Resolves #256 

Adds `id` to the `<select>` element directly instead of on the label only to properly associate the `<label>` and the form control.

## How to Test

- On `master`, go to: http://localhost:9001/?selectedKind=Form%7CSelect&selectedStory=With%20help%20text&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel and click on the select label - note that the select does not receive focus - this indicates a broken label/form control association
- On this branch, do the same and notice that focus is handled properly
