### PR TITLE
FE-944 Fix Table.Row styling

### DIFF
--- a/packages/matchbox/src/components/Table/TableElements.js
+++ b/packages/matchbox/src/components/Table/TableElements.js
@@ -57,9 +57,9 @@ HeaderCell.propTypes = {
 };
 HeaderCell.displayName = 'Table.HeaderCell';
 
-const Row = ({ rowData, children, className, header, ...rest }) => {
+const Row = ({ rowData, children, className, ...rest }) => {
   return (
-    <StyledRow header={header} className={className} {...rest}>
+    <StyledRow className={className} {...rest}>
       {rowData ? rowData.map((value, i) => <Cell value={value} key={`Cell-${i}`} />) : children}
     </StyledRow>
   );
@@ -69,7 +69,6 @@ Row.propTypes = {
   rowData: PropTypes.array,
   className: PropTypes.string,
   children: PropTypes.node,
-  header: PropTypes.bool,
 };
 Row.displayName = 'Table.Row';
 

--- a/packages/matchbox/src/components/Table/styles.js
+++ b/packages/matchbox/src/components/Table/styles.js
@@ -5,9 +5,7 @@ export const table = () => `
   text-align: left;
   width: 100%;
   padding: 0;
-
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  border-collapse: collapse;
 `;
 
 export const headerCell = () => `
@@ -20,12 +18,15 @@ export const cell = () => `
   word-break: break-all;
 `;
 
-export const row = props => `
+export const row = () => `
   background: ${tokens.color_white};
-  border-bottom: ${
-    props.header ? `${tokens.borderWidth_100} solid ${tokens.color_gray_400}` : 'none'
+  border: none;
+
+  thead & {
+    border-bottom: ${tokens.borderWidth_100} solid ${tokens.color_gray_400};
   }
-  &:nth-of-type(odd) {
-    background: ${props.header ? tokens.color_white : tokens.color_gray_100};
+
+  tbody &:nth-of-type(even) {
+    background: ${tokens.color_gray_100};
   }
 `;

--- a/unreleased.md
+++ b/unreleased.md
@@ -35,7 +35,6 @@
 - #340 - Select with the required prop now applies the required HTML attribute to the input
 - #341 - Adds a lightGray and darkGray variant to Tag component
 - #342 - Restyles the Table component and adds configurable padding
-- #342 - Add header prop type to Table Row - type bool
 - #343 - Update the Pager Component
 - #352 - Add link styles for the status styled-component
 - #349 - Restyles the TextField component


### PR DESCRIPTION
### What Changed
- Fixes spacing issues between cells (not sure how/when this got introduced)
- Scopes table row styles to `thead` and `tbody`
- Removes the `header`, was added in the Table restyling PR but can be removed now

### How To Test or Verify
- Run storybook with `npm run start:storybook`
- Verify there are no visual bugs on the Table stories

