### PR TITLE
FE-950 & FE-983 – Prevent tab content from wrapping, Specify tab button type, Fix component wrappers

### DIFF
--- a/packages/matchbox/src/components/Tabs/Tabs.js
+++ b/packages/matchbox/src/components/Tabs/Tabs.js
@@ -39,6 +39,7 @@ function Tab(props) {
       fitted={fitted}
       {...rest}
       onClick={handleClick}
+      type="button"
     >
       {content}
     </StyledTab>

--- a/packages/matchbox/src/components/Tabs/Tabs.js
+++ b/packages/matchbox/src/components/Tabs/Tabs.js
@@ -34,7 +34,9 @@ function Tab(props) {
 
   return (
     <StyledTab
-      component="button" // Ensures focusability
+      // Ensures focusability
+      // Overwriting component does not guarantee focusability
+      component={rest.component || rest.Component || 'button'}
       selected={selected === index}
       fitted={fitted}
       {...rest}

--- a/packages/matchbox/src/components/Tabs/Tabs.js
+++ b/packages/matchbox/src/components/Tabs/Tabs.js
@@ -25,18 +25,21 @@ const StyledTabs = styled('div')`
 `;
 
 function Tab(props) {
-  const { index, content, selected, fitted, ...rest } = props;
+  const { index, content, selected, fitted, component, Component, ...rest } = props;
 
   function handleClick(event) {
     const { index, onClick } = props;
     onClick(event, index);
   }
 
+  // Buttons ensure focusability
+  // Links will be focusable with an href
+  // TODO deprecate `Component`
+  const wrapper = component || Component || 'button';
+
   return (
     <StyledTab
-      // Ensures focusability
-      // Overwriting component does not guarantee focusability
-      component={rest.component || rest.Component || 'button'}
+      component={wrapper}
       selected={selected === index}
       fitted={fitted}
       {...rest}

--- a/packages/matchbox/src/components/Tabs/styles.js
+++ b/packages/matchbox/src/components/Tabs/styles.js
@@ -5,6 +5,7 @@ export const tabStyles = ({ selected, fitted }) => `
   ${buttonReset}
   position: relative;
   flex: ${fitted ? '1' : '0'};
+  text-decoration: none;
   
   padding: 0 ${tokens.spacing_200};
   ${'' /* Not a token, equivalent to 20px to enqure 10rem of spacing between text */}

--- a/packages/matchbox/src/components/Tabs/styles.js
+++ b/packages/matchbox/src/components/Tabs/styles.js
@@ -14,6 +14,7 @@ export const tabStyles = ({ selected, fitted }) => `
   font-weight: ${tokens.fontWeight_medium};
   line-height: 3.75rem; ${'' /* Equivalent to 60px */}
   color: ${selected ? tokens.color_blue_700 : tokens.color_gray_700};
+  white-space: nowrap;
 
   &:after {
     display: block;

--- a/packages/matchbox/src/components/Tabs/tests/Tabs.test.js
+++ b/packages/matchbox/src/components/Tabs/tests/Tabs.test.js
@@ -46,4 +46,11 @@ describe('Tabs', () => {
     expect(wrapper).toHaveStyleRule('margin-left', '10px', { media });
     expect(wrapper).toHaveStyleRule('margin-right', tokens.spacing_400);
   });
+
+  it('renders a custom tab component', () => {
+    const wrapper = subject({
+      tabs: [...defaultprops.tabs, { content: 'Tab 4', component: props => <a {...props} /> }],
+    });
+    expect(wrapper.find('a').text()).toEqual('Tab 4');
+  });
 });

--- a/stories/navigation/Tabs.stories.js
+++ b/stories/navigation/Tabs.stories.js
@@ -21,6 +21,11 @@ const tabs = [
     content: 'Example with long text',
     onClick: action('Domains Clicked'),
   },
+  {
+    content: 'Example with a component wrapper',
+    onClick: action('Domains Clicked'),
+    Component: props => <a {...props} href="#" />,
+  },
 ];
 
 const handleSelect = action('Tab Selected');

--- a/stories/navigation/Tabs.stories.js
+++ b/stories/navigation/Tabs.stories.js
@@ -18,7 +18,7 @@ const tabs = [
     onClick: action('Keys Clicked'),
   },
   {
-    content: 'Domains',
+    content: 'Example with long text',
     onClick: action('Domains Clicked'),
   },
 ];

--- a/unreleased.md
+++ b/unreleased.md
@@ -68,3 +68,4 @@
 - #358 - Adds Action proptypes, used internally by ActionList
 - #358 - ActionList actions now accept a new `is` prop, and accept either `link` `button` or
   `checkbox`
+- #361 – Tabs not specify `type="button"`

--- a/unreleased.md
+++ b/unreleased.md
@@ -68,4 +68,4 @@
 - #358 - Adds Action proptypes, used internally by ActionList
 - #358 - ActionList actions now accept a new `is` prop, and accept either `link` `button` or
   `checkbox`
-- #361 – Tabs not specify `type="button"`
+- #361 – Tabs now specify `type="button"` and support long text content


### PR DESCRIPTION
### What Changed
- Prevents tab text from wrapping for tabs with multiple words
- Specifies button `type` to prevent forms from submitting when clicking tabs
- Fixes instances where `component` or `Component` pass through a link

### How To Test or Verify
- Run storybook with `npm run start:storybook`
- Visit tab stories, verify text does not wrap
- Optionally, you can wrap tabs in a `form` with an onSubmit to check if clicking a tab submits the form