### PR TITLE
FE-996 Tab Updates

### DIFF
--- a/cypress/integration/Tab.spec.js
+++ b/cypress/integration/Tab.spec.js
@@ -1,0 +1,54 @@
+/// <reference types="Cypress" />
+
+describe('The Tabs component', () => {
+  describe('when not overflowing', () => {
+    beforeEach(() => {
+      cy.visit('/iframe.html?path=/story/navigation-tabs--example-tabs');
+      // Setting viewport dimensions to avoid side effects
+      cy.viewport(1400, 600);
+    });
+
+    it('should handle tab click', () => {
+      cy.get('button')
+        .eq(1)
+        .click();
+      cy.get('[aria-selected="true"]').should('have.text', 'More Details');
+    });
+
+    it('should handle keyboard navigation', () => {
+      cy.get('button')
+        .first()
+        .click();
+      cy.focused().tab();
+      cy.focused().should('have.text', 'More Details');
+      cy.focused().tab();
+      cy.focused().should('have.text', 'Example with long text');
+    });
+  });
+
+  describe('when overflowing', () => {
+    beforeEach(() => {
+      cy.visit('/iframe.html?path=/story/navigation-tabs--example-tabs');
+      cy.viewport(800, 600);
+      cy.wait(200);
+    });
+
+    it('should handle actionlist click', () => {
+      cy.get('[data-id="tab-options-button"]').click();
+      cy.get('[data-id="popover-content"]').should('be.visible');
+      cy.get('[data-id="popover-content"] button')
+        .eq(1)
+        .click();
+      cy.get('[aria-selected="true"]')
+        .first()
+        .should('have.text', 'Example with long text');
+    });
+
+    it('should handle keyboard navigation', () => {
+      cy.get('[data-id="tab-options-button"]').click();
+      cy.focused().should('have.text', 'More Options');
+      cy.focused().tab();
+      cy.focused().should('have.text', 'More Details');
+    });
+  });
+});

--- a/cypress/integration/Tab.spec.js
+++ b/cypress/integration/Tab.spec.js
@@ -44,6 +44,13 @@ describe('The Tabs component', () => {
         .should('have.text', 'Example with long text');
     });
 
