### PR TITLE
UX-240 Add focus styles to textfield, combobox, select

### DIFF
--- a/packages/matchbox/src/components/Button/styles.js
+++ b/packages/matchbox/src/components/Button/styles.js
@@ -20,7 +20,7 @@ export function focus(props) {
       break;
   }
 
-  return focusOutline(color);
+  return focusOutline({ color });
 }
 
 export const base = () => `

--- a/packages/matchbox/src/components/ComboBox/styles.js
+++ b/packages/matchbox/src/components/ComboBox/styles.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import { tokens } from '@sparkpost/design-tokens';
 import { Box } from '../Box';
+import { focusOutline } from '../../styles/helpers';
 
 const inputHeight = '2.5rem';
 
@@ -15,9 +16,7 @@ export const StyledInputWrapper = styled(Box)`
   border-radius: ${tokens.borderRadius_100};
   min-height: ${inputHeight};
 
-  &:focus-within {
-    border: ${tokens.borderWidth_100} solid ${tokens.color_blue_700};
-  }
+  ${focusOutline({ within: true })}
 `;
 
 export const StyledInput = styled('input')`

--- a/packages/matchbox/src/components/Select/Select.js
+++ b/packages/matchbox/src/components/Select/Select.js
@@ -13,6 +13,7 @@ import { createPropTypes } from '@styled-system/prop-types';
 import { omit } from '@styled-system/props';
 import { pick } from '../../helpers/systemProps';
 import useInputDescribedBy from '../../hooks/useInputDescribedBy';
