### PR TITLE
FE-796 List matchbox-icons as a peer dependency

### DIFF
--- a/packages/matchbox/package.json
+++ b/packages/matchbox/package.json
@@ -22,7 +22,6 @@
   "sideEffects": false,
   "dependencies": {
     "@sparkpost/design-tokens": "0.0.4",
-    "@sparkpost/matchbox-icons": "^1.2.1",
     "classnames": "^2.2.5",
     "prop-types": "^15.6.1",
     "react": "^16.8.6",
@@ -30,7 +29,11 @@
     "react-focus-lock": "^2.0.5",
     "react-transition-group": "^2.3.0"
   },
+  "peerDependencies": {
+    "@sparkpost/matchbox-icons": "^1.2.0"
+  },
   "devDependencies": {
+    "@sparkpost/matchbox-icons": "^1.2.1",
     "autoprefixer": "^7.2.5",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",

--- a/unreleased.md
+++ b/unreleased.md
@@ -3,3 +3,4 @@
 - #298 - Fix slider tracker rendering with positive min values
 - #298 - Slider now passes through the attribute 'aria-controls'
 - #304 - Min value is now correctly is set as a default value if a default is not provided
+- #302 - List matchbox-icons as a peer dependency


### PR DESCRIPTION
### What Changed
- `matchbox-icons` is now listed as a peer dependency in `matchbox` to reduce bundle size

### How To Test or Verify
(After publishing)
- Install `matchbox` in an app, and verify icons are not bundled with the components
- Can use https://marketplace.visualstudio.com/items?itemName=wix.vscode-import-cost
- Or verify npm warns of a peer dependency when installing, while icons are uninstalled

### PR Checklist
- [x] Add your changes to `unreleased.md` in the root directory. If you plan on publishing immediately after merging (such as a hotfix) or aren't making changes to a published package, you can ignore this step.
