### PR TITLE
FE-906 Add lightGray Tag variant and rename gray to darkGray

### DIFF
--- a/packages/matchbox/src/components/Tag/Tag.js
+++ b/packages/matchbox/src/components/Tag/Tag.js
@@ -44,7 +44,7 @@ function Tag(props) {
 Tag.displayName = 'Tag';
 Tag.propTypes = {
   /**
-   * 'orange' | 'blue' | 'yellow' | 'red' | 'navy' | 'purple' | 'green' | 'magenta' | 'teal' | 'gray'
+   * 'orange' | 'blue' | 'yellow' | 'red' | 'navy' | 'purple' | 'green' | 'magenta' | 'teal' | 'lightGray' | 'darkGray'
    */
   color: PropTypes.oneOf([
     'orange',
@@ -56,7 +56,8 @@ Tag.propTypes = {
     'green',
     'magenta',
     'teal',
-    'gray',
+    'lightGray',
+    'darkGray',
   ]),
   /**
    * Close button is hidden unless this is provided

--- a/packages/matchbox/src/components/Tag/styles.js
+++ b/packages/matchbox/src/components/Tag/styles.js
@@ -84,12 +84,16 @@ export const tagColor = props => {
       border = tokens.color_teal_500;
       color = tokens.color_teal_800;
       break;
-    case 'gray':
-    default:
+    case 'darkGray':
       bg = tokens.color_gray_300;
       border = tokens.color_gray_500;
       color = tokens.color_gray_900;
       break;
+    case 'lightGray':
+    default:
+      bg = tokens.color_gray_100;
+      border = tokens.color_gray_400;
+      color = tokens.color_gray_900;
   }
 
   return `
@@ -134,9 +138,13 @@ export const closeColor = props => {
       bg = tokens.color_teal_500;
       color = tokens.color_teal_800;
       break;
-    case 'gray':
-    default:
+    case 'darkGray':
       bg = tokens.color_gray_500;
+      color = tokens.color_gray_900;
+      break;
+    case 'lightGray':
+    default:
+      bg = tokens.color_gray_300;
       color = tokens.color_gray_900;
       break;
   }

--- a/packages/matchbox/src/components/Tag/tests/Tag.test.js
+++ b/packages/matchbox/src/components/Tag/tests/Tag.test.js
@@ -8,7 +8,7 @@ import Tag from '../Tag';
 describe('Tag', () => {
   it('should render a default tag', () => {
     const wrapper = global.mountStyled(<Tag>Hola!</Tag>);
-    expect(wrapper).toHaveStyleRule('background', '#d9e0e6');
+    expect(wrapper).toHaveStyleRule('background', '#f5f8fa');
     expect(wrapper).toHaveStyleRule('color', '#39444d');
     expect(wrapper.find('button')).not.toExist();
   });

--- a/stories/feedback/Tag.stories.js
+++ b/stories/feedback/Tag.stories.js
@@ -52,7 +52,7 @@ export const Colors = withInfo()(() => (
     <Tag onRemove={action('Tag Remove')} color="teal">
       domain.com
     </Tag>
-    <Tag onRemove={action('Tag Remove')} color="gray">
+    <Tag onRemove={action('Tag Remove')} color="darkGray">
       domain.com
     </Tag>
     <Tag>domain.com</Tag>

--- a/unreleased.md
+++ b/unreleased.md
@@ -27,3 +27,4 @@
 - #334 - Banner component dismiss button is now screen reader accessible
 - #334 - Banner with a status of 'default' now defaults to 'info'
 - #334 - Links within the Banner component overwrite color and hover color to be accessible
+- #341 - Adds a lightGray and darkGray variant to Tag component


### PR DESCRIPTION
### What Changed
For the Tag component: 
Renamed the "gray" variant to "darkGray", added a "lightGray" variant and made that the default.

### How To Test or Verify
Verify the default Tag has background color `color_gray_100` with `color_gray_400` border.
Verify the "lightGray" Tag has background color `color_gray_100` with `color_gray_400` border.
Verify the "darkGray" Tag has background color `color_gray_300` with `color_gray_500` border.

### PR Checklist
- [x] Add your changes to `unreleased.md` in the root directory. If you plan on publishing immediately after merging (such as a hotfix) or aren't making changes to a published package, you can ignore this step.
- [x] Provide screenshots or [screen recordings](https://getkap.co/) for any visual changes.
- [x] Get approval from a UX team member (**#uxfe** or **#design-guild** on Slack) for any visual changes.
