### PR TITLE
FE-778 - Add cypress tests for the tooltip component 

### DIFF
--- a/cypress/integration/Tooltip.spec.js
+++ b/cypress/integration/Tooltip.spec.js
@@ -1,0 +1,26 @@
+/// <reference types="Cypress" />
+
+/* eslint-disable no-undef */
+describe('The Tooltip component', () => {
+  beforeEach(() => {
+    cy.visit(
+      '/iframe.html?selectedKind=Overlays%7CTooltip&selectedStory=Default%20Style&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel',
+    );
+  });
+
+  it('should open when a mouse over event triggers.', () => {
+    cy.queryAllByText('Messages an ISP or other remote domain accepted').should('not.be.visible');
+    cy.get('button')
+      .first()
+      .trigger('mouseover');
+    cy.queryAllByText('Messages an ISP or other remote domain accepted').should('be.visible');
+  });
+
+  it('should open when clicking', () => {
+    cy.queryAllByText('Messages an ISP or other remote domain accepted').should('not.be.visible');
+    cy.get('button')
+      .first()
+      .click();
+    cy.queryAllByText('Messages an ISP or other remote domain accepted').should('be.visible');
+  });
+});

--- a/cypress/integration/Tooltip.spec.js
+++ b/cypress/integration/Tooltip.spec.js
@@ -1,6 +1,5 @@
 /// <reference types="Cypress" />
 
-/* eslint-disable no-undef */
 describe('The Tooltip component', () => {
   beforeEach(() => {
     cy.visit(
@@ -9,18 +8,28 @@ describe('The Tooltip component', () => {
   });
 
   it('should open when a mouse over event triggers.', () => {
-    cy.queryAllByText('Messages an ISP or other remote domain accepted').should('not.be.visible');
+    cy.findAllByText('Messages an ISP or other remote domain accepted').should('not.be.visible');
+
     cy.get('button')
       .first()
       .trigger('mouseover');
-    cy.queryAllByText('Messages an ISP or other remote domain accepted').should('be.visible');
+
+    cy.findAllByText('Messages an ISP or other remote domain accepted').should('be.visible');
+
+    cy.get('button')
+      .first()
+      .trigger('mouseout');
+
+    cy.findAllByText('Messages an ISP or other remote domain accepted').should('not.be.visible');
   });
 
   it('should open when clicking', () => {
-    cy.queryAllByText('Messages an ISP or other remote domain accepted').should('not.be.visible');
+    cy.findAllByText('Messages an ISP or other remote domain accepted').should('not.be.visible');
+
     cy.get('button')
       .first()
       .click();
-    cy.queryAllByText('Messages an ISP or other remote domain accepted').should('be.visible');
+
+    cy.findAllByText('Messages an ISP or other remote domain accepted').should('be.visible');
   });
 });

--- a/packages/matchbox/src/components/Tooltip/Tooltip.module.scss
+++ b/packages/matchbox/src/components/Tooltip/Tooltip.module.scss
@@ -10,7 +10,9 @@ $arrow-margin: 10px;
   .Content {
     visibility: visible;
   }
+
   .Tooltip {
+    visibility: visible;
     opacity: 1;
     transform: translate(0, 0) scale(1);
   }
@@ -80,6 +82,7 @@ $arrow-margin: 10px;
 }
 
 .Tooltip {
+  visibility: hidden;
   display: block;
   position: absolute;
   z-index: 1;

--- a/packages/matchbox/src/components/Tooltip/Tooltip.module.scss
+++ b/packages/matchbox/src/components/Tooltip/Tooltip.module.scss
@@ -7,6 +7,9 @@ $arrow-margin: 10px;
 }
 
 .hover {
+  .Content {
+    visibility: visible;
+  }
   .Tooltip {
     opacity: 1;
     transform: translate(0, 0) scale(1);
@@ -14,7 +17,8 @@ $arrow-margin: 10px;
 }
 
 .dark {
-  .Tip, .Tooltip {
+  .Tip,
+  .Tooltip {
     background: color(gray, 1);
     border: none !important;
   }
@@ -97,6 +101,7 @@ $arrow-margin: 10px;
 }
 
 .Content {
+  visibility: hidden;
   position: relative;
   z-index: 1;
   border-radius: border-radius(large);

--- a/unreleased.md
+++ b/unreleased.md
@@ -1,3 +1,4 @@
 ### Unreleased Changes
 
-- PR# - PR Title
+- #778 - Added visibility styles to the tooltip component to allow Cypress to work evaluate if the
+  tooltip is visibile or not


### PR DESCRIPTION
### What Changed
Added cypress tests for the tooltip component.

### How To Test or Verify
Run storybook locally -> `npm run start:storybook`
Run the e2e tests -> `npm run test:e2e:gui`

### PR Checklist
- [x] Add your changes to `unreleased.md` in the root directory. If you plan on publishing immediately after merging (such as a hotfix) or aren't making changes to a published package, you can ignore this step.
- [x] Provide screenshots or [screen recordings](https://getkap.co/) for any visual changes.
- [x] Get approval from a UX team member (**#uxfe** or **#design-guild** on Slack) for any visual changes.
