### PR TITLE
Add primitive Text component

### DIFF
--- a/config/helpers.js
+++ b/config/helpers.js
@@ -4,7 +4,13 @@ import { render } from 'enzyme';
 import theme from '../packages/matchbox/src/components/ThemeProvider/theme';
 
 jest.mock('../packages/matchbox/src/components/ThemeProvider/theme', () => ({
-  "mock-theme-key": "mock-theme-value"
+  "mock-theme-key": "mock-theme-value",
+  fontSizes: {
+    400: "1rem"
+  },
+  lineHeights: {
+    400: "1.5rem"
+  },
 }));
 
 // jest-styled-components@6.3.3 has some issues:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10909,7 +10909,8 @@
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
     },
     "asn1": {
       "version": "0.2.3",
@@ -14657,7 +14658,8 @@
     "core-js": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+      "dev": true
     },
     "core-js-compat": {
       "version": "3.3.3",
@@ -16803,6 +16805,7 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dev": true,
       "requires": {
         "iconv-lite": "~0.4.13"
       }
@@ -18266,6 +18269,7 @@
       "version": "0.8.16",
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
       "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+      "dev": true,
       "requires": {
         "core-js": "^1.0.0",
         "isomorphic-fetch": "^2.1.1",
@@ -20913,7 +20917,8 @@
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+      "dev": true
     },
     "icss-utils": {
       "version": "4.1.1",
@@ -21656,7 +21661,8 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
     },
     "is-string": {
       "version": "1.0.4",
@@ -21748,6 +21754,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "dev": true,
       "requires": {
         "node-fetch": "^1.0.1",
         "whatwg-fetch": ">=0.10.0"
@@ -28226,6 +28233,7 @@
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "dev": true,
       "requires": {
         "encoding": "^0.1.11",
         "is-stream": "^1.0.1"
@@ -30639,6 +30647,7 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dev": true,
       "requires": {
         "asap": "~2.0.3"
       }
@@ -30841,13 +30850,23 @@
       }
     },
     "prop-types": {
-      "version": "15.6.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
-      "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
       "requires": {
-        "fbjs": "^0.8.16",
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      },
+      "dependencies": {
+        "loose-envify": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        }
       }
     },
     "prop-types-exact": {
@@ -33598,7 +33617,8 @@
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "dev": true
     },
     "setprototypeof": {
       "version": "1.1.1",
@@ -35445,7 +35465,8 @@
     "ua-parser-js": {
       "version": "0.7.18",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
-      "integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
+      "integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA==",
+      "dev": true
     },
     "uglify-js": {
       "version": "3.6.4",
@@ -36679,7 +36700,8 @@
     "whatwg-fetch": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
+      "dev": true
     },
     "whatwg-mimetype": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@styled-system/prop-types": "^5.1.2",
     "downshift": "^3.2.10",
     "jest-in-case": "^1.0.2",
-    "prop-types": "^15.6.1",
+    "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-focus-lock": "^2.0.5",

--- a/packages/matchbox-icons/package-lock.json
+++ b/packages/matchbox-icons/package-lock.json
@@ -3342,9 +3342,9 @@
 			}
 		},
 		"react-is": {
-			"version": "16.8.6",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
-			"integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
+			"version": "16.11.0",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.11.0.tgz",
+			"integrity": "sha512-gbBVYR2p8mnriqAwWx9LbuUrShnAuSCNnuPGyc7GJrMVQtPDAh8iLpv7FRuMPFb56KkaVZIYSz1PrjI9q0QPCw=="
 		},
 		"readable-stream": {
 			"version": "2.3.6",

--- a/packages/matchbox/package.json
+++ b/packages/matchbox/package.json
@@ -25,7 +25,7 @@
     "@sparkpost/matchbox-icons": "^1.2.1",
     "@styled-system/prop-types": "^5.1.2",
     "classnames": "^2.2.5",
-    "prop-types": "^15.6.1",
+    "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-focus-lock": "^2.0.5",

--- a/packages/matchbox/src/components/Text/Text.js
+++ b/packages/matchbox/src/components/Text/Text.js
@@ -1,0 +1,29 @@
+import styled from 'styled-components';
+import { color, space, typography, compose } from 'styled-system';
+import { truncate, crop } from './styles';
+import PropTypes from 'prop-types';
+
+const system = compose(
+  color,
+  space,
+  typography
+);
+
+const Text = styled('p')`
+  ${system}
+  ${truncate}
+  ${crop}
+`;
+
+Text.propTypes = {
+  as: PropTypes.elementType.isRequired,
+  children: PropTypes.node.isRequired,
+  crop: PropTypes.bool
+};
+
+Text.defaultProps = {
+  as: 'p'
+};
+
+Text.displayName = 'Text';
+export default Text;

--- a/packages/matchbox/src/components/Text/index.js
+++ b/packages/matchbox/src/components/Text/index.js
@@ -1,0 +1,1 @@
+export { default as Text } from './Text';

--- a/packages/matchbox/src/components/Text/styles.js
+++ b/packages/matchbox/src/components/Text/styles.js
@@ -1,0 +1,49 @@
+import tokens from '@sparkpost/design-tokens/meta';
+import _ from 'lodash';
+
+export const truncate = (props) => {
+  if (props.truncate) {
+    return {
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap'
+    };
+  }
+};
+
+/**
+ * Crops the text elements line height.
+ * The element's vertical bounds will begin & end at the rendered font instead of line height.
+ * Warning: This is an experimental prop
+ */
+export const crop = (props) => {
+  const capHeight = 0.65; // Cap height optimized for Calibre
+  const baseline = 4; // Calculated height will always be divisible by this baseline
+
+  // Requires lineHeight and fontSize to reference a token
+  if (
+    !props.crop || !props.lineHeight || !props.fontSize ||
+    !_.find(tokens, ({ name }) => name === `line-height-${props.lineHeight}`) ||
+    !_.find(tokens, ({ name }) => name === `font-size-${props.fontSize}`)
+  ) {
+    return;
+  }
+
+  const lineHeight = _.find(tokens, ({ name }) => name === `line-height-${props.lineHeight}`).pixel_value.replace('px', '');
+  const fontSize = _.find(tokens, ({ name }) => name === `font-size-${props.fontSize}`).pixel_value.replace('px', '');
+
+  const topSpace = Number(lineHeight) - capHeight * Number(fontSize);
+  const heightCorrection = topSpace - (topSpace % baseline);
+
+  return `
+    transform: translate(0, ${heightCorrection / 2}px);
+
+    &::before {
+      content: '';
+      display: block;
+      height: 0;
+      width: 0;
+      margin-top: -${heightCorrection}px;
+    }
+  `;
+};

--- a/packages/matchbox/src/components/Text/styles.js
+++ b/packages/matchbox/src/components/Text/styles.js
@@ -14,11 +14,12 @@ export const truncate = (props) => {
 /**
  * Crops the text elements line height.
  * The element's vertical bounds will begin & end at the rendered font instead of line height.
- * Warning: This is an experimental prop
+ * This is an experimental prop
+ * Calibre naturally has more spacing above than below, cropping is not perfect.
  */
 export const crop = (props) => {
-  const capHeight = 0.65; // Cap height optimized for Calibre
-  const baseline = 4; // Calculated height will always be divisible by this baseline
+  const capHeight = 0.69; // Cap height optimized for Calibre
+  const baseline = 2; // Calculated height will always be divisible by this baseline
 
   // Requires lineHeight and fontSize to reference a token
   if (
@@ -32,18 +33,19 @@ export const crop = (props) => {
   const lineHeight = _.find(tokens, ({ name }) => name === `line-height-${props.lineHeight}`).pixel_value.replace('px', '');
   const fontSize = _.find(tokens, ({ name }) => name === `font-size-${props.fontSize}`).pixel_value.replace('px', '');
 
-  const topSpace = Number(lineHeight) - capHeight * Number(fontSize);
-  const heightCorrection = topSpace - (topSpace % baseline);
+  const desiredHeight = capHeight * Number(fontSize);
+  const spaceToRemove = (Number(lineHeight) - desiredHeight);
+  const spaceRoundedToBaseline = spaceToRemove - (spaceToRemove % baseline);
 
   return `
-    transform: translate(0, ${heightCorrection / 2}px);
+    transform: translateY(${spaceRoundedToBaseline / 2}px);
 
     &::before {
       content: '';
       display: block;
       height: 0;
       width: 0;
-      margin-top: -${heightCorrection}px;
+      margin-top: -${spaceRoundedToBaseline}px;
     }
   `;
 };

--- a/packages/matchbox/src/components/Text/tests/Text.test.js
+++ b/packages/matchbox/src/components/Text/tests/Text.test.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import Text from '../Text';
+import 'jest-styled-components';
+
+describe('Text', () => {
+  it('it should render correctly', () => {
+    const wrapper = global.renderStyled(<Text id="text-id">Text</Text>);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('it should truncate', () => {
+    const wrapper = global.renderStyled(<Text truncate>Text</Text>);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  describe('cropping', () => {
+    it('it should crop when provided a size and line height', () => {
+      const wrapper = global.renderStyled(<Text crop fontSize="400" lineHeight="400">Text</Text>);
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('it should not crop with an unsupported size token', () => {
+      const wrapper = global.renderStyled(<Text crop fontSize="10px" lineHeight="400">Text</Text>);
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('it should not crop with an unsupported line height token', () => {
+      const wrapper = global.renderStyled(<Text crop fontSize="400" lineHeight="10px">Text</Text>);
+      expect(wrapper).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/matchbox/src/components/Text/tests/Text.test.js
+++ b/packages/matchbox/src/components/Text/tests/Text.test.js
@@ -2,6 +2,11 @@ import React from 'react';
 import Text from '../Text';
 import 'jest-styled-components';
 
+jest.mock('@sparkpost/design-tokens/meta', () => ([
+  { name: 'font-size-400', pixel_value: '18px' },
+  { name: 'line-height-400', pixel_value: '24px' }
+]));
+
 describe('Text', () => {
   it('it should render correctly', () => {
     const wrapper = global.renderStyled(<Text id="text-id">Text</Text>);

--- a/packages/matchbox/src/components/Text/tests/__snapshots__/Text.test.js.snap
+++ b/packages/matchbox/src/components/Text/tests/__snapshots__/Text.test.js.snap
@@ -4,9 +4,9 @@ exports[`Text cropping it should crop when provided a size and line height 1`] =
 .c0 {
   font-size: 1rem;
   line-height: 1.5rem;
-  -webkit-transform: translate(0,6px);
-  -ms-transform: translate(0,6px);
-  transform: translate(0,6px);
+  -webkit-transform: translateY(5px);
+  -ms-transform: translateY(5px);
+  transform: translateY(5px);
 }
 
 .c0::before {
@@ -14,7 +14,7 @@ exports[`Text cropping it should crop when provided a size and line height 1`] =
   display: block;
   height: 0;
   width: 0;
-  margin-top: -12px;
+  margin-top: -10px;
 }
 
 <p

--- a/packages/matchbox/src/components/Text/tests/__snapshots__/Text.test.js.snap
+++ b/packages/matchbox/src/components/Text/tests/__snapshots__/Text.test.js.snap
@@ -1,0 +1,77 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Text cropping it should crop when provided a size and line height 1`] = `
+.c0 {
+  font-size: 1rem;
+  line-height: 1.5rem;
+  -webkit-transform: translate(0,6px);
+  -ms-transform: translate(0,6px);
+  transform: translate(0,6px);
+}
+
+.c0::before {
+  content: '';
+  display: block;
+  height: 0;
+  width: 0;
+  margin-top: -12px;
+}
+
+<p
+  class="c0"
+  font-size="400"
+>
+  Text
+</p>
+`;
+
+exports[`Text cropping it should not crop with an unsupported line height token 1`] = `
+.c0 {
+  font-size: 1rem;
+  line-height: 10px;
+}
+
+<p
+  class="c0"
+  font-size="400"
+>
+  Text
+</p>
+`;
+
+exports[`Text cropping it should not crop with an unsupported size token 1`] = `
+.c0 {
+  font-size: 10px;
+  line-height: 1.5rem;
+}
+
+<p
+  class="c0"
+  font-size="10px"
+>
+  Text
+</p>
+`;
+
+exports[`Text it should render correctly 1`] = `
+<p
+  class=""
+  id="text-id"
+>
+  Text
+</p>
+`;
+
+exports[`Text it should truncate 1`] = `
+.c0 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+<p
+  class="c0"
+>
+  Text
+</p>
+`;

--- a/packages/matchbox/src/components/ThemeProvider/tests/ThemeProvider.test.js
+++ b/packages/matchbox/src/components/ThemeProvider/tests/ThemeProvider.test.js
@@ -7,9 +7,8 @@ describe('ThemeProvider', () => {
   const subject = (props) => shallow(<ThemeProvider {...props} />);
 
   it('should use a provided theme', () => {
-    expect(subject().prop('theme')).toEqual({
-      'mock-theme-key': 'mock-theme-value' // Theme mocked in global helpers.js
-    });
+    // Theme mocked in global helpers.js
+    expect(subject().prop('theme')).toMatchSnapshot();
   });
 
   it('should be able to modify the theme', () => {

--- a/packages/matchbox/src/components/ThemeProvider/tests/__snapshots__/ThemeProvider.test.js.snap
+++ b/packages/matchbox/src/components/ThemeProvider/tests/__snapshots__/ThemeProvider.test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ThemeProvider should use a provided theme 1`] = `
+Object {
+  "fontSizes": Object {
+    "400": "1rem",
+  },
+  "lineHeights": Object {
+    "400": "1.5rem",
+  },
+  "mock-theme-key": "mock-theme-value",
+}
+`;

--- a/packages/matchbox/src/components/index.js
+++ b/packages/matchbox/src/components/index.js
@@ -25,6 +25,7 @@ export * from './Snackbar';
 export * from './Table';
 export * from './Tabs';
 export * from './Tag';
+export * from './Text';
 export * from './TextField';
 export * from './Toggle';
 export * from './ThemeProvider';

--- a/stories/Text.stories.js
+++ b/stories/Text.stories.js
@@ -29,21 +29,19 @@ export const Truncated = withInfo(infoOptions)(() => (
 export const Cropped = withInfo(infoOptions)(() => (
   <Box display="flex" justifyContent="space-around" m="600" alignItems="center">
     <Box border='400' padding="600">
-        <Text crop fontSize="700" lineHeight='700'>Cropped</Text>
-        <Text crop fontSize="700" lineHeight='700'>Cropped</Text>
-        <Text crop fontSize="700" lineHeight='700'>Cropped</Text>
-        <Text crop fontSize="700" lineHeight='700'>Cropped</Text>
+      <Text crop fontSize="700" lineHeight='700'>CROPPED</Text>
+      <Text crop fontSize="700" lineHeight='700'>CROPPED</Text>
+      <Text crop fontSize="700" lineHeight='700'>CROPPED</Text>
+      <Text crop fontSize="700" lineHeight='700'>CROPPED</Text>
     </Box>
     <Box border='400' padding="600">
-        <Box fontSize="700" lineHeight='700'>Not Cropped</Box>
-        <Box fontSize="700" lineHeight='700'>Not Cropped</Box>
-        <Box fontSize="700" lineHeight='700'>Not Cropped</Box>
-        <Box fontSize="700" lineHeight='700'>Not Cropped</Box>
+      <Box fontSize="700" lineHeight='700'>Not Cropped</Box>
+      <Box fontSize="700" lineHeight='700'>Not Cropped</Box>
+      <Box fontSize="700" lineHeight='700'>Not Cropped</Box>
+      <Box fontSize="700" lineHeight='700'>Not Cropped</Box>
     </Box>
     <Box border='400' padding="200">
-      <Box>
-        <Text crop fontSize="500" lineHeight='500'>Cropped</Text>
-      </Box>
+      <Text crop fontSize="500" lineHeight='500'>Cropped</Text>
     </Box>
     <Box border='400' padding="200">
       <Box fontSize="500" lineHeight='500'>Not Cropped</Box>

--- a/stories/Text.stories.js
+++ b/stories/Text.stories.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import { storiesOf, addDecorator } from '@storybook/react';
+import { withInfo } from '@storybook/addon-info';
+
+import { Text } from '@sparkpost/matchbox/components/Text';
+import { Box } from '@sparkpost/matchbox/components/Box';
+import { ThemeProvider } from '@sparkpost/matchbox/components/ThemeProvider';
+
+addDecorator((storyFn) => <ThemeProvider>{storyFn()}</ThemeProvider>);
+
+export default {
+  title: 'Text'
+};
+
+const infoOptions = {
+  propTables: [Text]
+};
+
+export const Styled = withInfo(infoOptions)(() => (
+  <Text as="h1" m="800" color="purple.700" fontSize="600" lineHeight="600" fontWeight="normal">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis.</Text>
+));
+
+export const Truncated = withInfo(infoOptions)(() => (
+  <Box width='120px' m="800">
+    <Text truncate as='p'>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis.</Text>
+  </Box>
+));
+
+export const Cropped = withInfo(infoOptions)(() => (
+  <Box display="flex" justifyContent="space-around" m="600" alignItems="center">
+    <Box border='400' padding="600">
+        <Text crop fontSize="700" lineHeight='700'>Cropped</Text>
+        <Text crop fontSize="700" lineHeight='700'>Cropped</Text>
+        <Text crop fontSize="700" lineHeight='700'>Cropped</Text>
+        <Text crop fontSize="700" lineHeight='700'>Cropped</Text>
+    </Box>
+    <Box border='400' padding="600">
+        <Box fontSize="700" lineHeight='700'>Not Cropped</Box>
+        <Box fontSize="700" lineHeight='700'>Not Cropped</Box>
+        <Box fontSize="700" lineHeight='700'>Not Cropped</Box>
+        <Box fontSize="700" lineHeight='700'>Not Cropped</Box>
+    </Box>
+    <Box border='400' padding="200">
+      <Box>
+        <Text crop fontSize="500" lineHeight='500'>Cropped</Text>
+      </Box>
+    </Box>
+    <Box border='400' padding="200">
+      <Box fontSize="500" lineHeight='500'>Not Cropped</Box>
+    </Box>
+  </Box>
+));
+
+export const ExampleOfTags = withInfo(infoOptions)(() => (
+  <Box display="flex" justifyContent="space-around" m="600" alignItems="center">
+    <Text>Paragraph</Text>
+    <Text as="i">Italic</Text>
+    <Text as="u">Underline</Text>
+    <Text as="abbr">I18N</Text>
+    <Text as="cite">Citation</Text>
+    <Text as="del">Deleted</Text>
+    <Text as="em">Emphasis</Text>
+    <Text as="ins">Inserted</Text>
+    <Text as="kbd">Ctrl + C</Text>
+    <Text as="mark">Highlighted</Text>
+    <Text as="s">Strikethrough</Text>
+    <Text as="samp">Sample</Text>
+    <Text as="sub">sub</Text>
+    <Text as="sup">sup</Text>
+    <Text as="span">Span</Text>
+  </Box>
+));

--- a/unreleased.md
+++ b/unreleased.md
@@ -5,3 +5,4 @@
 [4.0.0]
 - #267 - Updates to Babel 7, Rollup 1, Storybook 5
 - #270 - Refreshes global CSS, Adds Box component, and Installs styled-system
+- #272 - Adds primitive Text component


### PR DESCRIPTION
### What Changed
- Adds a new primitive `<Text />` component.
- Like the `<Box />`, this component makes use of styled-system, and has the options to adjust `color`, `space`, and `typography` system props.

### How To Test or Verify
- Start storybook with `npm run start:storybook`
- Visit http://localhost:9001/?path=/story/text--styled, and other stories.
- Verify the available props work, or provide feedback on the API.

<details>
<summary>Screenshots</summary>

![Screen Shot 2019-11-07 at 3 06 38 PM](https://user-images.githubusercontent.com/3903325/68423600-5ad38d00-0170-11ea-8bdf-8905d7f82b88.png)

![Screen Shot 2019-11-07 at 3 06 57 PM](https://user-images.githubusercontent.com/3903325/68423601-5ad38d00-0170-11ea-8415-89ad123f1a08.png)

![Screen Shot 2019-11-07 at 3 06 46 PM](https://user-images.githubusercontent.com/3903325/68423603-5ad38d00-0170-11ea-9a21-28bb4ac2572e.png)

</details>

<details>
<summary>PR Checklist</summary>

- [x] Add your changes to `unreleased.md` in the root directory. If you plan on publishing immediately after merging (such as a hotfix) or aren't making changes to a published package, you can ignore this step.
- [x] Provide screenshots or [screen recordings](https://getkap.co/) for any visual changes.

</details>