### PR TITLE
FE-997 Add modal container vertical padding, Fix white background ove…

### DIFF
--- a/packages/matchbox/src/components/Modal/styles.js
+++ b/packages/matchbox/src/components/Modal/styles.js
@@ -10,6 +10,7 @@ export const base = props => {
     left: 0;
     width: 100vw;
     height: 100vh;
+    padding: ${tokens.spacing_700} 0;
     min-height: 100%;
     max-height: 100vh;
     pointer-events: ${props.open ? 'auto' : 'none'};

--- a/packages/matchbox/src/components/Panel/styles.js
+++ b/packages/matchbox/src/components/Panel/styles.js
@@ -20,6 +20,7 @@ export const headerText = () => `
 export const panel = () => `
   position: relative;
   background: ${tokens.color_white};
+  border-radius: ${tokens.borderRadius_100};
   padding: ${tokens.spacing_0};
 `;
 

--- a/unreleased.md
+++ b/unreleased.md
@@ -107,3 +107,5 @@
 - #380 - Fix Toggle checked prop
 - #380 - Add defaultChecked prop to Toggle
 - #379 - Converts EmptyState to be styled component
+- #381 - Adds vertical padding to modal containers
+- #381 - Adds border radius to panel containers


### PR DESCRIPTION
### What Changed
- Adds vertical padding to modal containers, so content never touchers the viewport edges
- (extra) Adds border radius to panels – background color was previously overflowing past borders

![Screen Shot 2020-04-13 at 9 58 32 AM](https://user-images.githubusercontent.com/3903325/79126638-55591f00-7d6e-11ea-85ec-3ff1281f8a22.png)


### How To Test or Verify
- Run storybook with `npm run start:storybook`
- Visit modal stories and resize viewport vertically
- Verify modal content does not touch the top of the browser

### PR Checklist
- [x] Add your changes to `unreleased.md` in the root directory. If you plan on publishing immediately after merging (such as a hotfix) or aren't making changes to a published package, you can ignore this step.
