### PR TITLE
FE-921 Tag contents and close button are not vertically aligned

### DIFF
--- a/packages/matchbox/src/components/ComboBox/ComboBoxTextField.js
+++ b/packages/matchbox/src/components/ComboBox/ComboBoxTextField.js
@@ -38,31 +38,25 @@ function ComboBoxTextField(props) {
   const setWrapperClasses = classnames(
     styles.Wrapper,
     error && styles.Error,
-    disabled && styles.Disabled
+    disabled && styles.Disabled,
   );
 
   const labelMarkup = (
     <Label id={id} label={label}>
-      {error && errorInLabel && <Error className={styles.InlineError} wrapper='span' error={error} />}
+      {error && errorInLabel && (
+        <Error className={styles.InlineError} wrapper="span" error={error} />
+      )}
     </Label>
   );
 
-  const helpMarkup = helpText
-    ? <div className={styles.HelpText}>{helpText}</div>
-    : null;
+  const helpMarkup = helpText ? <div className={styles.HelpText}>{helpText}</div> : null;
 
   const selectedMarkup = selectedItems.length
     ? selectedItems.map((item, i) => (
-      <Tag
-        key={i}
-        onRemove={!disabled
-          ? () => removeItem(item)
-          : null
-        }
-      >
-        {itemToString(item)}
-      </Tag>
-    ))
+        <div className={styles.WrapperItem} key={i}>
+          <Tag onRemove={!disabled ? () => removeItem(item) : null}>{itemToString(item)}</Tag>
+        </div>
+      ))
     : null;
 
   // Auto focuses the input
