### PR TITLE
FE-1068: Last item in Stack has bottom margin

### DIFF
--- a/packages/matchbox/src/components/Stack/Stack.js
+++ b/packages/matchbox/src/components/Stack/Stack.js
@@ -38,7 +38,7 @@ function Stack(props) {
   return (
     <div>
       {items.map((child, i) => (
-        <StyledBox key={i} alignment={align} gutter={i < children.length - 1 ? space : null}>
+        <StyledBox key={i} alignment={align} gutter={i < items.length - 1 ? space : null}>
           {child}
         </StyledBox>
       ))}

--- a/packages/matchbox/src/components/Stack/tests/Stack.test.js
+++ b/packages/matchbox/src/components/Stack/tests/Stack.test.js
@@ -6,6 +6,7 @@ describe('Stack', () => {
   const subject = props =>
     global.mountStyled(
       <Stack {...props}>
+        {false && <span id="child-0">0</span>}
         <span id="child-1">1</span>
         <span id="child-2">2</span>
       </Stack>,
@@ -19,38 +20,38 @@ describe('Stack', () => {
 
   it('should render default spacing and alignment correctly', () => {
     const wrapper = subject();
-    expect(wrapper.find('div').at(0)).toHaveStyleRule('padding-bottom', '1rem');
-    expect(wrapper.find('div').at(1)).not.toHaveStyleRule('padding-bottom');
-    expect(wrapper.find('div').at(0)).not.toHaveStyleRule('align-items');
+    expect(wrapper.find('#child-1').parent()).toHaveStyleRule('padding-bottom', '1rem');
+    expect(wrapper.find('#child-1').parent()).toHaveStyleRule('align-items', undefined);
+    expect(wrapper.find('#child-2').parent()).toHaveStyleRule('padding-bottom', undefined);
   });
 
   it('should render styled system spacing and custom alignment correctly', () => {
     const wrapper = subject({ space: '500', align: 'right' });
-    expect(wrapper.find('div').at(0)).toHaveStyleRule('padding-bottom', '1.5rem');
-    expect(wrapper.find('div').at(1)).not.toHaveStyleRule('padding-bottom');
-    expect(wrapper.find('div').at(0)).toHaveStyleRule('align-items', 'flex-end');
-    expect(wrapper.find('div').at(1)).toHaveStyleRule('align-items', 'flex-end');
+    expect(wrapper.find('#child-1').parent()).toHaveStyleRule('padding-bottom', '1.5rem');
+    expect(wrapper.find('#child-2').parent()).toHaveStyleRule('padding-bottom', undefined);
+    expect(wrapper.find('#child-1').parent()).toHaveStyleRule('align-items', 'flex-end');
+    expect(wrapper.find('#child-2').parent()).toHaveStyleRule('align-items', 'flex-end');
   });
 
   it('should render non-styled system spacing ', () => {
     const wrapper = subject({ space: '10px', align: 'right' });
-    expect(wrapper.find('div').at(0)).toHaveStyleRule('padding-bottom', '10px');
+    expect(wrapper.find('#child-1').parent()).toHaveStyleRule('padding-bottom', '10px');
   });
 
   it('should render responsive spacing and alignment', () => {
     const wrapper = subject({ space: ['400', '50px'], align: ['right', 'center'] });
 
     // Min
-    expect(wrapper.find('div').at(0)).toHaveStyleRule('padding-bottom', '1rem');
-    expect(wrapper.find('div').at(1)).not.toHaveStyleRule('padding-bottom');
-    expect(wrapper.find('div').at(0)).toHaveStyleRule('align-items', 'flex-end');
-    expect(wrapper.find('div').at(1)).toHaveStyleRule('align-items', 'flex-end');
+    expect(wrapper.find('#child-1').parent()).toHaveStyleRule('padding-bottom', '1rem');
+    expect(wrapper.find('#child-2').parent()).toHaveStyleRule('padding-bottom', undefined);
+    expect(wrapper.find('#child-1').parent()).toHaveStyleRule('align-items', 'flex-end');
+    expect(wrapper.find('#child-2').parent()).toHaveStyleRule('align-items', 'flex-end');
 
     // First breakpoint
     const media = 'screen and (min-width:400px)';
-    expect(wrapper.find('div').at(0)).toHaveStyleRule('padding-bottom', '50px', { media });
-    expect(wrapper.find('div').at(1)).not.toHaveStyleRule('padding-bottom');
-    expect(wrapper.find('div').at(0)).toHaveStyleRule('align-items', 'center', { media });
-    expect(wrapper.find('div').at(1)).toHaveStyleRule('align-items', 'center', { media });
+    expect(wrapper.find('#child-1').parent()).toHaveStyleRule('padding-bottom', '50px', { media });
+    expect(wrapper.find('#child-2').parent()).toHaveStyleRule('padding-bottom', undefined);
+    expect(wrapper.find('#child-1').parent()).toHaveStyleRule('align-items', 'center', { media });
+    expect(wrapper.find('#child-2').parent()).toHaveStyleRule('align-items', 'center', { media });
   });
 });

--- a/unreleased.md
+++ b/unreleased.md
@@ -117,3 +117,4 @@
 - #384 - Adds `Drawer` component and `useDrawer` hook. See
 - #388 - Adds new sizing design tokens mapped to the `sizes` styled-system field
 - #388 - Adds new spacing design tokens
+- #393 - Fix Stack gutter for last child


### PR DESCRIPTION
### What Changed
 - One-liner to fix this bug
 - Removed use of `.not.toHaveStyleRule` in Stack tests because it was not working
 - Replaced `wrapper.find('div').at(0)` with `wrapper.find('#child-1').parent()`

### How To Test or Verify
 - Added an example to tests

### PR Checklist
- [x] Add your changes to `unreleased.md` in the root directory. If you plan on publishing immediately after merging (such as a hotfix) or aren't making changes to a published package, you can ignore this step.
~- [ ] Provide screenshots or [screen recordings](https://getkap.co/) for any visual changes.~
~- [ ] Get approval from a UX team member (**#uxfe** or **#design-guild** on Slack) for any visual changes.~
