### PR TITLE
FE-1018 Support CSS injection DOM node targeting

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,5 @@
+<!--
+  See ThemeProvider component
+  This is used to test the style-component's CSS injection targeting
+-->
+<style id="styles-target"></style>

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,0 +1,8 @@
+// import { addDecorator } from '@storybook/react';
+// import { ThemeProvider } from '@sparkpost/matchbox';
+
+// See https://storybook.js.org/docs/addons/introduction/#storybook-decorators
+// TODO Find out why this isnt working in FE-1002
+// addDecorator(storyFn => (
+//   <ThemeProvider target={document.getElementById('styles-target')}>{storyFn()}</ThemeProvider>
+// ));

--- a/packages/matchbox/src/components/ThemeProvider/ThemeProvider.js
+++ b/packages/matchbox/src/components/ThemeProvider/ThemeProvider.js
@@ -41,7 +41,7 @@ Manager.displayName = 'MatchboxStyleSheetManager';
  */
 function Theme(props) {
   return (
-    <Manager>
+    <Manager target={props.target}>
       <ThemeProvider theme={{ ...theme, ...props.theme }}>
         {/*
           FE-913:`skipGlobalStyles` is to exclude global styles from unit tests.
@@ -60,6 +60,7 @@ function Theme(props) {
 Theme.displayName = 'MatchboxThemeProvider';
 Theme.propTypes = {
   skipGlobalStyles: PropTypes.bool,
+  target: PropTypes.object,
 };
 
 export default Theme;

--- a/packages/matchbox/src/components/ThemeProvider/ThemeProvider.js
+++ b/packages/matchbox/src/components/ThemeProvider/ThemeProvider.js
@@ -11,6 +11,27 @@ const GlobalStyle = createGlobalStyle`
 `;
 
 /**
+ * See https://styled-components.com/docs/api#stylesheetmanager
+ * Target provides an alternate DOM node to inject styles info
+ *
+ * Example:
+ * In your app's <head>:
+ * <style id="styled-components-target"></style>
+ *
+ * When rendering ThemeProvider:
+ * <ThemeProvider target={document.getElementById('styled-components-target')} />
+ * */
+function Manager({ target, children }) {
+  if (!target) {
+    return children;
+  }
+
+  return <StyleSheetManager target={target}>{children}</StyleSheetManager>;
+}
+
+Manager.displayName = 'MatchboxStyleSheetManager';
+
+/**
  * Provides context for styled-system
  *
  * - https://www.styled-components.com/docs/advanced#theming
@@ -20,18 +41,7 @@ const GlobalStyle = createGlobalStyle`
  */
 function Theme(props) {
   return (
-    /**
-     * See https://styled-components.com/docs/api#stylesheetmanager
-     * Target provides an alternate DOM node to inject styles info
-     *
-     * Example:
-     * In your app's <head>:
-     * <style id="styled-components-target"></style>
-     *
-     * When rendering ThemeProvider:
-     * <ThemeProvider target={document.getElementById('styled-components-target')} />
-     * */
-    <StyleSheetManager target={props.target}>
+    <Manager>
       <ThemeProvider theme={{ ...theme, ...props.theme }}>
         {/*
           FE-913:`skipGlobalStyles` is to exclude global styles from unit tests.
@@ -43,10 +53,11 @@ function Theme(props) {
 
         {props.children}
       </ThemeProvider>
-    </StyleSheetManager>
+    </Manager>
   );
 }
 
+Theme.displayName = 'MatchboxThemeProvider';
 Theme.propTypes = {
   skipGlobalStyles: PropTypes.bool,
 };

--- a/packages/matchbox/src/components/ThemeProvider/ThemeProvider.js
+++ b/packages/matchbox/src/components/ThemeProvider/ThemeProvider.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ThemeProvider, createGlobalStyle } from 'styled-components';
+import { ThemeProvider, createGlobalStyle, StyleSheetManager } from 'styled-components';
 import { normalize } from 'styled-normalize';
 import theme from './theme';
 import global from './globalStyles';
@@ -18,18 +18,33 @@ const GlobalStyle = createGlobalStyle`
  *
  * @prop theme Overrides matchbox's theme
  */
-
 function Theme(props) {
   return (
     <ThemeProvider theme={{ ...theme, ...props.theme }}>
-      {/* 
+      {/*
         FE-913:`skipGlobalStyles` is to exclude global styles from unit tests.
         The custom assertion `toHaveAttributeValue` fails with this turned on.
         We should either move away from using this assertion (or even enzyme),
         or try to resolve the error
       */}
       {!props.skipGlobalStyles && <GlobalStyle />}
-      {props.children}
+
+      {/*
+        See https://styled-components.com/docs/api#stylesheetmanager
+        Target provides an alternate DOM node to inject styles info
+        
+        Example:
+        In your app's <head>:
+        <style id="styled-components-target"></style>
+
+        When rendering ThemeProvider:
+        <ThemeProvider target={document.getElementById('styled-components-target')} />
+      */}
+      {props.target && (
+        <StyleSheetManager target={props.target}>{props.children}</StyleSheetManager>
+      )}
+
+      {!props.target && <>{props.children}</>}
     </ThemeProvider>
   );
 }

--- a/packages/matchbox/src/components/ThemeProvider/ThemeProvider.js
+++ b/packages/matchbox/src/components/ThemeProvider/ThemeProvider.js
@@ -20,32 +20,30 @@ const GlobalStyle = createGlobalStyle`
  */
 function Theme(props) {
   return (
-    <ThemeProvider theme={{ ...theme, ...props.theme }}>
-      {/*
-        FE-913:`skipGlobalStyles` is to exclude global styles from unit tests.
-        The custom assertion `toHaveAttributeValue` fails with this turned on.
-        We should either move away from using this assertion (or even enzyme),
-        or try to resolve the error
-      */}
-      {!props.skipGlobalStyles && <GlobalStyle />}
+    /**
+     * See https://styled-components.com/docs/api#stylesheetmanager
+     * Target provides an alternate DOM node to inject styles info
+     *
+     * Example:
+     * In your app's <head>:
+     * <style id="styled-components-target"></style>
+     *
+     * When rendering ThemeProvider:
+     * <ThemeProvider target={document.getElementById('styled-components-target')} />
+     * */
+    <StyleSheetManager target={props.target}>
+      <ThemeProvider theme={{ ...theme, ...props.theme }}>
+        {/*
+          FE-913:`skipGlobalStyles` is to exclude global styles from unit tests.
+          The custom assertion `toHaveAttributeValue` fails with this turned on.
+          We should either move away from using this assertion (or even enzyme),
+          or try to resolve the error
+        */}
+        {!props.skipGlobalStyles && <GlobalStyle />}
 
-      {/*
-        See https://styled-components.com/docs/api#stylesheetmanager
-        Target provides an alternate DOM node to inject styles info
-        
-        Example:
-        In your app's <head>:
-        <style id="styled-components-target"></style>
-
-        When rendering ThemeProvider:
-        <ThemeProvider target={document.getElementById('styled-components-target')} />
-      */}
-      {props.target && (
-        <StyleSheetManager target={props.target}>{props.children}</StyleSheetManager>
-      )}
-
-      {!props.target && <>{props.children}</>}
-    </ThemeProvider>
+        {props.children}
+      </ThemeProvider>
+    </StyleSheetManager>
   );
 }
 

--- a/packages/matchbox/src/components/ThemeProvider/tests/ThemeProvider.test.js
+++ b/packages/matchbox/src/components/ThemeProvider/tests/ThemeProvider.test.js
@@ -4,9 +4,10 @@ import { shallow } from 'enzyme';
 import ThemeProvider from '../ThemeProvider';
 
 describe('ThemeProvider', () => {
-  const subject = (props) => shallow(<ThemeProvider {...props} />);
+  const subject = props => shallow(<ThemeProvider {...props} />);
 
   it('should be able to modify the theme', () => {
-    expect(subject({ theme: { testKey: 'testValue' }}).prop('theme').testKey).toEqual('testValue');
+    const wrapper = subject({ theme: { testKey: 'testValue' } }).find('ThemeProvider');
+    expect(wrapper.prop('theme').testKey).toEqual('testValue');
   });
 });

--- a/unreleased.md
+++ b/unreleased.md
@@ -112,3 +112,5 @@
 - #382 - Fix ComboBox children validation to check both displayName and name
 - #383 - Fix Grid in production builds by manually picking props
 - #386 - `className` is properly passed to `<Panel/>` instances
+- #385 - Adds a new `target` prop to `ThemeProvider`, see
+  https://styled-components.com/docs/api#stylesheetmanager


### PR DESCRIPTION
### What Changed
- Adds a new `target` prop to `ThemeProvider`, see https://styled-components.com/docs/api#stylesheetmanager

### How To Test or Verify
- Testing this in storybook is difficult due to our setup, you will need to remove all but one story and make sure only a single story uses `addDecorator`. (We have a follow up ticket to clean up stories)
- In a single `addDecorator` add:

```js
addDecorator(storyFn => (
   <ThemeProvider target={document.getElementById('styles-target')}>
      {storyFn()}
   </ThemeProvider>
));
```

- Verify the story works


### PR Checklist
- [x] Add your changes to `unreleased.md` in the root directory. If you plan on publishing immediately after merging (such as a hotfix) or aren't making changes to a published package, you can ignore this step.
