### PR TITLE
Custom Deprecate Prop Type

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,6 +19,7 @@
         "skipBlankLines": true
       }
     ],
+    "max-params": ["error", 4],
     "object-curly-spacing": [
       "error",
       "always",

--- a/packages/matchbox/src/components/UnstyledLink/UnstyledLink.js
+++ b/packages/matchbox/src/components/UnstyledLink/UnstyledLink.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { deprecate } from '../../helpers/propTypes';
 
 class UnstyledLink extends Component {
   static displayName = 'UnstyledLink';
@@ -7,10 +8,8 @@ class UnstyledLink extends Component {
   static propTypes = {
     to: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     external: PropTypes.bool,
-    component: PropTypes.oneOfType([
-      PropTypes.func,
-      PropTypes.element
-    ]),
+    component: PropTypes.elementType,
+    Component: deprecate(PropTypes.elementType, 'Use "component" instead'),
     children: PropTypes.node
   }
 

--- a/packages/matchbox/src/helpers/propTypes.js
+++ b/packages/matchbox/src/helpers/propTypes.js
@@ -1,0 +1,36 @@
+
+let warned = {};
+
+/**
+ * Custom prop type that logs a warning that a prop is being deprecated
+ * @param {propType} propType
+ * @param {string} message
+ */
+function deprecate(propType, message) {
+  function validate(props, propName, componentName, ...rest) {
+
+    if (props[propName] != null && process.env.NODE_ENV !== 'production') {
+      const warning = `Matchbox: Deprecated prop "${propName}" of "${componentName}"\n${message}`;
+      if (!warned[warning]) {
+        warned[warning] = true;
+        console.warn(warning); // eslint-disable-line no-console
+        return;
+      }
+    }
+
+    return propType(props, propName, componentName, ...rest);
+  }
+
+  validate.isRequired = propType.isRequired; // Fixes react-docgen false positive
+  return validate;
+}
+
+function resetWarned() {
+  warned = {};
+}
+
+deprecate.resetWarned = resetWarned;
+
+export {
+  deprecate
+};

--- a/stories/navigation/UnstyledLink.stories.js
+++ b/stories/navigation/UnstyledLink.stories.js
@@ -6,6 +6,12 @@ import StoryContainer from '../storyHelpers/StoryContainer';
 
 import { UnstyledLink } from '@sparkpost/matchbox';
 
+class DemoWrapper extends React.Component {
+  render() {
+    return <a>{this.props.children}</a>;
+  }
+}
+
 storiesOf('Navigation|UnstyledLink', module)
   .addDecorator((getStory) => (
     <StoryContainer>{ getStory() }</StoryContainer>
@@ -17,4 +23,12 @@ storiesOf('Navigation|UnstyledLink', module)
 
   .add('with an external link', withInfo()(() => (
     <UnstyledLink to='https://google.com' external>Google</UnstyledLink>
+  )))
+  
+  .add('with wrapper components', withInfo()(() => (
+    <>
+      <UnstyledLink component='button'>Any valid HTML tag</UnstyledLink>
+      <UnstyledLink component={({ children }) => <a>{children}</a>}>A Function</UnstyledLink>
+      <UnstyledLink component={DemoWrapper}>A Component</UnstyledLink>
+    </>
   )));

--- a/unreleased.md
+++ b/unreleased.md
@@ -8,4 +8,4 @@
 - #272 - Adds primitive Text component
 - #277 - Removes usage of default token variants
 - #278 - Adds @sparkpost/design-tokens to the Matchbox monorepo
-- #278 - Adds a custom deprecate prop type
+- #280 - Adds a custom deprecate prop type

--- a/unreleased.md
+++ b/unreleased.md
@@ -8,3 +8,4 @@
 - #272 - Adds primitive Text component
 - #277 - Removes usage of default token variants
 - #278 - Adds @sparkpost/design-tokens to the Matchbox monorepo
+- #278 - Adds a custom deprecate prop type


### PR DESCRIPTION
### What Changed
- Adds a custom prop type wrapper called `deprecate` to provide end users with a warning message
- Makes use of `deprecate` on an already deprecated prop in `UnstyledLink`
- React's `prop-types` warning return an `Error`, this function returns a console warning. I'm not entirely sure of FB's reasoning here, or if I should use `Error` instead

### How To Test or Verify
- Verify the `Component` prop on `UnstyledLink` emits a console warning

### PR Checklist
- [x] Add your changes to `unreleased.md` in the root directory. If you plan on publishing immediately after merging (such as a hotfix) or aren't making changes to a published package, you can ignore this step.
- [x] Provide screenshots or [screen recordings](https://getkap.co/) for any visual changes.
- [x] Get approval from a UX team member (**#uxfe** or **#design-guild** on Slack) for any visual changes.
