### PR TITLE
FE-926 Specify Button Type

### DIFF
--- a/packages/matchbox/src/components/Banner/Banner.js
+++ b/packages/matchbox/src/components/Banner/Banner.js
@@ -84,7 +84,7 @@ function Banner(props) {
 
   const dismissMarkup = onDismiss ? (
     <Box flex={['1', null, '0']} textAlign="right">
-      <StyledDismiss as="button" onClick={onDismiss} status={status} color="gray.800">
+      <StyledDismiss as="button" onClick={onDismiss} status={status} color="gray.800" type="button">
         <ScreenReaderOnly>Dismiss</ScreenReaderOnly>
         <Close size={24} />
       </StyledDismiss>

--- a/packages/matchbox/src/components/Banner/styles.js
+++ b/packages/matchbox/src/components/Banner/styles.js
@@ -71,6 +71,9 @@ export function dismissBase() {
   return `
     padding: 0.25rem;
     transition: background ${tokens.motionDuration_fast} ${tokens.motionEase_in_out};
+    &:hover {
+      cursor: pointer;
+    }
   `;
 }
 

--- a/packages/matchbox/src/components/Expandable/Expandable.js
+++ b/packages/matchbox/src/components/Expandable/Expandable.js
@@ -3,7 +3,7 @@ import Proptypes from 'prop-types';
 import styled from 'styled-components';
 import { margin } from 'styled-system';
 import { createPropTypes } from '@styled-system/prop-types';
-import { KeyboardArrowRight } from '@sparkpost/matchbox-icons';
+import { KeyboardArrowLeft } from '@sparkpost/matchbox-icons';
 import { onKeys } from '../../helpers/keyEvents';
 import { buttonReset } from '../../styles/helpers';
 import { expandable, header, title, subtitle, arrow, contentWrapper } from './styles';
@@ -109,6 +109,7 @@ function Expandable(props) {
           onKeyDown={handleKeyDown}
           ref={header}
           data-id="expandable-toggle"
+          type="button"
         >
           {iconMarkup}
           <Box display="inline-block" flex="1">
@@ -117,7 +118,7 @@ function Expandable(props) {
           </Box>
           <Box display="inline-block" flex="0">
             <StyledArrow isOpen={isOpen}>
-              <KeyboardArrowRight size={26} />
+              <KeyboardArrowLeft size={26} />
             </StyledArrow>
           </Box>
         </StyledHeader>

--- a/packages/matchbox/src/components/Expandable/styles.js
+++ b/packages/matchbox/src/components/Expandable/styles.js
@@ -36,7 +36,7 @@ export const header = () => `
 `;
 
 export const arrow = props => {
-  let rotate = 'rotate(0deg)';
+  let rotate = 'rotate(-90deg)';
 
   if (props.isOpen) {
     rotate = 'rotate(90deg)';

--- a/packages/matchbox/src/components/Expandable/tests/Expandable.test.js
+++ b/packages/matchbox/src/components/Expandable/tests/Expandable.test.js
@@ -17,7 +17,7 @@ describe('Expandable component', () => {
     );
     expect(wrapper.find(Expandable.Arrow)).toHaveStyleRule(
       'transform',
-      open ? 'rotate(90deg)' : 'rotate(0deg)',
+      open ? 'rotate(90deg)' : 'rotate(-90deg)',
     );
     expect(wrapper.find(Expandable.ContentWrapper)).toHaveStyleRule(
       'visibility',

--- a/packages/matchbox/src/components/Snackbar/Snackbar.js
+++ b/packages/matchbox/src/components/Snackbar/Snackbar.js
@@ -33,7 +33,14 @@ function Snackbar(props) {
       <Box fontSize="200" lineHeight="200" py="100" pr="400" maxWidth={maxWidth} minWidth="12.5rem">
         {children}
       </Box>
-      <StyledClose status={status} as="button" p="0.125rem" mx="100" onClick={onDismiss}>
+      <StyledClose
+        status={status}
+        as="button"
+        p="0.125rem"
+        mx="100"
+        onClick={onDismiss}
+        type="button"
+      >
         <Close size={24} />
         <ScreenReaderOnly>Close</ScreenReaderOnly>
       </StyledClose>

--- a/packages/matchbox/src/components/Snackbar/Snackbar.js
+++ b/packages/matchbox/src/components/Snackbar/Snackbar.js
@@ -7,6 +7,7 @@ import { createPropTypes } from '@styled-system/prop-types';
 import { Close, Info, CheckCircle, Warning, ErrorIcon } from '@sparkpost/matchbox-icons';
 import { margin } from 'styled-system';
 import { base, status, dismiss, dismissStatus } from './styles';
+import { buttonReset } from '../../styles/helpers';
 
 const StyledBox = styled(Box)`
   ${base}
@@ -15,6 +16,7 @@ const StyledBox = styled(Box)`
 `;
 
 const StyledClose = styled(Box)`
+  ${buttonReset}
   ${dismiss}
   ${dismissStatus}
 `;

--- a/packages/matchbox/src/components/Snackbar/styles.js
+++ b/packages/matchbox/src/components/Snackbar/styles.js
@@ -47,6 +47,9 @@ export const status = props => {
 export const dismiss = () => `
   display: inline-flex;
   transition: background ${tokens.motionDuration_fast};
+  &:hover {
+    cursor: pointer;
+  }
 `;
 
 export const dismissStatus = props => {

--- a/packages/matchbox/src/components/Snackbar/styles.js
+++ b/packages/matchbox/src/components/Snackbar/styles.js
@@ -46,8 +46,6 @@ export const status = props => {
 
 export const dismiss = () => `
   display: inline-flex;
-  border: none;
-  background: transparent;
   transition: background ${tokens.motionDuration_fast};
 `;
 

--- a/packages/matchbox/src/components/Tag/Tag.js
+++ b/packages/matchbox/src/components/Tag/Tag.js
@@ -27,7 +27,7 @@ function Tag(props) {
   const { color, children, onRemove, className, ...rest } = props;
 
   const closeMarkup = onRemove ? (
-    <StyledClose onClick={onRemove} tagColor={color}>
+    <StyledClose onClick={onRemove} tagColor={color} type="button">
       <Close size={16} />
       <ScreenReaderOnly>Close</ScreenReaderOnly>
     </StyledClose>

--- a/unreleased.md
+++ b/unreleased.md
@@ -45,3 +45,4 @@
 - #351 - ThemeProvider now injects global CSS and the exported `styles.css` should no longer be used
 - #348 - Restyles the Tabs component
 - #348 - Tab `connectBelow` is removed in favor of margin system props
+- #354 - Adds type="button" to Snackbar, Banner, Tag, Expandable button elements


### PR DESCRIPTION
### What Changed
- Specifies `type="button"` on component buttons in Snackbar, Banner, Expandable, Tag
- Also changes the expandable arrow rotations to match mockups

### How To Test or Verify
- Run storybook with `npm run start:storybook`
- Verify these component buttons have type specified
- Optional, use one of these components in an HTML form and verify they do not submit the form. Try wrapping expandable with `<form onSubmit={() => alert('submit')}>` in a story.
  - Try with Safari, I couldn't reproduce with Chrome

### PR Checklist
- [x] Add your changes to `unreleased.md` in the root directory. If you plan on publishing immediately after merging (such as a hotfix) or aren't making changes to a published package, you can ignore this step.