### PR TITLE
Upgrade React to 16.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21068,14 +21068,13 @@
       }
     },
     "react": {
-      "version": "16.8.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.8.6.tgz",
-      "integrity": "sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==",
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.11.0.tgz",
+      "integrity": "sha512-M5Y8yITaLmU0ynd0r1Yvfq98Rmll6q8AxaEe88c8e7LxO8fZ2cNgmFt0aGAS9wzf1Ao32NKXtCl+/tVVtkxq6g==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.13.6"
+        "prop-types": "^15.6.2"
       },
       "dependencies": {
         "prop-types": {
@@ -21097,11 +21096,6 @@
               }
             }
           }
-        },
-        "react-is": {
-          "version": "16.8.6",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
-          "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
         }
       }
     },
@@ -21201,14 +21195,14 @@
       }
     },
     "react-dom": {
-      "version": "16.8.6",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz",
-      "integrity": "sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==",
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.11.0.tgz",
+      "integrity": "sha512-nrRyIUE1e7j8PaXSPtyRKtz+2y9ubW/ghNgqKFHHAHaeP0fpF5uXR+sq8IMRHC+ZUxw7W9NyCDTBtwWxvkb0iA==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.13.6"
+        "scheduler": "^0.17.0"
       },
       "dependencies": {
         "prop-types": {
@@ -21231,10 +21225,14 @@
             }
           }
         },
-        "react-is": {
-          "version": "16.8.6",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
-          "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
+        "scheduler": {
+          "version": "0.17.0",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.17.0.tgz",
+          "integrity": "sha512-7rro8Io3tnCPuY4la/NuI5F2yfESpnfZyT6TtkXnSWVkcu0BCDJ+8gk5ozUaFaxpIyNuWAPXrH0yFcSi28fnDA==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
         }
       }
     },
@@ -22877,6 +22875,7 @@
       "version": "0.13.6",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
       "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "downshift": "^3.2.10",
     "jest-in-case": "^1.0.2",
     "prop-types": "^15.6.1",
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6",
+    "react": "^16.11.0",
+    "react-dom": "^16.11.0",
     "react-focus-lock": "^2.0.5"
   },
   "devDependencies": {

--- a/packages/matchbox-icons/package-lock.json
+++ b/packages/matchbox-icons/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sparkpost/matchbox-icons",
-	"version": "1.1.12",
+	"version": "1.2.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -2126,25 +2126,24 @@
 			}
 		},
 		"react": {
-			"version": "16.8.6",
-			"resolved": "https://registry.npmjs.org/react/-/react-16.8.6.tgz",
-			"integrity": "sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==",
+			"version": "16.11.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.11.0.tgz",
+			"integrity": "sha512-M5Y8yITaLmU0ynd0r1Yvfq98Rmll6q8AxaEe88c8e7LxO8fZ2cNgmFt0aGAS9wzf1Ao32NKXtCl+/tVVtkxq6g==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.2",
-				"scheduler": "^0.13.6"
+				"prop-types": "^15.6.2"
 			}
 		},
 		"react-dom": {
-			"version": "16.8.6",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz",
-			"integrity": "sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==",
+			"version": "16.11.0",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.11.0.tgz",
+			"integrity": "sha512-nrRyIUE1e7j8PaXSPtyRKtz+2y9ubW/ghNgqKFHHAHaeP0fpF5uXR+sq8IMRHC+ZUxw7W9NyCDTBtwWxvkb0iA==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
 				"prop-types": "^15.6.2",
-				"scheduler": "^0.13.6"
+				"scheduler": "^0.17.0"
 			}
 		},
 		"react-is": {
@@ -2413,9 +2412,9 @@
 			"optional": true
 		},
 		"scheduler": {
-			"version": "0.13.6",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
-			"integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.17.0.tgz",
+			"integrity": "sha512-7rro8Io3tnCPuY4la/NuI5F2yfESpnfZyT6TtkXnSWVkcu0BCDJ+8gk5ozUaFaxpIyNuWAPXrH0yFcSi28fnDA==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"

--- a/packages/matchbox-icons/package.json
+++ b/packages/matchbox-icons/package.json
@@ -25,8 +25,8 @@
   },
   "dependencies": {
     "prop-types": "^15.7.2",
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6"
+    "react": "^16.11.0",
+    "react-dom": "^16.11.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/packages/matchbox/package-lock.json
+++ b/packages/matchbox/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@sparkpost/matchbox",
-  "version": "3.7.2",
+  "version": "3.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -16,79 +16,6 @@
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/@sparkpost/design-tokens/-/design-tokens-0.0.4.tgz",
       "integrity": "sha512-bG5+UzROp4y57xrfTRbjz6cr3kNHOnn6CibPCwzV/dG3zmvDkfZPM8uumU5rdllxbzU4sid4sQ3skcZJ7Qu1LA=="
-    },
-    "@sparkpost/matchbox-icons": {
-      "version": "1.2.0",
-      "requires": {
-        "prop-types": "^15.7.2",
-        "react": "^16.8.6",
-        "react-dom": "^16.8.6"
-      },
-      "dependencies": {
-        "js-tokens": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-        },
-        "prop-types": {
-          "version": "15.7.2",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-          "requires": {
-            "loose-envify": "^1.4.0",
-            "object-assign": "^4.1.1",
-            "react-is": "^16.8.1"
-          }
-        },
-        "react": {
-          "version": "16.9.0",
-          "resolved": "https://registry.npmjs.org/react/-/react-16.9.0.tgz",
-          "integrity": "sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "react-dom": {
-          "version": "16.9.0",
-          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.9.0.tgz",
-          "integrity": "sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "scheduler": "^0.15.0"
-          }
-        },
-        "react-is": {
-          "version": "16.9.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
-          "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
-        },
-        "scheduler": {
-          "version": "0.15.0",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.15.0.tgz",
-          "integrity": "sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
-          }
-        }
-      }
     },
     "@types/acorn": {
       "version": "4.0.5",
@@ -6481,9 +6408,9 @@
       }
     },
     "react": {
-      "version": "16.9.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.9.0.tgz",
-      "integrity": "sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==",
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.11.0.tgz",
+      "integrity": "sha512-M5Y8yITaLmU0ynd0r1Yvfq98Rmll6q8AxaEe88c8e7LxO8fZ2cNgmFt0aGAS9wzf1Ao32NKXtCl+/tVVtkxq6g==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -6499,14 +6426,14 @@
       }
     },
     "react-dom": {
-      "version": "16.9.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.9.0.tgz",
-      "integrity": "sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==",
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.11.0.tgz",
+      "integrity": "sha512-nrRyIUE1e7j8PaXSPtyRKtz+2y9ubW/ghNgqKFHHAHaeP0fpF5uXR+sq8IMRHC+ZUxw7W9NyCDTBtwWxvkb0iA==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.15.0"
+        "scheduler": "^0.17.0"
       }
     },
     "react-focus-lock": {
@@ -7355,9 +7282,9 @@
       "dev": true
     },
     "scheduler": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.15.0.tgz",