+import { focusOutline } from '../../styles/helpers';
 
 const Option = ({ option }) => {
   if (typeof option === 'object') {
@@ -47,22 +48,32 @@ function Options({ options, placeholder, placeholderValue }) {
   );
 }
 
+const StyledInputWrapper = styled(Box)`
+  ${focusOutline({ within: true, offset: '2px' })}
+`;
+
+const StyledInput = styled(Box)`
+  outline: none;
+`;
+
 const SelectBox = props => {
   return (
-    <Box
-      as="select"
-      disabled={props.disabled}
-      width="100%"
-      border={props.hasError ? `1px solid ${tokens.color_red_700}` : '400'}
-      borderRadius="100"
-      bg={props.disabled ? 'gray.200' : 'white'}
-      pl="400"
-      pr="600"
-      lineHeight="2.5rem"
-      height="2.5rem"
-      color="gray.900"
-      {...props}
-    />
+    <StyledInputWrapper>
+      <StyledInput
+        as="select"
+        disabled={props.disabled}
+        width="100%"
+        border={props.hasError ? `1px solid ${tokens.color_red_700}` : '400'}
+        borderRadius="100"
+        bg={props.disabled ? 'gray.200' : 'white'}
+        pl="400"
+        pr="600"
+        lineHeight="2.5rem"
+        height="2.5rem"
+        color="gray.900"
+        {...props}
+      />
+    </StyledInputWrapper>
   );
 };
 

--- a/packages/matchbox/src/components/Select/tests/Select.test.js
+++ b/packages/matchbox/src/components/Select/tests/Select.test.js
@@ -40,11 +40,11 @@ describe('Select', () => {
     expect(
       wrapper
         .find('div')
-        .at(2)
+        .at(3)
         .text(),
     ).toEqual('test-error');
     expect(wrapper.find('select')).toHaveAttributeValue('aria-describedby', 'test-id-error');
-    expect(wrapper.find('div').at(2)).toHaveAttributeValue('id', 'test-id-error');
+    expect(wrapper.find('div').at(3)).toHaveAttributeValue('id', 'test-id-error');
   });
 
   it('should render with error and helptext describedby', () => {

--- a/packages/matchbox/src/components/TextField/TextField.js
+++ b/packages/matchbox/src/components/TextField/TextField.js
@@ -13,30 +13,40 @@ import { createPropTypes } from '@styled-system/prop-types';
 import { omit } from '@styled-system/props';
 import styled from 'styled-components';
 import { pick } from '../../helpers/systemProps';
+import { focusOutline } from '../../styles/helpers';
 
 const system = compose(margin, maxWidth);
 const StyledWrapper = styled('div')`
   ${system}
 `;
 
-// TODO Make this reusable and shared with Select
+const StyledInputWrapper = styled(Box)`
+  ${focusOutline({ within: true, offset: '2px' })}
+`;
+
+const StyledInput = styled(Box)`
+  outline: none;
+`;
+
 const FieldBox = props => {
   return (
-    <Box
-      as="input"
-      px="400"
-      {...props}
-      disabled={props.disabled}
-      width="100%"
-      border={props.hasError ? `1px solid ${tokens.color_red_700}` : '400'}
-      borderRadius="100"
-      bg={props.disabled ? 'gray.200' : 'white'}
-      color="gray.900"
-      height={props.height}
-      lineHeight={props.lineHeight}
-      py={props.py}
-      required={props.required}
-    />
+    <StyledInputWrapper>
+      <StyledInput
+        as="input"
+        px="400"
+        {...props}
+        disabled={props.disabled}
+        width="100%"
+        border={props.hasError ? `1px solid ${tokens.color_red_700}` : '400'}
+        borderRadius="100"
+        bg={props.disabled ? 'gray.200' : 'white'}
+        color="gray.900"
+        height={props.height}
+        lineHeight={props.lineHeight}
+        py={props.py}
+        required={props.required}
+      />
+    </StyledInputWrapper>
   );
 };
 

--- a/packages/matchbox/src/components/TextField/tests/TextField.test.js
+++ b/packages/matchbox/src/components/TextField/tests/TextField.test.js
@@ -8,7 +8,7 @@ describe('TextField', () => {
   const input = wrapper => wrapper.find('input');
   const label = wrapper => wrapper.find('label');
   const helptext = wrapper => wrapper.find('div').last();
-  const error = wrapper => wrapper.find('div').at(4); // last with no label or help text
+  const error = wrapper => wrapper.find('div').at(5); // last with no label or help text
   const textarea = wrapper => wrapper.find('textarea');
 
   it('renders defaults correctly', () => {

--- a/packages/matchbox/src/styles/helpers.js
+++ b/packages/matchbox/src/styles/helpers.js
@@ -37,6 +37,7 @@ export const visuallyHidden = `
  * Creates focus styles on an :after pseudo-element. Defaults to blue 700.
  * @param string color
  * @param within boolean
+ * @param offset string, pixel value
  */
 export const focusOutline = ({ color = tokens.color_blue_700, within = false, offset = '3px' }) => `
   position: relative;

--- a/packages/matchbox/src/styles/helpers.js
+++ b/packages/matchbox/src/styles/helpers.js
@@ -36,8 +36,9 @@ export const visuallyHidden = `
 /**
  * Creates focus styles on an :after pseudo-element. Defaults to blue 700.
  * @param string color
+ * @param within boolean
  */
-export const focusOutline = (color = tokens.color_blue_700) => `
+export const focusOutline = ({ color = tokens.color_blue_700, within = false, offset = '3px' }) => `
   position: relative;
   outline: none;
 
@@ -45,17 +46,17 @@ export const focusOutline = (color = tokens.color_blue_700) => `
     position: absolute;
     content: "";
     display: block;
-    top: -3px;
-    left: -3px;
-    right: -3px;
-    bottom: -3px;
+    top: -${offset};
+    left: -${offset};
+    right: -${offset};
+    bottom: -${offset};
     transition: ${tokens.motionDuration_fast};
     border-radius: ${tokens.borderRadius_200};
     box-shadow: none;
     pointer-events: none;
   } 
 
-  &:focus:after {
+  &:focus${within ? '-within' : ''}:after {
     z-index: ${tokens.zIndex_default};
     opacity: 1;
     box-shadow: 0 0 0 2px ${color};

--- a/unreleased.md
+++ b/unreleased.md
@@ -10,3 +10,4 @@ Example: - #456 - Deprecates Tab prop `tabs`
 - #476 - Fixes a visual bug with the drawer close button
 - #462 - Adds focus styles to all button variations
 - #490 - Toolips wait 300 ms after interaction before becoming visible
+- #493 - Adds focus styles to TextField, Select, ComboBoxTextfield


### PR DESCRIPTION

### What Changed
- Adds focus styles to `TextField` `Select` and `ComboBoxTextfield`

### How To Test or Verify
- Run storybook
- Visit related stories and test focus

### PR Checklist

- [x] Update `unreleased.md` in the root directory
<!--
Outline any changes to the development worflow, component APIs, component behavior. If this does not affect a published packages, you can ignore.
-->
- [ ] Approval from #uxfe or #design-guild
<!--
Provide screenshots or [screen recordings](https://getkap.co/) and request a review from.
Ignore if this does not contain and visual component changes
-->
