### PR TITLE
UX-155 Add Tab keyboard navigation

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,4 +7,7 @@ coverage:
       default:
         target: 80%
         threshold: 1%
-        base: auto
+    patch:
+      default:
+        target: 80%
+        threshold: 1%

--- a/cypress/integration/Tab.spec.js
+++ b/cypress/integration/Tab.spec.js
@@ -14,7 +14,7 @@ describe('The Tabs component', () => {
         .click();
       cy.get('[aria-selected="true"]').should('have.text', 'More Details');
       cy.get(`[tabindex="0"]`).should('have.text', 'Details');
-      cy.get(`[tabindex="-1"]`).should('have.length', 3);
+      cy.get(`[tabindex="-1"]`).should('have.length', 4);
     });
   });
 

--- a/cypress/integration/Tab.spec.js
+++ b/cypress/integration/Tab.spec.js
@@ -13,6 +13,8 @@ describe('The Tabs component', () => {
         .eq(1)
         .click();
       cy.get('[aria-selected="true"]').should('have.text', 'More Details');
+      cy.get(`[tabindex="0"]`).should('have.text', 'Details');
+      cy.get(`[tabindex="-1"]`).should('have.length', 3);
     });
   });
 
@@ -35,6 +37,7 @@ describe('The Tabs component', () => {
       cy.focused().should('have.text', 'Details');
       cy.get('body').type('{leftArrow}');
       cy.focused().should('have.text', 'Example with a component wrapper');
+      cy.get(`[tabindex="0"]`).should('have.text', 'Example with a component wrapper');
     });
 
     it('should handle home and end keys', () => {
@@ -54,6 +57,14 @@ describe('The Tabs component', () => {
     it('should tab past the tabs', () => {
       cy.tab();
       cy.focused().should('have.text', 'this is only here to test focus order');
+    });
+
+    it('should correctly reset tabindex to selected tab after blurring', () => {
+      cy.get('body').type('{rightArrow}');
+      cy.focused().should('have.text', 'More Details');
+      cy.tab();
+      cy.focused().should('have.text', 'this is only here to test focus order');
+      cy.get(`[tabindex="0"]`).should('have.text', 'Details');
     });
   });
 

--- a/cypress/integration/Tab.spec.js
+++ b/cypress/integration/Tab.spec.js
@@ -95,11 +95,9 @@ describe('The Tabs component', () => {
       cy.get('[data-id="popover-content"]').should('not.be.visible');
     });
 
-    it('should handle keyboard navigation', () => {
+    it('should focus on the menu', () => {
       cy.get('[data-id="tab-options-button"]').click();
-      cy.focused().should('have.text', 'More Options');
-      cy.focused().tab();
-      cy.focused().should('have.text', 'More Details');
+      cy.get('[data-id="popover-focus-wrapper"]').should('have.focus');
     });
   });
 });

--- a/cypress/integration/Tab.spec.js
+++ b/cypress/integration/Tab.spec.js
@@ -14,25 +14,56 @@ describe('The Tabs component', () => {
         .click();
       cy.get('[aria-selected="true"]').should('have.text', 'More Details');
     });
+  });
 