@@ -88,23 +82,25 @@ function ComboBoxTextField(props) {
       {label && !labelHidden && labelMarkup}
       <div className={setWrapperClasses} onClick={handleClick}>
         {selectedMarkup}
-        <input
-          {...rest}
-          autoFocus={autoFocus}
-          className={styles.Input}
-          disabled={disabled}
-          id={id}
-          name={name}
-          onFocus={onFocus}
-          onBlur={onBlur}
-          onChange={onChange}
-          onKeyDown={handleKeyDown}
-          placeholder={placeholder}
-          readOnly={readOnly}
-          ref={inputRef}
-          style={style}
-          value={value}
-        />
+        <div className={classnames(styles.WrapperItem, styles.Grow)} key="input">
+          <input
+            {...rest}
+            autoFocus={autoFocus}
+            className={styles.Input}
+            disabled={disabled}
+            id={id}
+            name={name}
+            onFocus={onFocus}
+            onBlur={onBlur}
+            onChange={onChange}
+            onKeyDown={handleKeyDown}
+            placeholder={placeholder}
+            readOnly={readOnly}
+            ref={inputRef}
+            style={style}
+            value={value}
+          />
+        </div>
       </div>
       {error && !errorInLabel && <Error error={error} />}
       {helpMarkup}
@@ -129,13 +125,13 @@ ComboBoxTextField.propTypes = {
   placeholder: PropTypes.string,
   readOnly: PropTypes.bool,
   removeItem: PropTypes.func,
-  selectedItems: PropTypes.array
+  selectedItems: PropTypes.array,
 };
 
 ComboBoxTextField.defaultProps = {
   selectedItems: [],
   itemToString: identity,
-  removeItem: noop
+  removeItem: noop,
 };
 
 export default ComboBoxTextField;

--- a/packages/matchbox/src/components/ComboBox/ComboBoxTextField.module.scss
+++ b/packages/matchbox/src/components/ComboBox/ComboBoxTextField.module.scss
@@ -21,8 +21,6 @@
 }
 
 .Input {
-  flex: 1;
-  display: inline-block;
   outline: none;
   border: none;
   background: transparent;
@@ -31,7 +29,8 @@
   font-weight: 400;
   font-size: font-size(400);
   line-height: rem(24);
-  padding: rem(3) rem(3);
+
+  width: 100%; // fill remaining space
 
   &:disabled {
     background: color(gray, 9);
@@ -47,7 +46,7 @@
   flex-wrap: wrap;
   align-items: center;
 
-  padding: rem(2) rem(6);
+  padding: rem(6) 0 0 rem(6);
 
   outline: none;
   border: 1px solid color(gray, 7);
@@ -74,11 +73,13 @@
   &:hover:not(.Disabled) {
     cursor: text;
   }
+}
 
-  // Targets tags
-  & > div {
-    display: inline-block;
-    margin: 0 3px 0 0;
+.WrapperItem {
+  margin: 0 rem(6) rem(6) 0;
+
+  &.Grow {
+    flex: 1;
   }
 }
 

--- a/packages/matchbox/src/components/ComboBox/tests/__snapshots__/ComboBoxTextField.test.js.snap
+++ b/packages/matchbox/src/components/ComboBox/tests/__snapshots__/ComboBoxTextField.test.js.snap
@@ -3,13 +3,11 @@
 exports[`ComboBoxTextField selected items should render selected items correctly 1`] = `
 Array [
   <Tag
-    key="0"
     onRemove={[Function]}
   >
     foo
   </Tag>,
   <Tag
-    key="1"
     onRemove={[Function]}
   >
     bar
@@ -29,23 +27,36 @@ exports[`ComboBoxTextField should render the full fieldset with label, id, error
     className="Wrapper Error"
     onClick={[Function]}
   >
-    <Tag
+    <div
+      className="WrapperItem"
       key="0"
-      onRemove={[Function]}
     >
-      foo
-    </Tag>
-    <Tag
+      <Tag
+        onRemove={[Function]}
+      >
+        foo
+      </Tag>
+    </div>
+    <div
+      className="WrapperItem"
       key="1"
-      onRemove={[Function]}
     >
-      bar
-    </Tag>
-    <input
-      className="Input"
-      id="test-id"
-      onKeyDown={[Function]}
-    />
+      <Tag
+        onRemove={[Function]}
+      >
+        bar
+      </Tag>
+    </div>
+    <div
+      className="WrapperItem Grow"
+      key="input"
+    >
+      <input
+        className="Input"
+        id="test-id"
+        onKeyDown={[Function]}
+      />
+    </div>
   </div>
   <Error
     error="error"

--- a/packages/matchbox/src/components/Tag/Tag.module.scss
+++ b/packages/matchbox/src/components/Tag/Tag.module.scss
@@ -3,7 +3,6 @@
 .Tag {
   display: inline-flex;
   white-space: nowrap;
-  align-items: center;
 }
 
 .hasRemove {
@@ -134,7 +133,8 @@
 }
 
 .Close, a.Close {
-  display: inline-block;
+  display: flex;
+  align-items: center;
   padding: 0 rem(6);
   border-radius: 0 border-radius(large) border-radius(large) 0;
   background: color(gray, 8);
@@ -148,9 +148,5 @@
   &:active {
     color: color(gray, 1);
     background: color(gray, 7);
-  }
-
-  & > * {
-    margin-top: -0.2em;
   }
 }

--- a/unreleased.md
+++ b/unreleased.md
@@ -2,3 +2,4 @@
 
 - #778 - Added visibility styles to the tooltip component to allow Cypress to work evaluate if the
   tooltip is visibile or not
+- #345 - Fixed spacing and tag alignment of ComboBoxTextField


### PR DESCRIPTION
This is follow-up to #284 

### What Changed
- Wrapped ComboBoxTextField items with `<div />`'s to control the spacing

<img width="1106" alt="Screen Shot 2020-03-05 at 11 28 28 PM" src="https://user-images.githubusercontent.com/1335605/76053276-b0f7e780-5f3a-11ea-967a-bac3f3dc1213.png">

<img width="298" alt="Screen Shot 2020-03-05 at 11 28 17 PM" src="https://user-images.githubusercontent.com/1335605/76053290-b81ef580-5f3a-11ea-89db-7a824e42188d.png">

<img width="1108" alt="Screen Shot 2020-03-05 at 11 31 44 PM" src="https://user-images.githubusercontent.com/1335605/76053300-bbb27c80-5f3a-11ea-81a3-78d67ca4e4b3.png">

<img width="435" alt="Screen Shot 2020-03-05 at 11 32 30 PM" src="https://user-images.githubusercontent.com/1335605/76053308-bf460380-5f3a-11ea-9bd5-fc5278d19e2e.png">

### How To Test or Verify
- Make sure to change the with of the available space to test wrapping
