### PR TITLE
Update changelog scripts to prepend to root file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,3 @@ storybook-static
 # changelog 
 .changelog
 .temp_changes.md
-.changelog.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+## 4.0.2 (2020-06-26)
+
+#### Enhancements
+
+- `matchbox`
+  - [#503](https://github.com/SparkPost/matchbox/pull/503) UX-252 Add helptext prop to
+    Actionlist.Action ([@jonambas](https://github.com/jonambas))
+  - [#500](https://github.com/SparkPost/matchbox/pull/500) UX-220 Drawers and Modals do not lock
+    focus if inside iframes ([@jonambas](https://github.com/jonambas))
+
+#### Committers: 3
+
+- Jon Ambas ([@jonambas](https://github.com/jonambas))
+- Logan Sparlin ([@logansparlin](https://github.com/logansparlin))
+- Tim Reeder ([@tokonoma](https://github.com/tokonoma))

--- a/README.md
+++ b/README.md
@@ -68,9 +68,8 @@ into SparkPost's NPM account locally via the NPM CLI.
 `public_repo` permissions and copy it to a `GITHUB_AUTH` variable in an `.env` file.
 
 ```bash
-# This generates a markdown changelog for the website under site/src/updates
-# Edit this file with a proper title, and push it up to your branch
-# The changelog is based on pull request titles and Github labels
+# This generates a markdown changelog for your release
+# Remember to copy this output and add it to CHANGELOG.md
 npm run changelog
 
 # Update the package versions with lerna. The CLI will prompt you

--- a/README.md
+++ b/README.md
@@ -68,8 +68,9 @@ into SparkPost's NPM account locally via the NPM CLI.
 `public_repo` permissions and copy it to a `GITHUB_AUTH` variable in an `.env` file.
 
 ```bash
-# This generates a markdown changelog for your release
-# Remember to copy this output and add it to CHANGELOG.md
+# This generates a markdown changelog for your release in CHANGELOG.md
+# Open the file and edit the title for your release with your version number
+# Commit and push this to the main branch prior to versioning
 npm run changelog
 
 # Update the package versions with lerna. The CLI will prompt you

--- a/README.md
+++ b/README.md
@@ -64,25 +64,30 @@ Our release process isn't perfect, and for now **only administrators can publish
 We use `lerna` to handle versioning and publishing to NPM. Before publishing, ensure you are logged
 into SparkPost's NPM account locally via the NPM CLI.
 
-**Important** - In order to run `changelog` you'll need to create a personal access token with the
-`public_repo` permissions and copy it to a `GITHUB_AUTH` variable in an `.env` file.
+**Publishing Steps**
+
+1. Merge all pull requests you wish to release to `main`
+1. Before publishing for the first time, set up your github auth token in `.env`. In order to run
+   `changelog` you'll need to create a personal access token with the `public_repo` permissions and
+   copy it to a `GITHUB_AUTH` variable in an `.env` file.
+1. On the `main` branch, run `npm run changelog`. This generates a markdown changelog in
+   `CHANGELOG.md`.
+1. Open and edit `CHANGELOG.md` with correct title and version number of your release.
+1. Push these changes to `main` if you have permissions, or on a new branch.
+1. Run `lerna version`. The Lerna CLI will prompt you for version numbers. See
+   https://github.com/lerna/lerna/tree/master/commands/version.
+1. Run `lerna publish`. The Lerna CLI will prompt you for a one time password from your
+   authenticator. See https://github.com/lerna/lerna/tree/master/commands/publish.
+
+**What the commands look like:**
 
 ```bash
-# This generates a markdown changelog for your release in CHANGELOG.md
-# Open the file and edit the title for your release with your version number
-# Commit and push this to the main branch prior to versioning
 npm run changelog
-
-# Update the package versions with lerna. The CLI will prompt you
-# to pick versions for each package that changed.
-# See https://github.com/lerna/lerna/tree/master/commands/version
+# Open the changelog file and edit
+git add CHANGELOG.md
+git commit -m "Update CHANGELOG.md"
+git push
 lerna version
-
-# Publish to NPM
-# Prepublish scripts will build each package and the CLI will
-# prompt you for a one-time password from your authenticator
-# See https://github.com/lerna/lerna/tree/master/commands/publish
 lerna publish
-
 # That's it!
 ```

--- a/README.md
+++ b/README.md
@@ -59,14 +59,15 @@ npm run build             # Builds all packages
 
 ### Releases
 
-Our release process isn't perfect, and for now **only administrators can publish**.
+Our release process isn't perfect, and requires some manual work.
 
 We use `lerna` to handle versioning and publishing to NPM. Before publishing, ensure you are logged
-into SparkPost's NPM account locally via the NPM CLI.
+into SparkPost's NPM account locally via the NPM CLI. Reach out to #UXFE or #design-guild on Slack
+if you need access.
 
 **Publishing Steps**
 
-1. Merge all pull requests you wish to release to `main`
+1. Merge all pull requests you wish to release to `main`.
 1. Before publishing for the first time, set up your github auth token in `.env`. In order to run
    `changelog` you'll need to create a personal access token with the `public_repo` permissions and
    copy it to a `GITHUB_AUTH` variable in an `.env` file.

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -1,23 +1,6 @@
 #!/bin/bash
 
-now=$(date +'%Y-%m-%d')
-year=$(date +'%Y')
-
-rm -f .changelog.md
-
-echo "---" > .changelog.md
-echo "title: Matchbox ENTER VERSION" >> .changelog.md
-echo "date: ${now}" >> .changelog.md
-echo "published: false" >> .changelog.md
-echo "category: release notes" >> .changelog.md
-echo "---" >> .changelog.md
-mkdir -p "site/src/updates/$year"
-cat .temp_changes.md >> .changelog.md
-sed -i -e 's/## /#### /g' .changelog.md
-
-mv .changelog.md "site/src/updates/$year/$now-release.mdx"
+echo "" >> .temp_changes.md
+cat CHANGELOG.md >> .temp_changes.md
+mv .temp_changes.md CHANGELOG.md
 rm -f .temp_changes.md
-rm -f .changelog.md
-rm -f .changelog.md-e
- 
-printf "\nChangelog generated\n → site/src/updates/$year/$now-release.mdx"

--- a/site/gatsby-config.js
+++ b/site/gatsby-config.js
@@ -10,12 +10,6 @@ module.exports = {
     'gatsby-plugin-react-helmet',
     'gatsby-plugin-sass',
     {
-      resolve: `gatsby-plugin-styled-components`,
-      options: {
-        // Add any options here
-      }
-    },
-    {
       resolve: 'gatsby-plugin-mdx',
       options: {
         defaultLayouts: {

--- a/site/gatsby-config.js
+++ b/site/gatsby-config.js
@@ -10,6 +10,12 @@ module.exports = {
     'gatsby-plugin-react-helmet',
     'gatsby-plugin-sass',
     {
+      resolve: `gatsby-plugin-styled-components`,
+      options: {
+        // Add any options here
+      }
+    },
+    {
       resolve: 'gatsby-plugin-mdx',
       options: {
         defaultLayouts: {


### PR DESCRIPTION
### What Changed
- Removes the auto `mdx` generation from the `changelog` script.

**New Workflow:**
- Before first release, set up your github auth token in `.env`
- Merge all pull requests you wish to release to `main`
- Run `npm run changelog`
- Edit `CHANGELOG.md` with correct version number of your release
- Run `lerna version`
- Run `lerna publish`

### How To Test or Verify
- Run `npm run changelog`
- Run git status, or check `CHANGELOG.md`
- You should see unreleased PR info

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
