### PR TITLE
Resolve #502 - Changes tag screen reader text to 'Remove'

### DIFF
--- a/packages/matchbox/src/components/ComboBox/tests/ComboBoxTextField.test.js
+++ b/packages/matchbox/src/components/ComboBox/tests/ComboBoxTextField.test.js
@@ -113,7 +113,7 @@ describe('ComboBoxTextField', () => {
   describe('selected items', () => {
     it('should render selected items correctly', () => {
       const wrapper = subject();
-      expect(tags(wrapper).text()).toEqual('fooClosebarClose');
+      expect(tags(wrapper).text()).toEqual('fooRemovebarRemove');
     });
 
     it('should handle remove on a tag correctly', () => {

--- a/packages/matchbox/src/components/Tag/Tag.js
+++ b/packages/matchbox/src/components/Tag/Tag.js
@@ -29,7 +29,7 @@ function Tag(props) {
   const closeMarkup = onRemove ? (
     <StyledClose onClick={onRemove} tagColor={color} type="button">
       <Close size={16} />
-      <ScreenReaderOnly>Close</ScreenReaderOnly>
+      <ScreenReaderOnly>Remove</ScreenReaderOnly>
     </StyledClose>
   ) : null;
 

--- a/packages/matchbox/src/components/Tag/tests/Tag.test.js
+++ b/packages/matchbox/src/components/Tag/tests/Tag.test.js
@@ -15,7 +15,7 @@ describe('Tag', () => {
 
   it('should render a remove button', () => {
     const wrapper = global.mountStyled(<Tag onRemove={jest.fn()}>Hola!</Tag>);
-    expect(wrapper.find('button').text()).toEqual('Close');
+    expect(wrapper.find('button').text()).toEqual('Remove');
   });
 
   it('should handle remove on click', () => {


### PR DESCRIPTION
Closes #502 

### What Changed
- Changes tag screen reader only text from 'Close' to 'Remove'

### How To Test or Verify
Run storybook and verify the Tag remove buttons have 'Remove' 

### PR Checklist
- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
