### PR TITLE
UX-158 Update Radio and Checkbox Components

### DIFF
--- a/packages/matchbox/src/components/Checkbox/Group.js
+++ b/packages/matchbox/src/components/Checkbox/Group.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box } from '../Box';
-import { ScreenReaderOnly } from '../ScreenReaderOnly';
+import { Label } from '../Label';
+import { Stack } from '../Stack';
 import { createPropTypes } from '@styled-system/prop-types';
 import styled from 'styled-components';
 import { margin } from 'styled-system';
@@ -20,21 +21,15 @@ function Group(props) {
   return (
     <StyledGroup {...systemProps}>
       {label && !labelHidden && (
-        <Box as="legend" lineHeight="200" fontSize="200" mb="100">
-          {label}
+        <Label label={label} labelHidden={labelHidden}>
           {required && (
             <Box as="span" pr="200" aria-hidden="true">
               *
             </Box>
           )}
-        </Box>
+        </Label>
       )}
-      {label && labelHidden && (
-        <ScreenReaderOnly>
-          <legend>{label}</legend>
-        </ScreenReaderOnly>
-      )}
-      {children}
+      <Stack space="100">{children}</Stack>
     </StyledGroup>
   );
 }

--- a/packages/matchbox/src/components/Checkbox/Group.js
+++ b/packages/matchbox/src/components/Checkbox/Group.js
@@ -20,8 +20,8 @@ function Group(props) {
 
   return (
     <StyledGroup {...systemProps}>
-      {label && !labelHidden && (
-        <Label label={label} labelHidden={labelHidden}>
+      {label && (
+        <Label as="legend" label={label} labelHidden={labelHidden}>
           {required && (
             <Box as="span" pr="200" aria-hidden="true">
               *

--- a/packages/matchbox/src/components/Checkbox/tests/Group.test.js
+++ b/packages/matchbox/src/components/Checkbox/tests/Group.test.js
@@ -7,7 +7,13 @@ describe('Checkbox Group', () => {
 
   it('renders a legend correctly', () => {
     const wrapper = subject({ label: 'test-label' });
-    expect(wrapper.find('legend').text()).toEqual('test-label');
+    expect(
+      wrapper
+        .find('legend')
+        .find('span')
+        .at(0)
+        .text(),
+    ).toEqual('test-label');
   });
 
   it('renders a legend with required correctly', () => {
@@ -17,7 +23,7 @@ describe('Checkbox Group', () => {
 
   it('renders a legend with required correctly while hidden correctly', () => {
     const wrapper = subject({ label: 'test-label', required: true, labelHidden: true });
-    expect(wrapper.find('legend').text()).toEqual('test-label');
+    expect(wrapper.find('label').text()).toEqual('test-label*');
   });
 
   it('renders with system props', () => {

--- a/packages/matchbox/src/components/Checkbox/tests/Group.test.js
+++ b/packages/matchbox/src/components/Checkbox/tests/Group.test.js
@@ -23,7 +23,7 @@ describe('Checkbox Group', () => {
 
   it('renders a legend with required correctly while hidden correctly', () => {
     const wrapper = subject({ label: 'test-label', required: true, labelHidden: true });
-    expect(wrapper.find('label').text()).toEqual('test-label*');
+    expect(wrapper.find('legend').text()).toEqual('test-label*');
   });
 
   it('renders with system props', () => {

--- a/packages/matchbox/src/components/HelpText/HelpText.js
+++ b/packages/matchbox/src/components/HelpText/HelpText.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 function HelpText(props) {
   return (
-    <Box id={props.id} fontSize="200" lineHeight="200" color="gray.700">
+    <Box id={props.id} fontSize="200" lineHeight="200" m="0" ml="500" color="gray.700">
       {props.children}
     </Box>
   );

--- a/packages/matchbox/src/components/Label/Label.js
+++ b/packages/matchbox/src/components/Label/Label.js
@@ -21,7 +21,7 @@ function Label(props) {
   if (labelHidden) {
     return (
       <ScreenReaderOnly>
-        <Box as="label" id={id && `${id}Label`} htmlFor={id}>
+        <Box as={as} id={id && `${id}Label`} htmlFor={id}>
           {label}
           {children}
         </Box>

--- a/packages/matchbox/src/components/Radio/Group.js
+++ b/packages/matchbox/src/components/Radio/Group.js
@@ -20,13 +20,15 @@ function Group(props) {
 
   return (
     <StyledGroup {...systemProps}>
-      <Label label={label} labelHidden={labelHidden}>
-        {required && (
-          <Box as="span" pr="200" aria-hidden="true">
-            *
-          </Box>
-        )}
-      </Label>
+      {label && (
+        <Label as="legend" label={label} labelHidden={labelHidden}>
+          {required && (
+            <Box as="span" pr="200" aria-hidden="true">
+              *
+            </Box>
+          )}
+        </Label>
+      )}
       <Stack space="100">{children}</Stack>
     </StyledGroup>
   );

--- a/packages/matchbox/src/components/Radio/Group.js
+++ b/packages/matchbox/src/components/Radio/Group.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box } from '../Box';
-import { ScreenReaderOnly } from '../ScreenReaderOnly';
+import { Label } from '../Label';
+import { Stack } from '../Stack';
 import { createPropTypes } from '@styled-system/prop-types';
 import styled from 'styled-components';
 import { margin } from 'styled-system';
@@ -19,21 +20,14 @@ function Group(props) {
 
   return (
     <StyledGroup {...systemProps}>
-      {labelHidden ? (
-        <ScreenReaderOnly>
-          <legend>{label}</legend>
-        </ScreenReaderOnly>
-      ) : (
-        <Box as="legend" lineHeight="200" fontSize="200" mb="100">
-          {label}
-          {required && (
-            <Box as="span" pr="200" aria-hidden="true">
-              *
-            </Box>
-          )}
-        </Box>
-      )}
-      {children}
+      <Label label={label} labelHidden={labelHidden}>
+        {required && (
+          <Box as="span" pr="200" aria-hidden="true">
+            *
+          </Box>
+        )}
+      </Label>
+      <Stack space="100">{children}</Stack>
     </StyledGroup>
   );
 }

--- a/packages/matchbox/src/components/Radio/tests/Group.test.js
+++ b/packages/matchbox/src/components/Radio/tests/Group.test.js
@@ -7,12 +7,18 @@ describe('Checkbox Group', () => {
 
   it('renders a legend correctly', () => {
     const wrapper = subject({ label: 'test-label' });
-    expect(wrapper.find('legend').text()).toEqual('test-label');
+    expect(
+      wrapper
+        .find('legend')
+        .find('span')
+        .at(0)
+        .text(),
+    ).toEqual('test-label');
   });
 
   it('renders a legend while hidden correctly', () => {
     const wrapper = subject({ label: 'test-label', labelHidden: true });
-    expect(wrapper.find('legend').text()).toEqual('test-label');
+    expect(wrapper.find('label').text()).toEqual('test-label');
   });
 
   it('renders with system props', () => {

--- a/packages/matchbox/src/components/Radio/tests/Group.test.js
+++ b/packages/matchbox/src/components/Radio/tests/Group.test.js
@@ -18,7 +18,7 @@ describe('Checkbox Group', () => {
 
   it('renders a legend while hidden correctly', () => {
     const wrapper = subject({ label: 'test-label', labelHidden: true });
-    expect(wrapper.find('label').text()).toEqual('test-label');
+    expect(wrapper.find('legend').text()).toEqual('test-label');
   });
 
   it('renders with system props', () => {

--- a/unreleased.md
+++ b/unreleased.md
@@ -123,3 +123,6 @@
 - #390 - `Tab` now uses a `pointer` cursor on hover
 - #390 - `Tabs` now accept the `borderBottom` system prop
 - #390 - `Drawer.Footer` now always positioned on bottom
+- #406 - `Checkbox` and `Radio` label now match `TextField` and use `Label` component
+- #406 - Help text on `Checkbox` and `Radio` now indented
+- #406 - Use `Stack` around inputs in `Checkbox` and `Radio` groups


### PR DESCRIPTION

<img width="371" alt="Screen Shot 2020-05-07 at 11 39 29 AM" src="https://user-images.githubusercontent.com/3878251/81320920-879d2a00-9057-11ea-8d0d-f1b990ab1062.png">
<img width="428" alt="Screen Shot 2020-05-07 at 11 39 26 AM" src="https://user-images.githubusercontent.com/3878251/81320921-8835c080-9057-11ea-9831-3edc416bc659.png">
<img width="350" alt="Screen Shot 2020-05-07 at 11 39 21 AM" src="https://user-images.githubusercontent.com/3878251/81320922-8835c080-9057-11ea-982f-7e7c8f08ee81.png">
<img width="270" alt="Screen Shot 2020-05-07 at 11 39 14 AM" src="https://user-images.githubusercontent.com/3878251/81320925-88ce5700-9057-11ea-8c6f-78c2b52e2d99.png">





### What Changed
- Use Label component to match styles to TextField label
- Stack around group checkboxes and radio groups
- indent helptext

### How To Test or Verify
- `npm run start:storybook`

### PR Checklist
- [ ] Add your changes to `unreleased.md` in the root directory. If you plan on publishing immediately after merging (such as a hotfix) or aren't making changes to a published package, you can ignore this step.
- [ ] Provide screenshots or [screen recordings](https://getkap.co/) for any visual changes.
- [ ] Get approval from a UX team member (**#uxfe** or **#design-guild** on Slack) for any visual changes.
