### PR TITLE
FE-918 - Fix active styled-component link styles (Snackbar Links)

### DIFF
--- a/packages/matchbox/src/components/Snackbar/styles.js
+++ b/packages/matchbox/src/components/Snackbar/styles.js
@@ -7,15 +7,29 @@ export const base = () => `
 `;
 
 export const status = props => {
-  const whiteLinks = `a, a:visited {color: ${tokens.color_white};}`;
-  const greyLinks = `a, a:visited {color: ${tokens.color_gray_900};}`;
+  function makeLinkColorStyles(color) {
+    return `
+      a, 
+      a:hover, 
+      a:visited { 
+        color: ${color} !important; 
+      }
+    `;
+  }
+  const whiteLinks = makeLinkColorStyles(tokens.color_white);
+  const greyLinks = makeLinkColorStyles(tokens.color_gray_900);
 
   switch (props.status) {
     case 'success':
-      return `${whiteLinks} background: ${tokens.color_green_800};`;
+      return `
+        ${whiteLinks} 
+        background: ${tokens.color_green_800};
+      `;
     case 'danger':
     case 'error':
-      return `${whiteLinks} background: ${tokens.color_red_700};`;
+      return `
+        ${whiteLinks} background: ${tokens.color_red_700};
+      `;
     case 'warning':
       return `
         ${greyLinks} 
@@ -24,7 +38,9 @@ export const status = props => {
       `;
     case 'default':
     default:
-      return `${whiteLinks} background: ${tokens.color_blue_800};`;
+      return `
+        ${whiteLinks} background: ${tokens.color_blue_800};
+      `;
   }
 };
 

--- a/packages/matchbox/src/components/Snackbar/styles.js
+++ b/packages/matchbox/src/components/Snackbar/styles.js
@@ -7,20 +7,24 @@ export const base = () => `
 `;
 
 export const status = props => {
+  const whiteLinks = `a, a:visited {color: ${tokens.color_white};}`;
+  const greyLinks = `a, a:visited {color: ${tokens.color_gray_900};}`;
+
   switch (props.status) {
     case 'success':
-      return `background: ${tokens.color_green_800};`;
+      return `${whiteLinks} background: ${tokens.color_green_800};`;
     case 'danger':
     case 'error':
-      return `background: ${tokens.color_red_700};`;
+      return `${whiteLinks} background: ${tokens.color_red_700};`;
     case 'warning':
       return `
+        ${greyLinks} 
         background: ${tokens.color_yellow_300};
         color: ${tokens.color_gray_900};
       `;
     case 'default':
     default:
-      return `background: ${tokens.color_blue_800};`;
+      return `${whiteLinks} background: ${tokens.color_blue_800};`;
   }
 };
 

--- a/stories/feedback/Snackbar.stories.js
+++ b/stories/feedback/Snackbar.stories.js
@@ -14,15 +14,17 @@ export default {
 
 export const Statuses = withInfo({ propTables: [Snackbar] })(() => (
   <Inline space="600">
-    <Snackbar onDismiss={action('Dismissed')}>Snakz</Snackbar>
+    <Snackbar onDismiss={action('Dismissed')}>
+      Snakz <a href="https://sparkpost.github.io/matchbox/">link</a>
+    </Snackbar>
     <Snackbar status="success" onDismiss={action('Dismissed')}>
-      Snakz good
+      Snakz good <a href="https://sparkpost.github.io/matchbox/">link</a>
     </Snackbar>
     <Snackbar status="warning" onDismiss={action('Dismissed')}>
-      Yer suspended
+      Yer suspended <a href="https://sparkpost.github.io/matchbox/">link</a>
     </Snackbar>
     <Snackbar status="danger" onDismiss={action('Dismissed')}>
-      Something went wrong
+      Something went wrong <a href="https://sparkpost.github.io/matchbox/">link</a>
     </Snackbar>
   </Inline>
 ));
@@ -31,7 +33,8 @@ export const Large = withInfo()(() => (
   <Snackbar maxWidth={700}>
     This one is large enough to get into some bacon ipsum dolor amet pork loin tri-tip turkey
     capicola. Rump doner short ribs biltong burgdoggen meatloaf. Prosciutto pork loin bacon, biltong
-    landjaeger salami ham spare ribs flank cupim porchetta leberkas.
+    landjaeger salami ham spare ribs flank cupim porchetta leberkas.{' '}
+    <a href="https://sparkpost.github.io/matchbox/">link</a>
   </Snackbar>
 ));
 
@@ -43,7 +46,7 @@ export const ResponsiveSystemProps = withInfo({ propTables: [Snackbar] })(() => 
       my={['200', '700', '300', '800']}
       mx="400"
     >
-      Yer suspended
+      Yer suspended <a href="https://sparkpost.github.io/matchbox/">link</a>
     </Snackbar>
     <Snackbar status="success" onDismiss={action('Dismissed')} mx={['200', '700', '300', '800']}>
       Template deleted

--- a/unreleased.md
+++ b/unreleased.md
@@ -36,3 +36,4 @@
 - #341 - Adds a lightGray and darkGray variant to Tag component
 - #342 - Restyles the Table component and adds configurable padding
 - #342 - Add header prop type to Table Row - type bool
+- #352 - Add link styles for status styled-component

--- a/unreleased.md
+++ b/unreleased.md
@@ -36,4 +36,4 @@
 - #341 - Adds a lightGray and darkGray variant to Tag component
 - #342 - Restyles the Table component and adds configurable padding
 - #342 - Add header prop type to Table Row - type bool
-- #352 - Add link styles for status styled-component
+- #352 - Add link styles for the status styled-component


### PR DESCRIPTION
### What Changed
Added link styles for the status styled component.

![image](https://user-images.githubusercontent.com/4204806/76347871-4dbcdb00-62d5-11ea-818a-3b7be5a9c49a.png)


### How To Test or Verify
Load up the snackbar in storybook and verify the links I put in are the correct color per status. (Links should also be underlined)

### PR Checklist
- [x] Add your changes to `unreleased.md` in the root directory. If you plan on publishing immediately after merging (such as a hotfix) or aren't making changes to a published package, you can ignore this step.
- [x] Provide screenshots or [screen recordings](https://getkap.co/) for any visual changes.
- [x] Get approval from a UX team member (**#uxfe** or **#design-guild** on Slack) for any visual changes.
