### PR TITLE
FE-773 - Toggle component (cypress tests)

### DIFF
--- a/cypress/integration/Toggle.spec.js
+++ b/cypress/integration/Toggle.spec.js
@@ -1,0 +1,68 @@
+/// <reference types="Cypress" />
+
+describe('The Toggle component', () => {
+  describe('Basic', () => {
+    beforeEach(() => {
+      cy.visit(
+        '/iframe.html?selectedKind=Action%7CToggle&selectedStory=basic%20toggle&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel'
+      );
+    });
+
+    it('Toggles!', () => {
+      cy.get('[data-id="toggle-input"]').should('not.be.checked');
+      cy.get('label').click();
+      cy.get('[data-id="toggle-input"]').should('be.checked');
+      cy.get('[data-id="toggle-input"]').uncheck({ force: true });
+      cy.get('[data-id="toggle-input"]').should('not.be.checked');
+    });
+  });
+
+  describe('Disabled', () => {
+    beforeEach(() => {
+      cy.visit(
+        '/iframe.html?selectedKind=Action%7CToggle&selectedStory=disabled%20toggle&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel'
+      );
+    });
+
+    it('Doesnt Toggle!', () => {
+      cy.get('label').click();
+      cy.get('[data-id="toggle-input"]').should('not.be.checked');
+      cy.get('label').click();
+      cy.get('[data-id="toggle-input"]').should('not.be.checked');
+    });
+  });
+
+  describe('Compact', () => {
+    beforeEach(() => {
+      cy.visit(
+        '/iframe.html?selectedKind=Action%7CToggle&selectedStory=compact%20toggle&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel'
+      );
+    });
+
+    it('Toggles!', () => {
+      cy.get('label').click();
+      cy.get('[data-id="toggle-input"]').should('be.checked');
+      cy.get('label').click();
+      cy.get('[data-id="toggle-input"]').should('not.be.checked');
+      cy.get('label').click();
+      cy.get('[data-id="toggle-input"]').should('be.checked');
+    });
+  });
+
+  describe('Compact disabled', () => {
+    beforeEach(() => {
+      cy.visit(
+        '/iframe.html?selectedKind=Action%7CToggle&selectedStory=compact%20and%20disabled%20toggle&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel'
+      );
+    });
+
+    it('Doesnt Toggle!', () => {
+      cy.get('label').click();
+      cy.get('[data-id="toggle-input"]').uncheck({ force: true });
+      cy.get('[data-id="toggle-input"]').should('be.checked');
+      cy.get('label').click();
+      cy.get('[data-id="toggle-input"]').uncheck({ force: true });
+      cy.get('[data-id="toggle-input"]').should('be.checked');
+    });
+  });
+});

--- a/stories/action/Toggle.stories.js
+++ b/stories/action/Toggle.stories.js
@@ -1,28 +1,27 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
-import { action } from '@storybook/addon-actions';
 import StoryContainer from '../storyHelpers/StoryContainer';
 
-import { Toggle, Checkbox } from '@sparkpost/matchbox';
+import { Toggle } from '@sparkpost/matchbox';
 
 export default storiesOf('Action|Toggle', module)
   .addDecorator((getStory) => (
-    <StoryContainer bg='white'>{ getStory() }</StoryContainer>
+    <StoryContainer bg='white'>{getStory()}</StoryContainer>
   ))
 
   .add('basic toggle', withInfo()(() => (
-    <Toggle id='id' />
+    <Toggle id='id' data-id="toggle-input" />
   )))
 
   .add('disabled toggle', withInfo()(() => (
-    <Toggle id='id' disabled />
+    <Toggle id='id' data-id="toggle-input" disabled />
   )))
 
   .add('compact toggle', withInfo()(() => (
-    <Toggle id='id' compact />
+    <Toggle id='id' data-id="toggle-input" compact />
   )))
 
   .add('compact and disabled toggle', withInfo()(() => (
-    <Toggle id='id' checked compact disabled />
+    <Toggle id='id' data-id="toggle-input" checked compact disabled />
   )));


### PR DESCRIPTION
FE-773 - Toggle component Cypress tests

### What Changed
Adds Cypress testing to the matchbox toggle component.

### How To Test or Verify

Run storybook locally -> `npm run start:storybook`
Run the e2e tests -> `npm run test:e2e:gui`

### PR Checklist
- [x] Add your changes to `unreleased.md` in the root directory. If you plan on publishing immediately after merging (such as a hotfix) or aren't making changes to a published package, you can ignore this step.
- [x] Provide screenshots or [screen recordings](https://getkap.co/) for any visual changes.
- [x] Get approval from a UX team member (**#uxfe** or **#design-guild** on Slack) for any visual changes.
