### PR TITLE
FE-1025 - Ensure className is properly passed to Panel component inst…

### DIFF
--- a/packages/matchbox/src/components/Panel/Panel.js
+++ b/packages/matchbox/src/components/Panel/Panel.js
@@ -57,7 +57,7 @@ function Panel(props) {
   const { p: contextP = '400', padding: contextPadding, ...context } = pick(rest);
 
   return (
-    <PanelOuter {...rest}>
+    <PanelOuter className={className} {...rest}>
       {accentMarkup}
       <PanelInner accent={accent}>
         <PanelPaddingContext.Provider value={{ p: contextP || contextPadding, ...context }}>
@@ -77,6 +77,7 @@ Panel.Accent = Accent;
 
 Panel.propTypes = {
   title: PropTypes.node,
+  className: PropTypes.string,
   accent: PropTypes.oneOfType([
     PropTypes.bool,
     PropTypes.oneOf(['orange', 'blue', 'red', 'yellow', 'green', 'purple', 'navy', 'gray']),

--- a/packages/matchbox/src/components/Panel/tests/Panel.test.js
+++ b/packages/matchbox/src/components/Panel/tests/Panel.test.js
@@ -179,4 +179,10 @@ describe('Panel', () => {
     expect(wrapper.find(Panel.Section).at(1)).toHaveStyleRule('padding-left', '0.5rem');
     expect(wrapper.find(Panel.Section).at(1)).toHaveStyleRule('padding-top', '1.5rem');
   });
+
+  it('renders with the passed in className', () => {
+    wrapper = global.mountStyled(<Panel className="my-class">Hello, world.</Panel>);
+
+    expect(wrapper.find('.my-class')).toExist();
+  });
 });

--- a/stories/layout/Panel.stories.js
+++ b/stories/layout/Panel.stories.js
@@ -13,7 +13,7 @@ export default {
 };
 
 export const WithATitle = withInfo()(() => (
-  <Panel title="Title" sectioned>
+  <Panel className="my-class" title="Title" sectioned>
     This is a panel with a title
   </Panel>
 ));

--- a/unreleased.md
+++ b/unreleased.md
@@ -111,3 +111,4 @@
 - #381 - Adds border radius to panel containers
 - #382 - Fix ComboBox children validation to check both displayName and name
 - #383 - Fix Grid in production builds by manually picking props
+- #386 - `className` is properly passed to `<Panel/>` instances


### PR DESCRIPTION
[FE-1025](https://jira.int.messagesystems.com/browse/FE-1025)

### What Changed
- `className` prop properly passed to the `<Panel/>` component

### How To Test or Verify
- Verify classes render in the Storybook example after running `npm run start:storybook`

### PR Checklist
- [ ] Incorporate feedback