### PR TITLE
FE-942 - <Label/> component does not render when no "label" prop is provided

### DIFF
--- a/packages/matchbox/src/components/Label/Label.js
+++ b/packages/matchbox/src/components/Label/Label.js
@@ -14,6 +14,10 @@ function Label(props) {
     mb = '100',
   } = props;
 
+  if (!label) {
+    return null;
+  }
+
   if (labelHidden) {
     return (
       <ScreenReaderOnly>

--- a/packages/matchbox/src/components/Label/tests/Label.test.js
+++ b/packages/matchbox/src/components/Label/tests/Label.test.js
@@ -27,6 +27,6 @@ describe('Label', () => {
   it('renders null when no "label" prop is provided', () => {
     const wrapper = global.mountStyled(<Label />);
 
-    expect(wrapper).toBeNull();
+    expect(wrapper).not.toExist();
   });
 });

--- a/packages/matchbox/src/components/Label/tests/Label.test.js
+++ b/packages/matchbox/src/components/Label/tests/Label.test.js
@@ -27,6 +27,6 @@ describe('Label', () => {
   it('renders null when no "label" prop is provided', () => {
     const wrapper = global.mountStyled(<Label />);
 
-    expect(wrapper).not.toExist();
+    expect(wrapper.find('label')).not.toExist();
   });
 });

--- a/packages/matchbox/src/components/Label/tests/Label.test.js
+++ b/packages/matchbox/src/components/Label/tests/Label.test.js
@@ -23,4 +23,10 @@ describe('Label', () => {
     expect(wrapper.find('label')).toHaveAttributeValue('id', 'label1Label');
     expect(wrapper.find('label')).toHaveAttributeValue('for', 'label1');
   });
+
+  it('renders null when no "label" prop is provided', () => {
+    const wrapper = global.mountStyled(<Label />);
+
+    expect(wrapper).toBeNull();
+  });
 });

--- a/packages/matchbox/src/components/Select/Select.js
+++ b/packages/matchbox/src/components/Select/Select.js
@@ -123,7 +123,7 @@ function Select(props) {
 
   return (
     <StyledWrapper {...systemProps}>
-      {label && labelMarkup}
+      {labelMarkup}
       <Box position="relative">
         <StyledSelect
           id={id}

--- a/unreleased.md
+++ b/unreleased.md
@@ -73,3 +73,4 @@
 - #362 - Deprecates Pagination prop `selectedColor`
 - #362 - Deprecates Pagination prop `flat`
 - #360 - Adds new `fontSize_root` token
+- #363 - `<Label/>` renders `null` when no `label` is provided


### PR DESCRIPTION
[FE-942](https://jira.int.messagesystems.com/browse/FE-942)

### What Changed
- `<Label/>` renders as `null` when no `"label"` is passed in

### How To Test or Verify
- Verify no `<Label/>` renders for the `<TextField/>` or `<Select/>` when no `"label"` is provided.

### PR Checklist
- [ ] Incorporate feedback
