### PR TITLE
Resolve 283 - Fix vertical alignment of tag close button

### DIFF
--- a/packages/matchbox/src/components/Tag/Tag.module.scss
+++ b/packages/matchbox/src/components/Tag/Tag.module.scss
@@ -1,8 +1,9 @@
 @import '../../styles/config';
 
 .Tag {
-  display: inline-block;
+  display: inline-flex;
   white-space: nowrap;
+  align-items: center;
 }
 
 .hasRemove {

--- a/unreleased.md
+++ b/unreleased.md
@@ -1,3 +1,3 @@
 ### Unreleased Changes
 
-- PR# - PR Title
+- #284 - Fix vertical alignment of tag close button


### PR DESCRIPTION
Resolves #283 

### What Changed
- Fixes vertical alignment on the Tag close button

![Screen Shot 2019-11-25 at 10 37 54 AM](https://user-images.githubusercontent.com/3903325/69555924-ea02e200-0f71-11ea-98aa-4b0587d82ef9.png)

### How To Test or Verify
- `npm run start:storybook`
- Go to the Tag story: http://localhost:9001/?selectedKind=Feedback%7CTag&selectedStory=with%20remove%20action&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel
- Verify the close buttons align with tag content

### PR Checklist
- [x] Add your changes to `unreleased.md` in the root directory. If you plan on publishing immediately after merging (such as a hotfix) or aren't making changes to a published package, you can ignore this step.
-  Provide screenshots or [screen recordings](https://getkap.co/) for any visual changes.
-  Get approval from a UX team member (**#uxfe** or **#design-guild** on Slack) for any visual changes.
