### PR TITLE
Scope pagination to container to skip storybook addons

### DIFF
--- a/cypress/integration/Pagination.spec.js
+++ b/cypress/integration/Pagination.spec.js
@@ -3,28 +3,27 @@
 describe('The Pagination component', () => {
   beforeEach(() => {
     cy.visit(
-      '/iframe.html?selectedKind=Navigation%7CPagination&selectedStory=with%20no%20margins&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel'
+      '/iframe.html?selectedKind=Navigation%7CPagination&selectedStory=with%20no%20margins&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel',
     );
   });
 
   it('Changes pages!', () => {
-    cy.queryByText('1').should('be.visible');
+    cy.get('[data-id="pagination-no-margin"]').then(elem => {
+      cy.findByText(/^1/, { container: elem }).should('be.visible');
 
-    cy.queryByText('2').click();
-    cy.queryByText('1').click();
+      cy.findByText(/^2/, { container: elem }).click();
+      cy.findByText(/^1/, { container: elem }).click();
 
-    cy.get('button:last-child > svg').click();
-    cy.get('button:last-child > svg').click();
-    cy.get('button:last-child > svg').click();
-    cy.get('button:last-child > svg').click();
-    cy.get('button:last-child > svg').click();
-    cy.get('button:last-child > svg').click();
-    cy.get('button:last-child > svg').click();
-    cy.get('button:last-child > svg').click();
-    cy.get('button:last-child > svg').click();
-    cy.get('button:last-child > svg').click();
-
-    cy.get('[data-id="pagination-no-margin"]').then((elem) => {
+      cy.get('button:last-child > svg').click();
+      cy.get('button:last-child > svg').click();
+      cy.get('button:last-child > svg').click();
+      cy.get('button:last-child > svg').click();
+      cy.get('button:last-child > svg').click();
+      cy.get('button:last-child > svg').click();
+      cy.get('button:last-child > svg').click();
+      cy.get('button:last-child > svg').click();
+      cy.get('button:last-child > svg').click();
+      cy.get('button:last-child > svg').click();
       cy.findByText(/^8/, { container: elem }).should('be.visible');
     });
   });
@@ -33,35 +32,31 @@ describe('The Pagination component', () => {
 describe('The Pagination component with lots of pages and flat buttons', () => {
   beforeEach(() => {
     cy.visit(
-      '/iframe.html?selectedKind=Navigation%7CPagination&selectedStory=with%20lots%20of%20pages%20and%20flat%20buttons&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel'
+      '/iframe.html?selectedKind=Navigation%7CPagination&selectedStory=with%20lots%20of%20pages%20and%20flat%20buttons&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel',
     );
   });
 
   it('Changes pages!', () => {
-    cy.queryByText('1').should('be.visible');
+    cy.get('[data-id="pagination-flat"]').then(elem => {
+      cy.findByText(/^1/, { container: elem }).should('be.visible');
 
-    cy.get('button:last-child > svg').click();
-    cy.get('button:first-child > svg').click();
-    cy.get('button:last-child > svg').click();
-    cy.get('button:last-child > svg').click();
-    cy.get('button:last-child > svg').click();
-    cy.get('button:last-child > svg').click();
-    cy.get('button:last-child > svg').click();
-    cy.get('button:last-child > svg').click();
-    cy.get('button:last-child > svg').click();
-    cy.get('button:last-child > svg').click();
-    cy.get('button:last-child > svg').click();
-    cy.get('button:last-child > svg').click();
+      cy.get('button:last-child > svg').click();
+      cy.get('button:first-child > svg').click();
+      cy.get('button:last-child > svg').click();
+      cy.get('button:last-child > svg').click();
+      cy.get('button:last-child > svg').click();
+      cy.get('button:last-child > svg').click();
+      cy.get('button:last-child > svg').click();
+      cy.get('button:last-child > svg').click();
+      cy.get('button:last-child > svg').click();
+      cy.get('button:last-child > svg').click();
+      cy.get('button:last-child > svg').click();
+      cy.get('button:last-child > svg').click();
 
-    cy.get('[data-id="pagination-flat"]').then((elem) => {
       cy.findByText(/^30/, { container: elem }).should('be.visible');
       cy.findByText(/^30/, { container: elem }).click();
-    });
-
-    cy.get('[data-id="pagination-flat"]').then((elem) => {
       cy.findByText(/^1/, { container: elem }).should('be.visible');
       cy.findByText(/^1/, { container: elem }).click();
     });
   });
 });
-


### PR DESCRIPTION
Small follow up to FE-776

### What Changed
- Scopes Pagination's Cypress tests to avoid picking up on Storybook addons

### How To Test or Verify
- Start storybook and run e2e tests
- `npm run start:storybook` and `test:e2e:headless`

### PR Checklist
- NA