-    it('should handle keyboard navigation', () => {
+  describe('keyboard navigation', () => {
+    beforeEach(() => {
+      cy.visit('/iframe.html?path=/story/navigation-tabs--example-tabs');
+      // Setting viewport dimensions to avoid side effects
+      cy.viewport(1400, 600);
       cy.get('button')
         .first()
         .click();
-      cy.focused().tab();
+    });
+
+    it('should handle arrow keys', () => {
+      cy.get('body').type('{rightArrow}');
       cy.focused().should('have.text', 'More Details');
-      cy.focused().tab();
-      cy.focused().should('have.text', 'Example with long text');
+      cy.get('body').type('{rightArrow}');
+      cy.get('body').type('{rightArrow}');
+      cy.get('body').type('{rightArrow}');
+      cy.focused().should('have.text', 'Details');
+      cy.get('body').type('{leftArrow}');
+      cy.focused().should('have.text', 'Example with a component wrapper');
+    });
+
+    it('should handle home and end keys', () => {
+      cy.get('body').type('{end}');
+      cy.focused().should('have.text', 'Example with a component wrapper');
+      cy.get('body').type('{home}');
+      cy.focused().should('have.text', 'Details');
+    });
+
+    it('should handle page up and page down keys', () => {
+      cy.get('body').type('{pageUp}');
+      cy.focused().should('have.text', 'Example with a component wrapper');
+      cy.get('body').type('{pageDown}');
+      cy.focused().should('have.text', 'Details');
+    });
+
+    it('should tab past the tabs', () => {
+      cy.tab();
+      cy.focused().should('have.text', 'this is only here to test focus order');
     });
   });
 
   // Tests are flakey because they require layout changes
   // Remove if these become a problem
-  describe.skip('when overflowing', () => {
+  describe('when overflowing', () => {
     beforeEach(() => {
       cy.visit('/iframe.html?path=/story/navigation-tabs--example-tabs');
       cy.viewport(800, 600);
-      cy.wait(400);
+      cy.wait(500);
     });
 
     it('should handle actionlist click', () => {

--- a/packages/matchbox/src/components/Popover/PopoverContent.js
+++ b/packages/matchbox/src/components/Popover/PopoverContent.js
@@ -44,7 +44,13 @@ const Content = React.forwardRef(function Content(props, ref) {
       }}
     >
       {state => (
-        <Box position="relative" height="100%" ref={ref} tabIndex="-1">
+        <Box
+          data-id="popover-focus-wrapper"
+          position="relative"
+          height="100%"
+          ref={ref}
+          tabIndex="-1"
+        >
           <StyledContent
             data-id="popover-content"
             className={className}

--- a/packages/matchbox/src/components/Tabs/Tab.js
+++ b/packages/matchbox/src/components/Tabs/Tab.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import styled from 'styled-components';
+import { UnstyledLink } from '../UnstyledLink';
+import { tabStyles } from './styles';
+
+// TODO Replace this when styled-components supports shouldForwardProps
+// See: https://github.com/styled-components/styled-components/commit/e02109e626ed117b76f220d0b9b926129655262d
+// Or when UnstyledLink is updated to use system props
+const LinkWrapper = React.forwardRef(function LinkWrapper(props, ref) {
+  const { selected, fitted, ...rest } = props;
+  return <UnstyledLink ref={ref} {...rest} />;
+});
+
+const StyledTab = styled(LinkWrapper)`
+  ${tabStyles}
+`;
+
+const Tab = React.forwardRef(function Tab(props, ref) {
+  const { index, content, selected, fitted, component, Component, tabIndex, ...rest } = props;
+
+  function handleClick(event) {
+    const { index, onClick } = props;
+    onClick(event, index);
+  }
+
+  // Buttons ensure focusability
+  // Links will be focusable with an href
+  // TODO deprecate `Component`
+  const wrapper = component || Component || 'button';
+
+  return (
+    <StyledTab
+      aria-selected={selected === index}
+      component={wrapper}
+      selected={selected === index}
+      fitted={fitted}
+      ref={ref}
+      {...rest}
+      onClick={handleClick}
+      role="tab"
+      tabIndex={tabIndex}
+      type="button"
+    >
+      {content}
+    </StyledTab>
+  );
+});
+
+Tab.displayName = 'Tab';
+
+export default Tab;

--- a/packages/matchbox/src/components/Tabs/Tabs.js
+++ b/packages/matchbox/src/components/Tabs/Tabs.js
@@ -28,11 +28,15 @@ const Container = styled('div')`
 `;
 
 function Tabs(props) {
-<<<<<<< HEAD
-  const { disableResponsiveBehavior, tabs, selected, onSelect, fitted, ...rest } = props;
-=======
-  const { tabs, selected, onSelect, fitted, keyboardActivation, ...rest } = props;
->>>>>>> 07501457... UX-155 Add keyboard navigation for tabs
+  const {
+    disableResponsiveBehavior,
+    keyboardActivation,
+    tabs,
+    selected,
+    onSelect,
+    fitted,
+    ...rest
+  } = props;
   const [isOverflowing, setIsOverflowing] = React.useState(false);
   const [popoverOpen, setPopoverOpen] = React.useState(false);
 
@@ -78,7 +82,7 @@ function Tabs(props) {
     selected,
     onSelect,
     keyboardActivation,
-    disableResponsiveBehavior
+    disableResponsiveBehavior,
   });
 
   return (

--- a/packages/matchbox/src/components/Tabs/Tabs.js
+++ b/packages/matchbox/src/components/Tabs/Tabs.js
@@ -71,7 +71,7 @@ function Tabs(props) {
   }, [wrapperRef, overflowRef, windowSize]);
 
   // Constructs the tabs, their props and handles tab keyboard navigation
-  const { tabMarkup, tabActions, onFocusContainerKeyDown, focusContainerRef } = useTabConstructor({
+  const { tabMarkup, tabActions, focusContainerProps } = useTabConstructor({
     tabs,
     fitted,
     handleClick,
@@ -95,8 +95,7 @@ function Tabs(props) {
             top="0"
             right="0"
             display="flex"
-            ref={focusContainerRef}
-            onKeyDown={onFocusContainerKeyDown}
+            {...focusContainerProps}
           >
             {tabMarkup}
             {/* Measurement pixel used to detect content overflow */}

--- a/packages/matchbox/src/components/Tabs/Tabs.js
+++ b/packages/matchbox/src/components/Tabs/Tabs.js
@@ -70,6 +70,7 @@ function Tabs(props) {
     }
   }, [wrapperRef, overflowRef, windowSize]);
 
+  // Constructs the tabs, their props and handles tab keyboard navigation
   const { tabMarkup, tabActions, onFocusContainerKeyDown, focusContainerRef } = useTabConstructor({
     tabs,
     fitted,

--- a/packages/matchbox/src/components/Tabs/Tabs.js
+++ b/packages/matchbox/src/components/Tabs/Tabs.js
@@ -6,27 +6,16 @@ import { margin, borderBottom } from 'styled-system';
 import { createPropTypes } from '@styled-system/prop-types';
 import { pick } from '@styled-system/props';
 import { ActionList } from '../ActionList';
-import { UnstyledLink } from '../UnstyledLink';
 import { Box } from '../Box';
 import { Button } from '../Button';
 import { Popover } from '../Popover';
 import { ScreenReaderOnly } from '../ScreenReaderOnly';
 import { deprecate } from '../../helpers/propTypes';
-import { containerStyles, overflowTabs, tabStyles } from './styles';
+import useTabConstructor from './useTabConstructor';
+import Tab from './Tab';
+import { containerStyles, overflowTabs } from './styles';
 
 import { getPositionFor, useWindowSize } from '../../helpers/geometry';
-
-// TODO Replace this when styled-components supports shouldForwardProps
-// See: https://github.com/styled-components/styled-components/commit/e02109e626ed117b76f220d0b9b926129655262d
-// Or when UnstyledLink is updated to use system props
-function LinkWrapper(props) {
-  const { selected, fitted, ...rest } = props;
-  return <UnstyledLink {...rest} />;
-}
-
-const StyledTab = styled(LinkWrapper)`
-  ${tabStyles}
-`;
 
 const OverflowTabContainer = styled('div')`
   ${overflowTabs}
@@ -38,39 +27,12 @@ const Container = styled('div')`
   ${containerStyles}
 `;
 
-function Tab(props) {
-  const { index, content, selected, fitted, component, Component, ...rest } = props;
-
-  function handleClick(event) {
-    const { index, onClick } = props;
-    onClick(event, index);
-  }
-
-  // Buttons ensure focusability
-  // Links will be focusable with an href
-  // TODO deprecate `Component`
-  const wrapper = component || Component || 'button';
-
-  return (
-    <StyledTab
-      aria-selected={selected === index}
-      component={wrapper}
-      selected={selected === index}
-      fitted={fitted}
-      {...rest}
-      onClick={handleClick}
-      role="tab"
-      type="button"
-    >
-      {content}
-    </StyledTab>
-  );
-}
-
-Tab.displayName = 'Tab';
-
 function Tabs(props) {
+<<<<<<< HEAD
   const { disableResponsiveBehavior, tabs, selected, onSelect, fitted, ...rest } = props;
+=======
+  const { tabs, selected, onSelect, fitted, keyboardActivation, ...rest } = props;
+>>>>>>> 07501457... UX-155 Add keyboard navigation for tabs
   const [isOverflowing, setIsOverflowing] = React.useState(false);
   const [popoverOpen, setPopoverOpen] = React.useState(false);
 
@@ -108,44 +70,43 @@ function Tabs(props) {
     }
   }, [wrapperRef, overflowRef, windowSize]);
 
-  const selectedTab = tabs[selected];
-
-  // Constructs ActionList actions from tabs
-  const tabActions = React.useMemo(() => {
-    if (disableResponsiveBehavior) {
-      return;
-    }
-    return tabs.map((tab, i) => {
-      return { is: 'button', ...tab, onClick: e => handleClick(e, i), visible: i !== selected };
-    });
-  }, [selected, tabs, isOverflowing, disableResponsiveBehavior]);
+  const { tabMarkup, tabActions, onFocusContainerKeyDown, focusContainerRef } = useTabConstructor({
+    tabs,
+    fitted,
+    handleClick,
+    selected,
+    onSelect,
+    keyboardActivation,
+    disableResponsiveBehavior
+  });
 
   return (
     <Container borderBottom="400" {...pick(rest)} ref={wrapperRef}>
-      <Box aria-hidden={isOverflowing} overflow="hidden">
+      <Box aria-hidden={isOverflowing}>
         <OverflowTabContainer
           aria-orientation="horizontal"
           isOverflowing={isOverflowing}
           role="tablist"
         >
-          {tabs.map((tab, i) => (
-            <Tab
-              key={i}
-              index={i}
-              fitted={fitted}
-              selected={selected}
-              {...tab}
-              onClick={handleClick}
-            />
-          ))}
-          {/* Measurement pixel used to detect content overflow */}
-          <Box display="inline-block" width="1px" height="1px" ref={overflowRef} />
+          <Box
+            position="absolute"
+            left="0"
+            top="0"
+            right="0"
+            display="flex"
+            ref={focusContainerRef}
+            onKeyDown={onFocusContainerKeyDown}
+          >
+            {tabMarkup}
+            {/* Measurement pixel used to detect content overflow */}
+            <Box display="inline-block" width="1px" height="1px" ref={overflowRef} />
+          </Box>
         </OverflowTabContainer>
       </Box>
       {isOverflowing && !disableResponsiveBehavior && (
         <Box display="flex" alignItems="center" justifyContent="space-between">
           <Box flex="0">
-            <Tab index={selected} selected={selected} {...selectedTab} />
+            <Tab index={selected} selected={selected} {...tabs[selected]} />
           </Box>
 
           <Box flex="0">
@@ -198,6 +159,7 @@ Tabs.propTypes = {
     PropTypes.oneOf(['orange', 'blue', 'navy', 'purple', 'red']),
     'Tab color is no longer configurable',
   ),
+  keyboardActivation: PropTypes.oneOf(['auto', 'manual']),
   /**
    * Index of selected tab
    */
@@ -205,6 +167,10 @@ Tabs.propTypes = {
   onSelect: PropTypes.func,
   ...createPropTypes(margin.propNames),
   ...createPropTypes(borderBottom.propNames),
+};
+
+Tabs.defaultProps = {
+  keyboardActivation: 'auto',
 };
 
 export default Tabs;

--- a/packages/matchbox/src/components/Tabs/Tabs.js
+++ b/packages/matchbox/src/components/Tabs/Tabs.js
@@ -27,7 +27,7 @@ const Container = styled('div')`
   ${containerStyles}
 `;
 
-function Tabs(props) {
+const Tabs = React.forwardRef(function Tabs(props, userRef) {
   const {
     disableResponsiveBehavior,
     keyboardActivation,
@@ -85,8 +85,17 @@ function Tabs(props) {
     disableResponsiveBehavior,
   });
 
+  const assignWrapperRefs = node => {
+    if (wrapperRef) {
+      wrapperRef.current = node;
+    }
+    if (userRef) {
+      userRef.current = node;
+    }
+  };
+
   return (
-    <Container borderBottom="400" {...pick(rest)} ref={wrapperRef}>
+    <Container borderBottom="400" {...pick(rest)} ref={assignWrapperRefs} tabIndex="-1">
       <Box aria-hidden={isOverflowing}>
         <OverflowTabContainer
           aria-orientation="horizontal"
@@ -140,7 +149,7 @@ function Tabs(props) {
       )}
     </Container>
   );
-}
+});
 
 Tabs.displayName = 'Tabs';
 Tabs.propTypes = {

--- a/packages/matchbox/src/components/Tabs/readme.md
+++ b/packages/matchbox/src/components/Tabs/readme.md
@@ -1,0 +1,34 @@
+# Tabs
+
+```js
+import { Tabs, useTabs } from '@sparkpost/matchbox';
+
+function Example() {
+  const {
+    getTabsProps, // Provides required tab props, onSelect, selected, and constructed tabs with onClick handlers
+    tabIndex, // The selected tab index
+    tabs, // The constructed tabs with onClick handlers
+    setTabIndex, // Function to programatically set tab index
+  } = useTabs({
+    tabs, // Your tabs array
+    initialSelected, // Sets initial selected tab
+  });
+
+  return (
+    <>
+      <Tabs
+        {...getTabProps()}
+        // When set to 'auto', automatically activates tabs when using focus keyboard navigation
+        // When set to 'manual', tab activation requires using space or enter keys after focusing
+        keyboardActivation="manual"
+        // Stretches the tabs to span the full width
+        fitted
+        // System prop to manually overwrite border
+        borderBottom="none"
+        // System prop to manually set margins
+        m="500"
+      />
+    </>
+  );
+}
+```

--- a/packages/matchbox/src/components/Tabs/styles.js
+++ b/packages/matchbox/src/components/Tabs/styles.js
@@ -8,9 +8,10 @@ export const tabStyles = ({ selected, fitted }) => `
   position: relative;
   flex: ${fitted ? '1' : '0'};
   text-decoration: none;
+  outline: none;
   
   padding: 0 ${tokens.spacing_200};
-  margin: 0 ${!fitted ? `${tokens.sizing_450}` : '0'};
+  margin: 0 ${!fitted ? `${tokens.sizing_450}` : `${tokens.sizing_200}`};
 
   font-size: ${tokens.fontSize_200};
   font-weight: ${tokens.fontWeight_medium};
@@ -21,13 +22,16 @@ export const tabStyles = ({ selected, fitted }) => `
     color: ${selected ? tokens.color_blue_700 : tokens.color_gray_700};
   }
 
-  &:after {
+  &:after, &:before {
     display: block;
     position: absolute;
     content: '';
     bottom: 0px;
     left: 0;
     right: 0;
+  }
+
+  &:after {
     height: ${tokens.spacing_100};
     background: ${selected ? tokens.color_blue_700 : 'transparent'};
     transition: ${tokens.motionDuration_fast} ${tokens.motionEase_in_out};
@@ -37,6 +41,19 @@ export const tabStyles = ({ selected, fitted }) => `
     ${!selected ? `color: ${tokens.color_gray_900};` : ''};
     &:after {
       ${!selected ? `background: ${tokens.color_gray_400};` : ''}
+    }
+  }
+
+  &:before {
+    top: 0;
+    border-radius: ${tokens.borderRadius_100};
+    box-shadow:  0 0 0 2px ${tokens.color_white}, 0 0 0 4px ${tokens.color_blue_700};
+    opacity: 0;
+  }
+
+  &:focus, &:active {
+    &:before {
+      opacity: 1;
     }
   }
 `;

--- a/packages/matchbox/src/components/Tabs/tests/Tabs.test.js
+++ b/packages/matchbox/src/components/Tabs/tests/Tabs.test.js
@@ -59,4 +59,22 @@ describe('Tabs', () => {
     });
     expect(wrapper.find('a').text()).toEqual('Tab 4');
   });
+
+  it('renders with with a ref', () => {
+    function Test() {
+      const ref = React.useRef();
+      React.useEffect(() => {
+        ref.current.focus();
+      }, []);
+      return (
+        <>
+          <Tabs ref={ref} {...defaultprops} />
+          not this
+        </>
+      );
+    }
+    global.mountStyled(<Test />);
+    expect(document.activeElement.innerHTML.includes('Tab 1')).toBe(true);
+    expect(document.activeElement.innerHTML.includes('not this')).toBe(false);
+  });
 });

--- a/packages/matchbox/src/components/Tabs/tests/Tabs.test.js
+++ b/packages/matchbox/src/components/Tabs/tests/Tabs.test.js
@@ -21,7 +21,7 @@ describe('Tabs', () => {
   it('renders fitted styles', () => {
     const wrapper = subject({ fitted: true });
     expect(wrapper.find('button').at(0)).toHaveStyleRule('flex', '1');
-    expect(wrapper.find('button').at(0)).toHaveStyleRule('margin', '0 0');
+    expect(wrapper.find('button').at(0)).toHaveStyleRule('margin', '0 0.5rem');
   });
 
   it('renders with first tab selected', () => {
@@ -49,7 +49,13 @@ describe('Tabs', () => {
 
   it('renders a custom tab component', () => {
     const wrapper = subject({
-      tabs: [...defaultprops.tabs, { content: 'Tab 4', component: props => <a {...props} /> }],
+      tabs: [
+        ...defaultprops.tabs,
+        {
+          content: 'Tab 4',
+          component: React.forwardRef((props, ref) => <a ref={ref} {...props} />),
+        },
+      ],
     });
     expect(wrapper.find('a').text()).toEqual('Tab 4');
   });

--- a/packages/matchbox/src/components/Tabs/useTabConstructor.js
+++ b/packages/matchbox/src/components/Tabs/useTabConstructor.js
@@ -1,0 +1,106 @@
+import React from 'react';
+import Tab from './Tab';
+import { onKey, onKeys } from '../../helpers/keyEvents';
+
+function useTabConstructor({
+  tabs,
+  fitted,
+  selected = 0,
+  handleClick,
+  onSelect,
+  keyboardActivation,
+  disableResponsiveBehavior,
+}) {
+  const [focused, setFocused] = React.useState(0);
+  const focusContainerRef = React.useRef({});
+  const tabRefs = React.useRef({ current: [{}] });
+
+  // Handles keydown events on the tab focus container
+  const onFocusContainerKeyDown = React.useCallback(
+    e => {
+      const isWithin = focusContainerRef.current && focusContainerRef.current.contains(e.target);
+
+      if (!isWithin) {
+        return;
+      }
+
+      onKey('arrowRight', () => {
+        e.preventDefault();
+        if (focused === tabs.length - 1) {
+          setFocused(0);
+        } else {
+          setFocused(focused + 1);
+        }
+      })(e);
+
+      onKey('arrowLeft', () => {
+        e.preventDefault();
+        if (focused === 0) {
+          setFocused(tabs.length - 1);
+        } else {
+          setFocused(focused - 1);
+        }
+      })(e);
+
+      onKeys(['home', 'pageDown'], () => {
+        e.preventDefault();
+        setFocused(0);
+      })(e);
+
+      onKeys(['end', 'pageUp'], () => {
+        e.preventDefault();
+        setFocused(tabs.length - 1);
+      })(e);
+    },
+    [tabs, focusContainerRef.current, focused],
+  );
+
+  // Preps array of tab item refs
+  React.useEffect(() => {
+    tabRefs.current = new Array(tabs.length);
+  }, [tabs]);
+
+  // Focuses on tab items when focused index changes
+  // Optionally calls onSelect
+  React.useEffect(() => {
+    if (tabRefs.current[focused]) {
+      tabRefs.current[focused].focus();
+      if (keyboardActivation === 'auto' && onSelect) {
+        onSelect(focused);
+      }
+    }
+  }, [focused]);
+
+  // Constructs Tabs with refs
+  const tabMarkup = tabs.map((tab, i) => (
+    <Tab
+      ref={n => (tabRefs.current[i] = n)}
+      key={i}
+      index={i}
+      fitted={fitted}
+      selected={selected}
+      {...tab}
+      onClick={handleClick}
+      tabIndex={focused === i || selected === i ? '0' : '-1'}
+    />
+  ));
+
+  // Constructs ActionList actions from tabs
+  const tabActions = React.useMemo(() => {
+    if (disableResponsiveBehavior) {
+      return;
+    }
+    return tabs.map((tab, i) => {
+      return { is: 'button', ...tab, onClick: e => handleClick(e, i), visible: i !== selected };
+    });
+  }, [selected, tabs]);
+
+  return {
+    tabMarkup,
+    tabActions,
+    onFocusContainerKeyDown,
+    focusContainerRef,
+  };
+}
+
+export default useTabConstructor;

--- a/packages/matchbox/src/components/Text/Text.js
+++ b/packages/matchbox/src/components/Text/Text.js
@@ -12,20 +12,20 @@ const StyledText = styled('p')`
   ${lookslike}
 `;
 
-const Text = function(props) {
-  const { as, lookslike, children, ...rest } = props;
+const Text = React.forwardRef(function Text(props, ref) {
+  const { as, looksLike, children, ...rest } = props;
 
   return (
-    <StyledText as={as} lookslike={lookslike} {...rest}>
+    <StyledText as={as} lookslike={looksLike} ref={ref} {...rest}>
       {children}
     </StyledText>
   );
-};
+});
 
 Text.propTypes = {
   as: PropTypes.elementType.isRequired,
   children: PropTypes.node.isRequired,
-  lookslike: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p']),
+  looksLike: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p']),
 };
 
 Text.defaultProps = {

--- a/packages/matchbox/src/components/UnstyledLink/UnstyledLink.js
+++ b/packages/matchbox/src/components/UnstyledLink/UnstyledLink.js
@@ -4,7 +4,7 @@ import { deprecate } from '../../helpers/propTypes';
 
 import { Text } from '../Text';
 
-function UnstyledLink(props) {
+const UnstyledLink = React.forwardRef(function UnstyledLink(props, ref) {
   const { children, to, title, Component, component, external, onClick, role, ...rest } = props;
 
   const WrapperComponent = component || Component;
@@ -20,6 +20,7 @@ function UnstyledLink(props) {
         rel={external ? 'noopener noreferrer' : ''}
         title={linkTitle}
         onClick={onClick}
+        ref={ref}
         {...rest}
       >
         {children}
@@ -29,18 +30,18 @@ function UnstyledLink(props) {
 
   if (WrapperComponent) {
     return (
-      <Text as={WrapperComponent} to={to} title={linkTitle} onClick={onClick} {...rest}>
+      <Text as={WrapperComponent} to={to} title={linkTitle} onClick={onClick} ref={ref} {...rest}>
         {children}
       </Text>
     );
   }
 
   return (
-    <Text as="a" title={linkTitle} role={linkRole} onClick={onClick} {...rest}>
+    <Text as="a" title={LinkTitle} role={linkRole} onClick={onClick} ref={ref} {...rest}>
       {children}
     </Text>
   );
-}
+});
 
 UnstyledLink.displayName = 'UnstyledLink';
 

--- a/packages/matchbox/src/components/UnstyledLink/UnstyledLink.js
+++ b/packages/matchbox/src/components/UnstyledLink/UnstyledLink.js
@@ -37,7 +37,7 @@ const UnstyledLink = React.forwardRef(function UnstyledLink(props, ref) {
   }
 
   return (
-    <Text as="a" title={LinkTitle} role={linkRole} onClick={onClick} ref={ref} {...rest}>
+    <Text as="a" title={linkTitle} role={linkRole} onClick={onClick} ref={ref} {...rest}>
       {children}
     </Text>
   );

--- a/packages/matchbox/src/helpers/keyEvents.js
+++ b/packages/matchbox/src/helpers/keyEvents.js
@@ -2,57 +2,71 @@ const keys = {
   backspace: {
     key: 'Backspace',
     keyCode: 8,
-    shiftKey: false
+    shiftKey: false,
   },
   enter: {
     key: 'Enter',
     keyCode: 13,
-    shiftKey: false
+    shiftKey: false,
   },
   escape: {
     key: 'Escape',
     keyCode: 27,
-    shiftKey: false
+    shiftKey: false,
   },
   arrowRight: {
     key: 'ArrowRight',
     keyCode: 39,
-    shiftKey: false
+    shiftKey: false,
   },
   arrowLeft: {
     key: 'ArrowLeft',
     keyCode: 37,
-    shiftKey: false
+    shiftKey: false,
   },
   arrowUp: {
     key: 'ArrowUp',
     keyCode: 38,
-    shiftKey: false
+    shiftKey: false,
   },
   arrowDown: {
     key: 'ArrowDown',
     keyCode: 40,
-    shiftKey: false
+    shiftKey: false,
   },
   home: {
     key: 'Home',
     keyCode: 36,
-    shiftKey: false
+    shiftKey: false,
   },
   end: {
     key: 'End',
     keyCode: 35,
-    shiftKey: false
+    shiftKey: false,
   },
   space: {
     key: ' ',
     keyCode: 32,
-    shiftKey: false
-  }
+    shiftKey: false,
+  },
+  pageUp: {
+    key: 'PageUp',
+    keyCode: 33,
+    shiftKey: false,
+  },
+  pageDown: {
+    key: 'PageDown',
+    keyCode: 34,
+    shiftKey: false,
+  },
 };
 
 function compareEvent(event, e) {
-  return (e.key === keys[event].key || e.keyCode === keys[event].keyCode) && e.shiftKey === keys[event].shiftKey;
+  return (
+    !!keys[event] &&
+    (e.key === keys[event].key || e.keyCode === keys[event].keyCode) &&
+    e.shiftKey === keys[event].shiftKey
+  );
 }
 
 /**
@@ -73,6 +87,6 @@ export function onKey(event, callback) {
  */
 export function onKeys(events, callback) {
   return function handleEvents(e) {
-    events.forEach((event) => onKey(event, callback)(e));
+    events.forEach(event => onKey(event, callback)(e));
   };
 }

--- a/packages/matchbox/src/hooks/index.js
+++ b/packages/matchbox/src/hooks/index.js
@@ -1,2 +1,3 @@
 export { default as useDrawer } from './useDrawer';
+export { default as useTabs } from './useTabs';
 export { default as useWindowEvent } from './useWindowEvent';

--- a/packages/matchbox/src/hooks/useTabs.js
+++ b/packages/matchbox/src/hooks/useTabs.js
@@ -1,0 +1,35 @@
+import React from 'react';
+
+/**
+ * Reusable hook to be used with the Tabs component
+ */
+function useTabs({ tabs = [], initialSelected = 0 }) {
+  const [tabIndex, setTabIndex] = React.useState(initialSelected);
+
+  const tabsWithOnClick = React.useMemo(() => {
+    return tabs.map((tab, i) => ({ ...tab, onClick: () => setTabIndex(i) }));
+  }, [tabs]);
+
+  const onSelect = React.useCallback(
+    index => {
+      setTabIndex(index);
+    },
+    [tabs],
+  );
+
+  const getTabsProps = userProps => ({
+    tabs: tabsWithOnClick,
+    selected: tabIndex,
+    onSelect,
+    ...userProps,
+  });
+
+  return {
+    getTabsProps,
+    tabIndex,
+    tabs,
+    setTabIndex,
+  };
+}
+
+export default useTabs;

--- a/stories/Text.stories.js
+++ b/stories/Text.stories.js
@@ -49,25 +49,25 @@ export const ExampleOfTags = withInfo(infoOptions)(() => (
 
 export const LooksLike = withInfo(infoOptions)(() => (
   <Box>
-    <Text as="h1" lookslike="h4">
+    <Text as="h1" looksLike="h4">
       Is h1, Looks Like h4
     </Text>
-    <Text as="h2" lookslike="h6">
+    <Text as="h2" looksLike="h6">
       Is h2, Looks Like h6
     </Text>
-    <Text as="h3" lookslike="h2">
+    <Text as="h3" looksLike="h2">
       Is h3, Looks Like h2
     </Text>
-    <Text as="h4" lookslike="h1">
+    <Text as="h4" looksLike="h1">
       Is h4, Looks Like h1
     </Text>
-    <Text as="h5" lookslike="h3">
+    <Text as="h5" looksLike="h3">
       Is h5, Looks Like h3
     </Text>
-    <Text as="h6" lookslike="h4">
+    <Text as="h6" looksLike="h4">
       Is h6, Looks Like h4
     </Text>
-    <Text as="p" lookslike="h1">
+    <Text as="p" looksLike="h1">
       Is p, Looks Like h1
     </Text>
   </Box>

--- a/stories/navigation/Tabs.stories.js
+++ b/stories/navigation/Tabs.stories.js
@@ -19,7 +19,7 @@ const tabs = [
   {
     content: 'Example with a component wrapper',
     onClick: action('Example with component clicked'),
-    Component: props => <a {...props} href="#" />,
+    Component: React.forwardRef((props, ref) => <a ref={ref} {...props} href="#" />),
   },
 ];
 
@@ -27,7 +27,7 @@ const handleSelect = action('Tab Selected');
 
 const Example = () => {
   const [i, seti] = React.useState(0);
-  return <Tabs selected={i} onSelect={ind => seti(ind)} tabs={tabs} />;
+  return <Tabs selected={i} onSelect={ind => seti(ind)} tabs={tabs} keyboardActivation="manual" />;
 };
 
 export default {

--- a/stories/navigation/Tabs.stories.js
+++ b/stories/navigation/Tabs.stories.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { withInfo } from '@storybook/addon-info';
 import { action } from '@storybook/addon-actions';
-import { Tabs, Panel } from '@sparkpost/matchbox';
+import { Tabs, Panel, useTabs } from '@sparkpost/matchbox';
 
 const tabs = [
   {
@@ -23,59 +23,55 @@ const tabs = [
   },
 ];
 
-const handleSelect = action('Tab Selected');
-
-const Example = () => {
-  const [i, seti] = React.useState(0);
-  return (
-    <Tabs
-      mb="800"
-      selected={i}
-      onSelect={ind => seti(ind)}
-      tabs={tabs}
-      keyboardActivation="manual"
-    />
-  );
-};
-
 export default {
   title: 'Navigation|Tabs',
 };
 
-export const ExampleTabs = withInfo({ source: false, propTables: [Tabs] })(() => (
-  <>
-    <Example />
-    <button>this is only here to test focus order</button>
-  </>
-));
+export const ExampleTabs = withInfo({ source: false, propTables: [Tabs] })(() => {
+  const { getTabsProps } = useTabs({ tabs });
+  return (
+    <>
+      <Tabs mb="800" {...getTabsProps()} keyboardActivation="manual" />
+      <button>this is only here to test focus order</button>
+    </>
+  );
+});
 
-export const DefaultTabs = withInfo()(() => (
-  <Tabs selected={0} connectBelow={false} onSelect={handleSelect} tabs={tabs} />
-));
+export const AutomaticKeyboardActivation = withInfo()(() => {
+  const { getTabsProps } = useTabs({ tabs });
+  return <Tabs mb="800" {...getTabsProps()} keyboardActivation="auto" />;
+});
 
-export const FittedTabs = withInfo()(() => (
-  <Tabs fitted selected={0} onSelect={handleSelect} tabs={tabs} />
-));
+export const FittedTabs = withInfo()(() => {
+  const { getTabsProps } = useTabs({ tabs });
+  return <Tabs mb="800" {...getTabsProps()} fitted keyboardActivation="auto" />;
+});
 
-export const ExampleWithinPanel = withInfo()(() => (
-  <>
-    <Panel mb="400">
-      <Tabs selected={0} onSelect={handleSelect} tabs={tabs} />
-      <Panel.Section p="400">Example</Panel.Section>
-    </Panel>
-    <Panel>
-      <Tabs fitted selected={0} onSelect={handleSelect} tabs={tabs} />
-      <Panel.Section p="400">Example</Panel.Section>
-    </Panel>
-  </>
-));
+export const ExampleWithinPanel = withInfo()(() => {
+  const { getTabsProps } = useTabs({ tabs });
+  return (
+    <>
+      <Panel mb="400">
+        <Tabs {...getTabsProps()} />
+        <Panel.Section p="400">Example</Panel.Section>
+      </Panel>
+      <Panel>
+        <Tabs fitted {...getTabsProps()} />
+        <Panel.Section p="400">Example</Panel.Section>
+      </Panel>
+    </>
+  );
+});
 
-export const SystemProps = withInfo()(() => (
-  <>
-    <Tabs selected={0} borderBottom="none" tabs={tabs} my={['400', null, '800', '100px']} />
-    <Tabs fitted selected={0} tabs={tabs} mx={['400', null, '800', '200px']} />
-  </>
-));
+export const SystemProps = withInfo()(() => {
+  const { getTabsProps } = useTabs({ tabs });
+  return (
+    <>
+      <Tabs borderBottom="none" {...getTabsProps()} my={['400', null, '800', '100px']} />
+      <Tabs fitted {...getTabsProps()} mx={['400', null, '800', '200px']} />
+    </>
+  );
+});
 
 export const DisabledResponsiveBehavior = withInfo()(() => (
   <Tabs selected={0} disableResponsiveBehavior onSelect={handleSelect} tabs={tabs} />

--- a/stories/navigation/Tabs.stories.js
+++ b/stories/navigation/Tabs.stories.js
@@ -74,5 +74,5 @@ export const SystemProps = withInfo()(() => {
 });
 
 export const DisabledResponsiveBehavior = withInfo()(() => (
-  <Tabs selected={0} disableResponsiveBehavior onSelect={handleSelect} tabs={tabs} />
+  <Tabs selected={0} disableResponsiveBehavior tabs={tabs} />
 ));

--- a/stories/navigation/Tabs.stories.js
+++ b/stories/navigation/Tabs.stories.js
@@ -27,14 +27,27 @@ const handleSelect = action('Tab Selected');
 
 const Example = () => {
   const [i, seti] = React.useState(0);
-  return <Tabs selected={i} onSelect={ind => seti(ind)} tabs={tabs} keyboardActivation="manual" />;
+  return (
+    <Tabs
+      mb="800"
+      selected={i}
+      onSelect={ind => seti(ind)}
+      tabs={tabs}
+      keyboardActivation="manual"
+    />
+  );
 };
 
 export default {
   title: 'Navigation|Tabs',
 };
 
-export const ExampleTabs = withInfo({ source: false, propTables: [Tabs] })(() => <Example />);
+export const ExampleTabs = withInfo({ source: false, propTables: [Tabs] })(() => (
+  <>
+    <Example />
+    <button>this is only here to test focus order</button>
+  </>
+));
 
 export const DefaultTabs = withInfo()(() => (
   <Tabs selected={0} connectBelow={false} onSelect={handleSelect} tabs={tabs} />

--- a/unreleased.md
+++ b/unreleased.md
@@ -159,3 +159,8 @@
 - #245 - Adds new `label` and `valueText` props to Progressbar
 - #235 - Adds new `title` prop to Table that renders a screen reader accessible caption
 - #247 - UnstyledLinks now use `role="button"` if they are not links
+- #413 - Adds support for tab keyboard navigation
+- #413 - Adds new prop keyboardActivation defaults to auto
+- #413 - Tabs with custom components now require a ref to be forwarded
+- #413 - Adds new useTabs hook to support tab state implementation
+- #413 - Refs can now be forwarded to Text, UnstyledLink, Tabs


### PR DESCRIPTION
### What Changed
- Adds support for tab keyboard navigation
- Adds new prop `keyboardActivation` defaults to `auto`
- Adds new `useTabs` hook to support tab state implementation
- Refs can now be forwarded to `Text`, `UnstyledLink`
- Tabs with custom components now require a `ref` to be forwarded

Key | Desc
-- | --
Enter / Spacebar | Activates focused tab – inherited through button and anchor tags with href
Tab | When focus is before tablist moves focus to the active tab. If focus is on the active tab moves focus to the next element in the keyboard focus order, and skip the next tab.
ArrowLeft / ArrowRight | Navigates between tabs when orientation is "horizontal". When on last, should move to first. When on first, should move to last.
Home / PageUp | Navigates to the last tab in the TabList.
End / PageDown | Navigates to the first tab in the TabList.



### How To Test or Verify
- Run storybook `npm run start:storybook`
- Visit tab stories and verify key events work with both auto and manual activation

### PR Checklist

- [x] Update `unreleased.md` in the root directory
<!--
Outline any changes to the development worflow, component APIs, component behavior. If this does not affect a published packages, you can ignore.
-->
- [ ] Approval from #uxfe or #design-guild
<!--
Provide screenshots or [screen recordings](https://getkap.co/) and request a review from.
Ignore if this does not contain and visual component changes
-->