-      "integrity": "sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.17.0.tgz",
+      "integrity": "sha512-7rro8Io3tnCPuY4la/NuI5F2yfESpnfZyT6TtkXnSWVkcu0BCDJ+8gk5ozUaFaxpIyNuWAPXrH0yFcSi28fnDA==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/packages/matchbox/package.json
+++ b/packages/matchbox/package.json
@@ -25,8 +25,8 @@
     "@sparkpost/matchbox-icons": "^1.2.1",
     "classnames": "^2.2.5",
     "prop-types": "^15.6.1",
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6",
+    "react": "^16.11.0",
+    "react-dom": "^16.11.0",
     "react-focus-lock": "^2.0.5",
     "react-transition-group": "^2.3.0"
   },

--- a/packages/matchbox/src/components/Snackbar/Snackbar.js
+++ b/packages/matchbox/src/components/Snackbar/Snackbar.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Close, Info, CheckCircle, Warning, ErrorIcon } from '@sparkpost/matchbox-icons';
-import { UnstyledLink } from '../';
+import { UnstyledLink } from '../UnstyledLink';
 import { onKey } from '../../helpers/keyEvents';
 
 import styles from './Snackbar.module.scss';

--- a/packages/matchbox/src/components/Snackbar/Snackbar.js
+++ b/packages/matchbox/src/components/Snackbar/Snackbar.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { Close, Info, CheckCircle, Warning, ErrorIcon } from '@sparkpost/matchbox-icons';
+import { UnstyledLink } from '../';
 import { onKey } from '../../helpers/keyEvents';
 
 import styles from './Snackbar.module.scss';
@@ -70,15 +71,14 @@ class Snackbar extends Component {
 
         <div className={styles.Content} style={{ maxWidth }}>{children}</div>
 
-        <a
+        <UnstyledLink
+          component='button'
           className={styles.Dismiss}
           onClick={onDismiss}
           onKeyDown={this.handleKeydown}
-          role="button"
-          href="javascript:void(0);"
         >
           <Close size={21} className={styles.DismissIcon} />
-        </a>
+        </UnstyledLink>
       </div>
     );
   }

--- a/packages/matchbox/src/components/Snackbar/Snackbar.module.scss
+++ b/packages/matchbox/src/components/Snackbar/Snackbar.module.scss
@@ -68,9 +68,9 @@
   margin-right: -4px;
   vertical-align: top;
   padding: rem(12) spacing();
-  border-bottom: none;
   user-select: none;
-
+  background: transparent;
+  border: none;
   color: color(gray, 10);
   font-size: font-size(200);
 

