### PR TITLE
Issues 295 & 296 - Fix track rendering with positive min values & pass through aria-controls

### DIFF
--- a/packages/matchbox/src/components/Slider/Slider.js
+++ b/packages/matchbox/src/components/Slider/Slider.js
@@ -186,6 +186,7 @@ function Slider(props) {
       />
       <div
         id={id}
+        aria-controls={props['aria-controls']}
         aria-valuemin={min}
         aria-valuemax={max}
         aria-valuenow={sliderValue}

--- a/packages/matchbox/src/components/Slider/Slider.js
+++ b/packages/matchbox/src/components/Slider/Slider.js
@@ -42,7 +42,7 @@ function Slider(props) {
   // Updates slider location when value changes
   React.useEffect(() => {
     if (rect.width) {
-      const absoluteProportion = (sliderValue + Math.abs(min)) / Math.abs(min - max);
+      const absoluteProportion = (sliderValue - min) / Math.abs(min - max);
       setSliderLocation(lerp(0, rect.width, absoluteProportion));
       if (onChange) {
         onChange(sliderValue);

--- a/packages/matchbox/src/components/Slider/Slider.js
+++ b/packages/matchbox/src/components/Slider/Slider.js
@@ -58,7 +58,7 @@ function Slider(props) {
     }
 
     return Object.keys(ticks).reduce((acc, number) => {
-      const absoluteProportion = (Number(number) + Math.abs(min)) / Math.abs(min - max);
+      const absoluteProportion = (Number(number) - min) / Math.abs(min - max);
       return {
         ...acc,
         [number]: {

--- a/packages/matchbox/src/components/Slider/Slider.js
+++ b/packages/matchbox/src/components/Slider/Slider.js
@@ -1,4 +1,4 @@
-/* eslint max-lines: ["error", 250] */
+/* eslint max-lines: ["error", 260] */
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
@@ -242,7 +242,11 @@ Slider.propTypes = {
   /**
    * A value to programatically control the slider
    */
-  value: PropTypes.number
+  value: PropTypes.number,
+  /**
+   * Describes a side-effect relationship with another DOM element
+   */
+  'aria-controls': PropTypes.string
 };
 
 export default Slider;

--- a/packages/matchbox/src/components/Slider/tests/Slider.test.js
+++ b/packages/matchbox/src/components/Slider/tests/Slider.test.js
@@ -35,6 +35,11 @@ describe('Slider component', () => {
     expect(slider.find('.Handle')).toHaveAttributeValue('id', 'test-id');
   });
 
+  it('should render an aria-controls attribute ', () => {
+    const slider = subject({ 'aria-controls': 'test-id' });
+    expect(slider.find('.Handle')).toHaveAttributeValue('aria-controls', 'test-id');
+  });
+
   it('should handle a provided value', () => {
     const slider = subject({ value: 50, onChange });
     expect(slider.find('.Track')).toHaveAttributeValue('style', { width: '100px' });

--- a/packages/matchbox/src/components/Slider/tests/Slider.test.js
+++ b/packages/matchbox/src/components/Slider/tests/Slider.test.js
@@ -48,6 +48,13 @@ describe('Slider component', () => {
     expect(onChange).toHaveBeenCalledWith(50);
   });
 
+  it('should handle a provided value with a min and max', () => {
+    const slider = subject({ value: 1000, onChange, min: 1000, max: 10000 });
+    expect(slider.find('.Track')).toHaveAttributeValue('style', { width: '0px' });
+    expect(slider.find('.Handle')).toHaveAttributeValue('style', { left: '0px' });
+    expect(slider.find('.Handle')).toHaveAttributeValue('aria-valuenow', '1000');
+  });
+
   it('should handle a mouse down', () => {
     const slider = subject({ value: 50, onChange });
     slider.find('.Slider').simulate('mouseDown', {

--- a/stories/form/Slider.stories.js
+++ b/stories/form/Slider.stories.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
-import { action } from '@storybook/addon-actions';
 import StoryContainer from '../storyHelpers/StoryContainer';
 
 import { Slider, TextField } from '@sparkpost/matchbox';

--- a/stories/form/Slider.stories.js
+++ b/stories/form/Slider.stories.js
@@ -14,7 +14,11 @@ export default storiesOf('Form|Slider', module)
 
   .add('basic slider', withInfo({})(() => {
     return (
-      <Slider defaultValue={50} />
+      <div>
+        <Slider min={100000} max={1000000}/>
+        <Slider min={-100} max={-50}/>
+        <Slider min={10} max={100}/>
+      </div>
     )
   }))
 

--- a/stories/form/Slider.stories.js
+++ b/stories/form/Slider.stories.js
@@ -15,7 +15,7 @@ export default storiesOf('Form|Slider', module)
   .add('basic slider', withInfo({})(() => {
     return (
       <div>
-        <Slider min={100000} max={1000000}/>
+        <Slider aria-controls='test-id' min={100000} max={1000000}/>
         <Slider min={-100} max={-50}/>
         <Slider min={10} max={100}/>
       </div>

--- a/unreleased.md
+++ b/unreleased.md
@@ -1,3 +1,3 @@
 ### Unreleased Changes
 
-- PR# - PR Title
+- #298 - Fix slider tracker rendering with positive min values

--- a/unreleased.md
+++ b/unreleased.md
@@ -1,3 +1,4 @@
 ### Unreleased Changes
 
 - #298 - Fix slider tracker rendering with positive min values
+- #298 - Slider now passes through the attribute 'aria-controls'


### PR DESCRIPTION
### What Changed
- Resolves #295 - Fixes a bug math in the slider handle position calculation when `min` is a positive number
- Resolves #296 - Slider passes through `aria-controls`

### How To Test or Verify
- Visit http://localhost:9001/?selectedKind=Form%7CSlider&selectedStory=basic%20slider&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel
- Interact with the first slider:
```js
<Slider min={100000} max={1000000}/>
```


### PR Checklist
- [x] Add your changes to `unreleased.md` in the root directory. If you plan on publishing immediately after merging (such as a hotfix) or aren't making changes to a published package, you can ignore this step.
- [x] Provide screenshots or [screen recordings](https://getkap.co/) for any visual changes.
- [x] Get approval from a UX team member (**#uxfe** or **#design-guild** on Slack) for any visual changes.
