### PR TITLE
FE-916 Fix Banner buttons as links

### DIFF
--- a/packages/matchbox/src/components/Banner/Banner.js
+++ b/packages/matchbox/src/components/Banner/Banner.js
@@ -49,6 +49,9 @@ function IconSection({ status }) {
 const StyledContainer = styled(Box)`
   ${container}
   ${margin}
+`;
+
+const StyledChildren = styled('div')`
   ${childLinks}
 `;
 
@@ -100,7 +103,9 @@ function Banner(props) {
       <IconSection status={status} />
       <Box flex="1" order={['1', null, '0']} flexBasis={['100%', null, 'auto']}>
         {titleMarkup}
-        <Box mb={actionMarkup ? '500' : '0'}>{children}</Box>
+        <Box mb={actionMarkup ? '500' : '0'}>
+          <StyledChildren>{children}</StyledChildren>
+        </Box>
         {actionMarkup}
       </Box>
       {dismissMarkup}


### PR DESCRIPTION
### What Changed
- Restricts the link color override in Banners to only children and not Banner buttons

### How To Test or Verify
- Run storybook with `npm run start:storybook`
- Visit banner stories, add a `to` prop to one of the banner actions. EG:
```js
<Banner
  action={{
    content: 'test',
    to: 'test',
    external: true
  }}
>
```