--- a/packages/matchbox/src/components/Snackbar/tests/__snapshots__/Snackbar.test.js.snap
+++ b/packages/matchbox/src/components/Snackbar/tests/__snapshots__/Snackbar.test.js.snap
@@ -22,18 +22,17 @@ exports[`Snackbar renders Snackbar 1`] = `
   >
     Snacksssss
   </div>
-  <a
+  <UnstyledLink
     className="Dismiss"
-    href="javascript:void(0);"
+    component="button"
     onClick={[MockFunction]}
     onKeyDown={[Function]}
-    role="button"
   >
     <Close
       className="DismissIcon"
       size={21}
     />
-  </a>
+  </UnstyledLink>
 </div>
 `;
 
@@ -59,17 +58,16 @@ exports[`Snackbar renders Snackbar with different props 1`] = `
   >
     Snacksssss
   </div>
-  <a
+  <UnstyledLink
     className="Dismiss"
-    href="javascript:void(0);"
+    component="button"
     onClick={[MockFunction]}
     onKeyDown={[Function]}
-    role="button"
   >
     <Close
       className="DismissIcon"
       size={21}
     />
-  </a>
+  </UnstyledLink>
 </div>
 `;

--- a/packages/matchbox/src/components/Tag/Tag.js
+++ b/packages/matchbox/src/components/Tag/Tag.js
@@ -50,11 +50,10 @@ class Tag extends Component {
 
     const closeMarkup = onRemove
       ? <UnstyledLink
+        component='button'
         className={styles.Close}
         onClick={onRemove}
-        onKeyDown={this.handleKeydown}
-        to="javascript:void(0)"
-        role="button">
+        onKeyDown={this.handleKeydown}>
         <Close size={16} />
 
         <ScreenReaderOnly>Close</ScreenReaderOnly>

--- a/packages/matchbox/src/components/Tag/Tag.module.scss
+++ b/packages/matchbox/src/components/Tag/Tag.module.scss
@@ -135,6 +135,7 @@
 .Close, a.Close {
   display: inline-block;
   padding: 0 rem(6);
+  border: none;
   border-radius: 0 border-radius(large) border-radius(large) 0;
   background: color(gray, 8);
   color: color(gray, 4);

--- a/packages/matchbox/src/components/Tag/tests/__snapshots__/Tag.test.js.snap
+++ b/packages/matchbox/src/components/Tag/tests/__snapshots__/Tag.test.js.snap
@@ -13,10 +13,9 @@ exports[`Tag renders with close button 1`] = `
   </div>
   <UnstyledLink
     className="Close"
+    component="button"
     onClick={[MockFunction]}
     onKeyDown={[Function]}
-    role="button"
-    to="javascript:void(0)"
   >
     <Close
       size={16}

--- a/packages/matchbox/src/components/Tooltip/TooltipOverlay.js
+++ b/packages/matchbox/src/components/Tooltip/TooltipOverlay.js
@@ -38,7 +38,7 @@ class TooltipOverlay extends Component {
     this.handleMeasurement();
   }
 
-  componentWillReceiveProps() {
+  UNSAFE_componentWillReceiveProps() {
     this.handleMeasurement();
   }
 

--- a/packages/matchbox/src/components/UnstyledLink/UnstyledLink.js
+++ b/packages/matchbox/src/components/UnstyledLink/UnstyledLink.js
@@ -9,7 +9,8 @@ class UnstyledLink extends Component {
     external: PropTypes.bool,
     component: PropTypes.oneOfType([
       PropTypes.func,
-      PropTypes.element
+      PropTypes.element,
+      PropTypes.string
     ]),
     children: PropTypes.node
   }

--- a/packages/matchbox/src/components/WindowEvent/WindowEvent.js
+++ b/packages/matchbox/src/components/WindowEvent/WindowEvent.js
@@ -24,7 +24,7 @@ class WindowEvent extends Component {
     this.addEvent();
   }
 
-  componentWillUpdate() {
+  UNSAFE_componentWillUpdate() {
     this.removeEvent();
   }
 


### PR DESCRIPTION
Resolves #273 

### What Changed
- Upgrades React and React DOM in all packages to 16.11.0
- Prepends deprecated lifecycle methods with `UNSAFE_`
- Replaces `a` links with inline javascript with buttons

### How To Test or Verify
- Run storybook with `npm run start:storybook`
- Open developer tools and verify no React warnings or errors are displayed on all stories
- (Optional) `npm link` with 2web2ui to make sure no additional changes are necessary

### PR Checklist
- [ ] Add your changes to `unreleased.md` in the root directory. If you plan on publishing immediately after merging (such as a hotfix) or aren't making changes to a published package, you can ignore this step.
- [ ] Provide screenshots or [screen recordings](https://getkap.co/) for any visual changes.
- [ ] Get approval from a UX team member (**#uxfe** or **#design-guild** on Slack) for any visual changes.
