### PR TITLE
Resolve #281 - Replace data-test with data-id

### DIFF
--- a/cypress/integration/Modal.spec.js
+++ b/cypress/integration/Modal.spec.js
@@ -7,25 +7,25 @@ describe('The Modal component', () => {
   });
 
   it('opens when clicking the "Open modal" button', () => {
-    cy.get('[data-test="open-modal"]').click();
+    cy.get('[data-id="open-modal"]').click();
 
     cy.contains('Are you sure you want to delete your template?').should('be.visible');
   });
 
   it('traps focus within the modal when rendered', () => {
-    cy.get('[data-test="open-modal"]').click();
+    cy.get('[data-id="open-modal"]').click();
 
     // Wait for transition animation
     cy.wait(300);
 
     // This is equivalent to tabbing when entering the window, so should handle the tab trap appropriately
     cy.get('body').tab();
-    cy.focused().should('have.attr', 'data-test', 'modal-close');
+    cy.focused().should('have.attr', 'data-id', 'modal-close');
     cy.focused().tab();
-    cy.focused().should('have.attr', 'data-test', 'delete-button');
+    cy.focused().should('have.attr', 'data-id', 'delete-button');
     cy.focused().tab();
-    cy.focused().should('have.attr', 'data-test', 'cancel-button');
+    cy.focused().should('have.attr', 'data-id', 'cancel-button');
     cy.focused().tab();
-    cy.focused().should('have.attr', 'data-test', 'modal-close');
+    cy.focused().should('have.attr', 'data-id', 'modal-close');
   });
 });

--- a/packages/matchbox/src/components/Modal/Content.js
+++ b/packages/matchbox/src/components/Modal/Content.js
@@ -47,7 +47,7 @@ class Content extends Component {
             const classes = classnames(styles.Content, state && styles[state]);
 
             return (
-              <div className={styles.ContentWrapper} ref={this.contentWrapperRef} tabIndex="-1" data-test="modal-content-wrapper">
+              <div className={styles.ContentWrapper} ref={this.contentWrapperRef} tabIndex="-1" data-id="modal-content-wrapper">
                 <div className={classes} ref={contentRef}>
                   {children}
                 </div>

--- a/packages/matchbox/src/components/Modal/Modal.js
+++ b/packages/matchbox/src/components/Modal/Modal.js
@@ -72,7 +72,7 @@ class Modal extends Component {
               <WindowEvent event='keydown' handler={this.handleKeyDown} />
               <WindowEvent event='click' handler={this.handleOutsideClick} />
               {showCloseButton && (
-                <Button className={styles.CloseButton} flat onClick={onClose} data-test='modal-close'>
+                <Button className={styles.CloseButton} flat onClick={onClose} data-id='modal-close'>
                   Close <Close />
                 </Button>
               )}

--- a/packages/matchbox/src/components/Modal/tests/__snapshots__/Modal.test.js.snap
+++ b/packages/matchbox/src/components/Modal/tests/__snapshots__/Modal.test.js.snap
@@ -70,7 +70,7 @@ exports[`Modal should render contents when open 2`] = `
 exports[`Modal should render contents when open 3`] = `
 <div
   className="ContentWrapper"
-  data-test="modal-content-wrapper"
+  data-id="modal-content-wrapper"
   tabIndex="-1"
 >
   <div
@@ -150,7 +150,7 @@ exports[`Modal should render modal with close button 1`] = `
         />
         <Button
           className="CloseButton"
-          data-test="modal-close"
+          data-id="modal-close"
           flat={true}
           onClick={[MockFunction]}
           size="default"

--- a/stories/overlays/Modal.stories.js
+++ b/stories/overlays/Modal.stories.js
@@ -18,7 +18,7 @@ class ModalDemo extends React.Component {
   render() {
     return (
       <div>
-        <a onClick={this.handleChange} href="javascript:void(0);" role="button" data-test="open-modal">
+        <a onClick={this.handleChange} href="javascript:void(0);" role="button" data-id="open-modal">
           Open modal
         </a>
 
@@ -26,9 +26,9 @@ class ModalDemo extends React.Component {
           <Panel title="Delete Template" sectioned accent>
             <p>Are you sure you want to delete your template?</p>
 
-            <Button style={{ marginRight: '1rem' }} primary onClick={this.handleChange} data-test="delete-button">Delete</Button>
+            <Button style={{ marginRight: '1rem' }} primary onClick={this.handleChange} data-id="delete-button">Delete</Button>
 
-            <Button onClick={this.handleChange} data-test="cancel-button">Cancel</Button>
+            <Button onClick={this.handleChange} data-id="cancel-button">Cancel</Button>
           </Panel>
         </Modal>
       </div>

--- a/unreleased.md
+++ b/unreleased.md
@@ -1,3 +1,3 @@
 ### Unreleased Changes
 
-- PR# - PR Title
+- #282 - Replace `data-test` with `data-id`


### PR DESCRIPTION
Resolves #281

### What Changed
- Replaces instances of `data-test` with `data-id`

### How To Test or Verify
- Tests that leverage these attributes continue to pass
- No instances of `data-test` remain in components

### PR Checklist
- [X] Add your changes to `unreleased.md` in the root directory. If you plan on publishing immediately after merging (such as a hotfix) or aren't making changes to a published package, you can ignore this step.
- [ ] Provide screenshots or [screen recordings](https://getkap.co/) for any visual changes. - **N/A**
- [ ] Get approval from a UX team member (**#uxfe** or **#design-guild** on Slack) for any visual changes. - **N/A**
