### PR TITLE
FE-982 - Properly pass height to styled component

### DIFF
--- a/packages/matchbox/src/components/TextField/TextField.js
+++ b/packages/matchbox/src/components/TextField/TextField.js
@@ -30,7 +30,7 @@ const FieldBox = props => {
       borderRadius="100"
       bg={props.disabled ? 'gray.200' : 'white'}
       lineHeight="2.5rem"
-      height="2.5rem"
+      height={props.height}
       color="gray.900"
       required={props.required}
     />

--- a/unreleased.md
+++ b/unreleased.md
@@ -86,3 +86,4 @@
 - #371 - Restyles `<Modal/>` component using styled components
 - #371 - Adds React Portal to the `<Modal/>` component with a new `portalId` prop to handle
   rendering
+- #375 - Resolve bug by properly passing the `height` prop to a child styled component


### PR DESCRIPTION
[FE-982](https://jira.int.messagesystems.com/browse/FE-982)

### What Changed
- Properly pass height prop to styled component that was set statically

### How To Test or Verify
- Run Storybook locally and go here: `/iframe.html?id=form-textfield--multiline`
- Verify that on the `rc/4.0.0` and go to the above URL, verify the bug. Checkout `FE-982` and verify the bug is fixed.

### PR Checklist
- [ ] Add your changes to `unreleased.md` in the root directory. If you plan on publishing immediately after merging (such as a hotfix) or aren't making changes to a published package, you can ignore this step.
