### PR TITLE
FE-852 Add Motion Tokens

### DIFF
--- a/packages/design-tokens/formats/meta.js.js
+++ b/packages/design-tokens/formats/meta.js.js
@@ -1,11 +1,11 @@
-const { getPalette, getName, kebabToFriendly, getCommonJsName } = require('./utils');
+const { getPalette, getName, kebabToFriendly, getCommonJsName, replacePrefix } = require('./utils');
 
 function map(result) {
   const { props, aliases } = result.toJS();
   const baseline = Number(aliases.DEFAULT_BASE.value.replace('px', ''));
 
   function renderProp(prop) {
-    let scssMapGet = `${prop.type}(${getName(prop.name)})`;
+    let scssMapGet = `${prop.type}(${replacePrefix(prop.name, prop.type)})`;
     const friendly = kebabToFriendly(prop.name);
 
     // Hides 'base' from function arguments on nested maps
@@ -26,7 +26,7 @@ function map(result) {
       return `"pixel_value": "${value}px", "pixel_value_unitless": "${value}"`;
     }
 
-    return (`{
+    return `{
       "category": "${prop.category}",
       "css": "--${prop.name}",
       "friendly": "${friendly}",
@@ -36,7 +36,7 @@ function map(result) {
       "type": "${prop.type}",
       "value": "${prop.value}",
       ${declarePixelValues()}
-    }`);
+    }`;
   }
 
   return `module.exports = [${props.map(renderProp)}]`;

--- a/packages/design-tokens/formats/utils.js
+++ b/packages/design-tokens/formats/utils.js
@@ -1,18 +1,24 @@
+function replacePrefix(name, prefix) {
+  return name.replace(`${prefix}-`, '');
+}
+
 function getName(name, prefix) {
-  const noPrefix = name.replace(`${prefix}-`, '').split('-');
+  const noPrefix = replacePrefix(name, prefix).split('-');
   return noPrefix.pop();
 }
 
 function getPalette(name, prefix) {
-  return name.replace(`${prefix}-`, '').split('-').shift();
+  return name
+    .replace(`${prefix}-`, '')
+    .split('-')
+    .shift();
 }
 
 function groupByPalette(props, prefix) {
-  const withPalette = props.map((prop) => ({
+  const withPalette = props.map(prop => ({
     ...prop,
-    palette: getPalette(prop.name, prefix)
-  }
-  ));
+    palette: getPalette(prop.name, prefix),
+  }));
 
   const groupedByPalette = withPalette.reduce((acc, prop) => {
     if (!acc[prop.palette]) {
@@ -28,11 +34,11 @@ function groupByPalette(props, prefix) {
 }
 
 function kebabToCamel(str) {
-  return str.replace(/-([a-z|0-9])/g, (g) => g[1].toUpperCase());
+  return str.replace(/-([a-z|0-9])/g, g => g[1].toUpperCase());
 }
 
 function kebabToFriendly(str) {
-  const r = str.replace(/-([a-z|0-9])/g, (g) => ` ${g[1].toUpperCase()}`);
+  const r = str.replace(/-([a-z|0-9])/g, g => ` ${g[1].toUpperCase()}`);
   return r.charAt(0).toUpperCase() + r.slice(1);
 }
 /**
@@ -47,7 +53,7 @@ function getCommonJsName(str, type) {
   const parts = variantOrPalette.split('-');
 
   const prefix = kebabToCamel(type);
-  const getVariant = (str) => str === 'base' ? '' : `_${str}`;
+  const getVariant = str => (str === 'base' ? '' : `_${str}`);
 
   if (parts.length === 1) {
     return `${prefix}${getVariant(parts.pop())}`;
@@ -62,5 +68,6 @@ module.exports = {
   getCommonJsName,
   groupByPalette,
   kebabToCamel,
-  kebabToFriendly
+  kebabToFriendly,
+  replacePrefix,
 };

--- a/packages/design-tokens/gulpfile.js/index.js
+++ b/packages/design-tokens/gulpfile.js/index.js
@@ -17,33 +17,36 @@ theo.registerTransform('docs', ['color/hex']);
 theo.registerTransform('web', ['color/hex']);
 
 // Format sources
-const deepMapSources = [
-  { src: 'tokens/color.yml', prefix: 'color' }
-];
+const deepMapSources = [{ src: 'tokens/color.yml', prefix: 'color' }];
 
 const scssMapSources = [
   { src: 'tokens/border-radius.yml' },
   { src: 'tokens/border-width.yml' },
   { src: 'tokens/box-shadow.yml' },
   { src: 'tokens/media-query.yml' },
+  { src: 'tokens/motion-duration.yml' },
+  { src: 'tokens/motion-ease.yml' },
   { src: 'tokens/font-family.yml' },
   { src: 'tokens/font-size.yml' },
   { src: 'tokens/font-weight.yml' },
   { src: 'tokens/line-height.yml' },
   { src: 'tokens/spacing.yml' },
-  { src: 'tokens/z-index.yml' }
+  { src: 'tokens/z-index.yml' },
 ];
 
 const indexFormats = ['common.js', 'custom-properties.css', 'meta.js'];
 
-gulp.task('deep-map', (done) => {
+gulp.task('deep-map', done => {
   deepMapSources.map(({ src, ...options }) => {
-    gulp.src(src)
-      .pipe(gulpTheo({
-        transform: { type: 'web', includeMeta: true },
-        format: { type: 'deep-map.scss', options }
-      }))
-      .on('error', (err) => {
+    gulp
+      .src(src)
+      .pipe(
+        gulpTheo({
+          transform: { type: 'web', includeMeta: true },
+          format: { type: 'deep-map.scss', options },
+        }),
+      )
+      .on('error', err => {
         throw new Error(err);
       })
       .pipe(gulp.dest('dist'));
@@ -51,14 +54,17 @@ gulp.task('deep-map', (done) => {
   done();
 });
 
-gulp.task('map', (done) => {
+gulp.task('map', done => {
   scssMapSources.map(({ src }) => {
-    gulp.src(src)
-      .pipe(gulpTheo({
-        transform: { type: 'web' },
-        format: { type: 'map.scss' }
-      }))
-      .on('error', (err) => {
+    gulp
+      .src(src)
+      .pipe(
+        gulpTheo({
+          transform: { type: 'web' },
+          format: { type: 'map.scss' },
+        }),
+      )
+      .on('error', err => {
         throw new Error(err);
       })
       .pipe(gulp.dest('dist'));
@@ -66,30 +72,38 @@ gulp.task('map', (done) => {
   done();
 });
 
-gulp.task('index', (done) => {
-  indexFormats.map((type) => {
-    gulp.src('tokens/index.yml')
-      .pipe(gulpTheo({
-        transform: { type: 'web' },
-        format: { type }
-      }))
+gulp.task('index', done => {
+  indexFormats.map(type => {
+    gulp
+      .src('tokens/index.yml')
+      .pipe(
+        gulpTheo({
+          transform: { type: 'web' },
+          format: { type },
+        }),
+      )
       .pipe(gulp.dest('dist'));
   });
   done();
 });
 
-gulp.task('docs', () => gulp.src('tokens/index.yml')
-  .pipe(gulpTheo({
-    transform: { type: 'docs' },
-    format: {
-      type: 'html',
-      options: { transformPropName: (a) => a }
-    }
-  }))
-  .pipe(gulp.dest('docs')));
+gulp.task('docs', () =>
+  gulp
+    .src('tokens/index.yml')
+    .pipe(
+      gulpTheo({
+        transform: { type: 'docs' },
+        format: {
+          type: 'html',
+          options: { transformPropName: a => a },
+        },
+      }),
+    )
+    .pipe(gulp.dest('docs')),
+);
 
 gulp.task('serve', () => {
-  browserSync.init({ server: { baseDir: 'docs' }});
+  browserSync.init({ server: { baseDir: 'docs' } });
   gulp.watch('tokens/*.yml', gulp.task('docs')).on('change', browserSync.reload);
 });
 

--- a/packages/design-tokens/package-lock.json
+++ b/packages/design-tokens/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@sparkpost/design-tokens",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sparkpost/design-tokens",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "SparkPost Design Tokens",
   "main": "index.js",
   "style": "dist/index.scss",

--- a/packages/design-tokens/tokens.scss
+++ b/packages/design-tokens/tokens.scss
@@ -7,5 +7,7 @@
 @import "./dist/font-weight.map.scss";
 @import "./dist/line-height.map.scss";
 @import "./dist/media-query.map.scss";
+@import "./dist/motion-duration.map.scss";
+@import "./dist/motion-ease.map.scss";
 @import "./dist/spacing.map.scss";
 @import "./dist/z-index.map.scss";

--- a/packages/design-tokens/tokens/index.yml
+++ b/packages/design-tokens/tokens/index.yml
@@ -8,5 +8,7 @@ imports:
   - ./font-weight.yml
   - ./line-height.yml
   - ./media-query.yml
+  - ./motion-duration.yml
+  - ./motion-ease.yml
   - ./spacing.yml
   - ./z-index.yml

--- a/packages/design-tokens/tokens/motion-duration.yml
+++ b/packages/design-tokens/tokens/motion-duration.yml
@@ -1,0 +1,10 @@
+global:
+  category: motion-duration
+  type: motion-duration
+props:
+  - name: motion-duration-fast
+    value: '0.15s'
+  - name: motion-duration-medium
+    value: '0.3s'
+  - name: motion-duration-slow
+    value: '0.7s'

--- a/packages/design-tokens/tokens/motion-ease.yml
+++ b/packages/design-tokens/tokens/motion-ease.yml
@@ -1,0 +1,10 @@
+global:
+  category: motion-ease
+  type: motion-ease
+props:
+  - name: motion-ease-in
+    value: 'cubic-bezier(.35, 0, .7, .2)'
+  - name: motion-ease-out
+    value: 'cubic-bezier(0, 0, .3, 1)'
+  - name: motion-ease-inout
+    value: 'cubic-bezier(.4, 0, .3, 1)'

--- a/packages/design-tokens/tokens/motion-ease.yml
+++ b/packages/design-tokens/tokens/motion-ease.yml
@@ -6,5 +6,5 @@ props:
     value: 'cubic-bezier(.35, 0, .7, .2)'
   - name: motion-ease-out
     value: 'cubic-bezier(0, 0, .3, 1)'
-  - name: motion-ease-inout
+  - name: motion-ease-in-out
     value: 'cubic-bezier(.4, 0, .3, 1)'

--- a/packages/matchbox/package-lock.json
+++ b/packages/matchbox/package-lock.json
@@ -1010,9 +1010,9 @@
       "integrity": "sha512-kBa+cDHOR9jpRJ+kcGMsysrls0leukrm68DmFQoMIWQcXdr2cZvyvypWuGYT7U+9kAExUE7+T7r6G3C3A6L8MQ=="
     },
     "@sparkpost/design-tokens": {
-      "version": "1.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@sparkpost/design-tokens/-/design-tokens-1.0.0-beta.14.tgz",
-      "integrity": "sha512-FZCJ4r9fZDKZ2XxZN1nqlbgHYaQRfYj21jN/gCBPxNcsRatghKkJHy1RvpPd9LcXZnB9cI9d9vOBqU9+7AcFfQ=="
+      "version": "1.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@sparkpost/design-tokens/-/design-tokens-1.0.0-beta.15.tgz",
+      "integrity": "sha512-/4sNFUOSjhAytk6poaM3IlAtQI/3//UzOnTOUd8xXwyz8Uc8xkIwOa5IUK7VUcGfCSmpWdIesTK7mYtQQFnxUw=="
     },
     "@sparkpost/matchbox-icons": {
       "version": "1.2.1",

--- a/packages/matchbox/package.json
+++ b/packages/matchbox/package.json
@@ -21,7 +21,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@sparkpost/design-tokens": "^1.0.0-beta.14",
+    "@sparkpost/design-tokens": "^1.0.0-beta.15",
     "@sparkpost/matchbox-icons": "^1.2.1",
     "@styled-system/prop-types": "^5.1.2",
     "classnames": "^2.2.5",


### PR DESCRIPTION
### What Changed
Adds the following transition property tokens:
- duration
  - motion-duration-fast: 0.15s
  - motion-duration-medium: 0.3s
  - motion-duration-slow: 0.7s
- easing
  - motion-ease-in: cubic-bezier(.35, 0, .7, .2)
  - motion-ease-out: cubic-bezier(0, 0, .3, 1)
  - motion-ease-inout: cubic-bezier(.4, 0, .3, 1)

### How To Test or Verify
- Run the token build locally from within design-tokens with `npm run build`
- Inspect the built assets in `dist` to verify the two sets of tokens

### PR Checklist
- [ ] Provide screenshots or [screen recordings](https://getkap.co/) for any visual changes.
- [ ] Get approval from a UX team member (**#uxfe** or **#design-guild** on Slack) for any visual changes.