+    it('should toggle when activator is clicked', () => {
+      cy.get('[data-id="tab-options-button"]').click();
+      cy.get('[data-id="popover-content"]').should('be.visible');
+      cy.get('[data-id="tab-options-button"]').click();
+      cy.get('[data-id="popover-content"]').should('not.be.visible');
+    });
+
     it('should handle keyboard navigation', () => {
       cy.get('[data-id="tab-options-button"]').click();
       cy.focused().should('have.text', 'More Options');

--- a/packages/matchbox/src/components/Tabs/Tabs.js
+++ b/packages/matchbox/src/components/Tabs/Tabs.js
@@ -156,7 +156,7 @@ function Tabs(props) {
                   aria-expanded={popoverOpen}
                   data-id="tab-options-button"
                   flat
-                  onClick={() => setPopoverOpen(true)}
+                  onClick={() => setPopoverOpen(!popoverOpen)}
                 >
                   <MoreHoriz size={20} />
                   <ScreenReaderOnly>More Options</ScreenReaderOnly>

--- a/packages/matchbox/src/components/Tabs/Tabs.js
+++ b/packages/matchbox/src/components/Tabs/Tabs.js
@@ -2,6 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { MoreHoriz } from '@sparkpost/matchbox-icons';
+import { margin, borderBottom } from 'styled-system';
+import { createPropTypes } from '@styled-system/prop-types';
+import { pick } from '@styled-system/props';
 import { ActionList } from '../ActionList';
 import { UnstyledLink } from '../UnstyledLink';
 import { Box } from '../Box';
@@ -9,10 +12,8 @@ import { Button } from '../Button';
 import { Popover } from '../Popover';
 import { ScreenReaderOnly } from '../ScreenReaderOnly';
 import { deprecate } from '../../helpers/propTypes';
-import { margin } from 'styled-system';
-import { createPropTypes } from '@styled-system/prop-types';
 import { containerStyles, overflowTabs, tabStyles } from './styles';
-import { pick } from '@styled-system/props';
+
 import { getPositionFor, useWindowSize } from '../../helpers/geometry';
 
 // TODO Replace this when styled-components supports shouldForwardProps
@@ -33,6 +34,7 @@ const OverflowTabContainer = styled('div')`
 
 const Container = styled('div')`
   ${margin}
+  ${borderBottom}
   ${containerStyles}
 `;
 
@@ -114,7 +116,7 @@ function Tabs(props) {
   }, [selected, tabs, isOverflowing]);
 
   return (
-    <Container {...pick(rest)} ref={wrapperRef}>
+    <Container borderBottom="400" {...pick(rest)} ref={wrapperRef}>
       <Box aria-hidden={isOverflowing} overflow="hidden">
         <OverflowTabContainer
           aria-orientation="horizontal"
@@ -196,6 +198,7 @@ Tabs.propTypes = {
   selected: PropTypes.number.isRequired,
   onSelect: PropTypes.func,
   ...createPropTypes(margin.propNames),
+  ...createPropTypes(borderBottom.propNames),
 };
 
 export default Tabs;

--- a/packages/matchbox/src/components/Tabs/Tabs.js
+++ b/packages/matchbox/src/components/Tabs/Tabs.js
@@ -1,27 +1,39 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import { MoreHoriz } from '@sparkpost/matchbox-icons';
+import { ActionList } from '../ActionList';
 import { UnstyledLink } from '../UnstyledLink';
+import { Box } from '../Box';
+import { Button } from '../Button';
+import { Popover } from '../Popover';
+import { ScreenReaderOnly } from '../ScreenReaderOnly';
 import { deprecate } from '../../helpers/propTypes';
 import { margin } from 'styled-system';
 import { createPropTypes } from '@styled-system/prop-types';
-import { wrapperStyles, tabStyles } from './styles';
+import { containerStyles, overflowTabs, tabStyles } from './styles';
 import { pick } from '@styled-system/props';
+import { getPositionFor, useWindowSize } from '../../helpers/geometry';
 
 // TODO Replace this when styled-components supports shouldForwardProps
 // See: https://github.com/styled-components/styled-components/commit/e02109e626ed117b76f220d0b9b926129655262d
 // Or when UnstyledLink is updated to use system props
-function LinkWrapper({ selected, fitted, ...props }) {
-  return <UnstyledLink {...props} />;
+function LinkWrapper(props) {
+  const { selected, fitted, ...rest } = props;
+  return <UnstyledLink {...rest} />;
 }
 
 const StyledTab = styled(LinkWrapper)`
   ${tabStyles}
 `;
 
-const StyledTabs = styled('div')`
+const OverflowTabContainer = styled('div')`
+  ${overflowTabs}
+`;
+
+const Container = styled('div')`
   ${margin}
-  ${wrapperStyles}
+  ${containerStyles}
 `;
 
 function Tab(props) {
@@ -39,11 +51,13 @@ function Tab(props) {
 
   return (
     <StyledTab
+      aria-selected={selected === index}
       component={wrapper}
       selected={selected === index}
       fitted={fitted}
       {...rest}
       onClick={handleClick}
+      role="tab"
       type="button"
     >
       {content}
@@ -55,6 +69,12 @@ Tab.displayName = 'Tab';
 
 function Tabs(props) {
   const { tabs, selected, onSelect, fitted, ...rest } = props;
+  const [isOverflowing, setIsOverflowing] = React.useState(false);
+  const [popoverOpen, setPopoverOpen] = React.useState(false);
+
+  const wrapperRef = React.useRef();
+  const overflowRef = React.useRef();
+  const windowSize = useWindowSize();
 
   function handleClick(event, index) {
     const { onClick } = tabs[index];
@@ -66,14 +86,87 @@ function Tabs(props) {
     if (onSelect && selected !== index) {
       onSelect(index, selected);
     }
+
+    if (isOverflowing) {
+      setPopoverOpen(false);
+    }
   }
 
+  React.useLayoutEffect(() => {
+    const wrapperPosition = getPositionFor(wrapperRef.current);
+    const overflowPosition = getPositionFor(overflowRef.current);
+
+    // Compares tab container width with its position relative to a measurement pixel
+    if (wrapperPosition.width < overflowPosition.left - wrapperPosition.left) {
+      setIsOverflowing(true);
+    } else {
+      setIsOverflowing(false);
+    }
+  }, [wrapperRef, overflowRef, windowSize]);
+
+  const selectedTab = tabs[selected];
+
+  // Constructs ActionList actions from tabs
+  const tabActions = React.useMemo(() => {
+    return tabs.map((tab, i) => {
+      return { is: 'button', ...tab, onClick: e => handleClick(e, i), visible: i !== selected };
+    });
+  }, [selected, tabs, isOverflowing]);
+
   return (
-    <StyledTabs {...pick(rest)}>
-      {tabs.map((tab, i) => (
-        <Tab key={i} index={i} fitted={fitted} selected={selected} {...tab} onClick={handleClick} />
-      ))}
-    </StyledTabs>
+    <Container {...pick(rest)} ref={wrapperRef}>
+      <Box aria-hidden={isOverflowing} overflow="hidden">
+        <OverflowTabContainer
+          aria-orientation="horizontal"
+          isOverflowing={isOverflowing}
+          role="tablist"
+        >
+          {tabs.map((tab, i) => (
+            <Tab
+              key={i}
+              index={i}
+              fitted={fitted}
+              selected={selected}
+              {...tab}
+              onClick={handleClick}
+            />
+          ))}
+          {/* Measurement pixel used to detect content overflow */}
+          <Box display="inline-block" width="1px" height="1px" ref={overflowRef} />
+        </OverflowTabContainer>
+      </Box>
+      {isOverflowing && (
+        <Box display="flex" alignItems="center" justifyContent="space-between">
+          <Box flex="0">
+            <Tab index={0} selected={0} {...selectedTab} />
+          </Box>
+
+          <Box flex="0">
+            <Popover
+              id="tab-options"
+              left
+              bottom
+              open={popoverOpen}
+              onClose={() => setPopoverOpen(false)}
+              trigger={
+                <Button
+                  aria-controls="tab-options"
+                  aria-expanded={popoverOpen}
+                  data-id="tab-options-button"
+                  flat
+                  onClick={() => setPopoverOpen(true)}
+                >
+                  <MoreHoriz size={20} />
+                  <ScreenReaderOnly>More Options</ScreenReaderOnly>
+                </Button>
+              }
+            >
+              <ActionList actions={tabActions} />
+            </Popover>
+          </Box>
+        </Box>
+      )}
+    </Container>
   );
 }
 

--- a/packages/matchbox/src/components/Tabs/Tabs.js
+++ b/packages/matchbox/src/components/Tabs/Tabs.js
@@ -140,7 +140,7 @@ function Tabs(props) {
       {isOverflowing && (
         <Box display="flex" alignItems="center" justifyContent="space-between">
           <Box flex="0">
-            <Tab index={0} selected={0} {...selectedTab} />
+            <Tab index={selected} selected={selected} {...selectedTab} />
           </Box>
 
           <Box flex="0">

--- a/packages/matchbox/src/components/Tabs/styles.js
+++ b/packages/matchbox/src/components/Tabs/styles.js
@@ -10,12 +10,11 @@ export const tabStyles = ({ selected, fitted }) => `
   text-decoration: none;
   
   padding: 0 ${tokens.spacing_200};
-  ${'' /* Not a token, equivalent to 20px to enqure 10rem of spacing between text */}
-  margin: 0 ${!fitted ? '1.25rem' : '0'};
+  margin: 0 ${!fitted ? `${tokens.sizing_450}` : '0'};
 
   font-size: ${tokens.fontSize_200};
   font-weight: ${tokens.fontWeight_medium};
-  line-height: 3.75rem; ${'' /* Equivalent to 60px */}
+  line-height: ${tokens.sizing_750};
   white-space: nowrap;
 
   &, &:visited {
@@ -54,6 +53,5 @@ export const overflowTabs = ({ isOverflowing }) => `
 
 export const containerStyles = () => `
   position: relative;
-  ${'' /* TODO Update with sizing tokens */}
-  height: 3.75rem; 
+  height: ${tokens.sizing_750};
 `;

--- a/packages/matchbox/src/components/Tabs/styles.js
+++ b/packages/matchbox/src/components/Tabs/styles.js
@@ -3,6 +3,8 @@ import { tokens } from '@sparkpost/design-tokens';
 
 export const tabStyles = ({ selected, fitted }) => `
   ${buttonReset}
+  display: inline-block;
+  cursor: pointer;
   position: relative;
   flex: ${fitted ? '1' : '0'};
   text-decoration: none;
@@ -14,14 +16,17 @@ export const tabStyles = ({ selected, fitted }) => `
   font-size: ${tokens.fontSize_200};
   font-weight: ${tokens.fontWeight_medium};
   line-height: 3.75rem; ${'' /* Equivalent to 60px */}
-  color: ${selected ? tokens.color_blue_700 : tokens.color_gray_700};
   white-space: nowrap;
+
+  &, &:visited {
+    color: ${selected ? tokens.color_blue_700 : tokens.color_gray_700};
+  }
 
   &:after {
     display: block;
     position: absolute;
     content: '';
-    bottom: -1px;
+    bottom: 0px;
     left: 0;
     right: 0;
     height: ${tokens.spacing_100};
@@ -37,7 +42,19 @@ export const tabStyles = ({ selected, fitted }) => `
   }
 `;
 
-export const wrapperStyles = () => `
+export const overflowTabs = ({ isOverflowing }) => `
+  position: absolute;
+  left: 0;
+  top: 0;
+  right:0;
   display: flex;
+  visibility: ${isOverflowing ? 'hidden' : 'visible'};
+  pointer-events: ${isOverflowing ? 'none' : 'auto'};
+`;
+
+export const containerStyles = () => `
+  position: relative;
+  ${'' /* TODO Update with sizing tokens */}
+  height: 3.75rem; 
   border-bottom: ${tokens.borderWidth_100} solid ${tokens.color_gray_400};
 `;

--- a/packages/matchbox/src/components/Tabs/styles.js
+++ b/packages/matchbox/src/components/Tabs/styles.js
@@ -56,5 +56,4 @@ export const containerStyles = () => `
   position: relative;
   ${'' /* TODO Update with sizing tokens */}
   height: 3.75rem; 
-  border-bottom: ${tokens.borderWidth_100} solid ${tokens.color_gray_400};
 `;

--- a/stories/navigation/Tabs.stories.js
+++ b/stories/navigation/Tabs.stories.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { addDecorator } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
 import { action } from '@storybook/addon-actions';
-// import StoryContainer from '../storyHelpers/StoryContainer';
 
 import { Tabs, ThemeProvider, Panel } from '@sparkpost/matchbox';
 
@@ -19,11 +18,11 @@ const tabs = [
   },
   {
     content: 'Example with long text',
-    onClick: action('Domains Clicked'),
+    onClick: action('Example with long text clicked'),
   },
   {
     content: 'Example with a component wrapper',
-    onClick: action('Domains Clicked'),
+    onClick: action('Example with component clicked'),
     Component: props => <a {...props} href="#" />,
   },
 ];

--- a/stories/navigation/Tabs.stories.js
+++ b/stories/navigation/Tabs.stories.js
@@ -64,7 +64,7 @@ export const ExampleWithinPanel = withInfo()(() => (
 
 export const SystemProps = withInfo()(() => (
   <>
-    <Tabs selected={0} tabs={tabs} my={['400', null, '800', '100px']} />
+    <Tabs selected={0} borderBottom="none" tabs={tabs} my={['400', null, '800', '100px']} />
     <Tabs fitted selected={0} tabs={tabs} mx={['400', null, '800', '200px']} />
   </>
 ));

--- a/stories/navigation/Tabs.stories.js
+++ b/stories/navigation/Tabs.stories.js
@@ -14,8 +14,8 @@ const tabs = [
     onClick: action('Details Clicked'),
   },
   {
-    content: 'Keys',
-    onClick: action('Keys Clicked'),
+    content: 'More Details',
+    onClick: action('More Details Clicked'),
   },
   {
     content: 'Example with long text',

--- a/stories/storyHelpers/StoryContainer.js
+++ b/stories/storyHelpers/StoryContainer.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const StoryContainer = ({ bg, children }) => (
-  <div style={{ padding: '30px', minHeight: '100vh', background: bg || '#f2f2f5' }}>{children}</div>
+  <div style={{ padding: '12px', minHeight: '100vh', background: bg || '#f2f2f5' }}>{children}</div>
 );
 
 export default StoryContainer;

--- a/unreleased.md
+++ b/unreleased.md
@@ -119,3 +119,6 @@
 - #388 - Adds new spacing design tokens
 - #393 - Fix Stack gutter for last child
 - #396 - Adds z-index tokens to the z indices styled-system field
+- #390 - `Tabs` are now responsive for both fitted and non-fitted variations
+- #390 - `Tab` now uses a `pointer` cursor on hover
+- #390 - `Tabs` now accept the `borderBottom` system prop


### PR DESCRIPTION
### What Changed
-  `Tabs` are now responsive for both fitted and non-fitted variations
-  `Tab` now uses a `pointer` cursor on hover
-  `Tabs` now accept the `borderBottom` system prop
-  Follow up ticket for keyboard navigation: FE-1067

### How To Test or Verify
- Run storybook with `npm run start:storybook`
- Visit Tab stories, verify responsive behavior

### PR Checklist
- [x] Add your changes to `unreleased.md` in the root directory. If you plan on publishing immediately after merging (such as a hotfix) or aren't making changes to a published package, you can ignore this step.
- [x] Get approval from a UX team member (**#uxfe** or **#design-guild** on Slack) for any visual changes.
