### PR TITLE
Resolve issue #261 by moving padding right styles to heade…

### DIFF
--- a/packages/matchbox/src/components/Panel/Panel.module.scss
+++ b/packages/matchbox/src/components/Panel/Panel.module.scss
@@ -58,8 +58,12 @@
   white-space: nowrap;
 }
 
-.SectionContent, .HeaderText {
+.SectionContent,
+.HeaderText {
   flex: 1 0 0;
+}
+
+.HeaderText {
   padding-right: spacing(small);
 }
 


### PR DESCRIPTION
Resolves issue #261 

### What Changed
* Removes `padding-right` declaration for the `.SectionContent` class

### How To Test or Verify
1. Go to http://localhost:9001/?selectedKind=Layout%7CPanel&selectedStory=with%20multiple%20sections&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel
1. Verify the padding right styles are no longer present:
![Screen Shot 2019-10-15 at 1 44 02 PM](https://user-images.githubusercontent.com/3613392/66855800-eb43f680-ef51-11e9-9a56-0f96c4b503f0.png)

### PR Checklist
- [ ] Add your changes to `unreleased.md` in the root directory. If you plan on publishing immediately after merging (such as a hotfix) or aren't making changes to a published package, you can ignore this step.
- [X] Provide screenshots or [screen recordings](https://getkap.co/) for any visual changes.
- **N/A** Get approval from a UX team member (**#uxfe** or **#design-guild** on Slack) for any visual changes.
