### PR TITLE
Resolve #517 - Page secondary actions now render correctly, Adjust Page responsive behavior

### DIFF
--- a/packages/matchbox/src/components/Page/Page.js
+++ b/packages/matchbox/src/components/Page/Page.js
@@ -61,7 +61,7 @@ function SecondaryActions({ actions = [], hasPrimaryAction }) {
     return (
       <Button
         {...action}
-        outline
+        outlineBorder
         color="blue"
         mr={hasPrimaryAction ? ['0', null, null, '500'] : ' 0'}
         ml={hasPrimaryAction ? ['500', null, null, '0'] : '0'}

--- a/packages/matchbox/src/components/Page/Page.js
+++ b/packages/matchbox/src/components/Page/Page.js
@@ -55,7 +55,7 @@ function SecondaryActions({ actions = [], hasPrimaryAction }) {
     return null;
   }
 
-  if (visibleActions.length == 1) {
+  if (visibleActions.length === 1) {
     const action = visibleActions[0];
 
     return (
@@ -89,13 +89,12 @@ function SecondaryActions({ actions = [], hasPrimaryAction }) {
             aria-expanded={isOpen}
             color="blue"
             onClick={() => setIsOpen(!isOpen)}
-            outline
+            outlineBorder
+            p="0"
             width="2.5rem" // Forces a square
           >
-            <Box position="absolute">
-              <MoreHoriz />
-              <ScreenReaderOnly>More Options</ScreenReaderOnly>
-            </Box>
+            <MoreHoriz />
+            <ScreenReaderOnly>More Options</ScreenReaderOnly>
           </Button>
         }
       >

--- a/packages/matchbox/src/components/Page/Page.js
+++ b/packages/matchbox/src/components/Page/Page.js
@@ -80,7 +80,7 @@ function SecondaryActions({ actions = [], hasPrimaryAction }) {
       <Popover
         bottom
         id="page-secondary-actions"
-        left
+        left={[false, null, true]}
         onClose={() => setIsOpen(false)}
         open={isOpen}
         trigger={

--- a/packages/matchbox/src/components/Page/Page.js
+++ b/packages/matchbox/src/components/Page/Page.js
@@ -63,8 +63,8 @@ function SecondaryActions({ actions = [], hasPrimaryAction }) {
         {...action}
         outlineBorder
         color="blue"
-        mr={hasPrimaryAction ? ['0', null, null, '500'] : ' 0'}
-        ml={hasPrimaryAction ? ['500', null, null, '0'] : '0'}
+        mr={hasPrimaryAction ? ['0', null, '500'] : ' 0'}
+        ml={hasPrimaryAction ? ['300', null, '0'] : '0'}
       >
         {action.content}
       </Button>
@@ -74,8 +74,8 @@ function SecondaryActions({ actions = [], hasPrimaryAction }) {
   return (
     <Box
       position="relative"
-      mr={hasPrimaryAction ? ['0', null, null, '500'] : ' 0'}
-      ml={hasPrimaryAction ? ['500', null, null, '0'] : '0'}
+      mr={hasPrimaryAction ? ['0', null, '500'] : ' 0'}
+      ml={hasPrimaryAction ? ['300', null, '0'] : '0'}
     >
       <Popover
         bottom
@@ -143,13 +143,13 @@ function Page(props) {
 
   return (
     <div>
-      <Box mt={['500', null, null, '700']} mb={['300', null, null, '500']}>
+      <Box mt={['500', null, '700']} mb={['300', null, '500']}>
         {breadcrumbAction && (
           <Box mb="500">
             <Breadcrumb {...breadcrumbAction} />
           </Box>
         )}
-        <Box display={[null, null, 'block', 'flex']} alignItems="flex-start">
+        <Box display={[null, 'block', 'flex']} alignItems="flex-start">
           <Box flex="1">
             {title && (
               <Box
@@ -166,10 +166,10 @@ function Page(props) {
           <Box
             flex="0"
             display="flex"
-            flexDirection={['row-reverse', null, null, 'row']}
+            flexDirection={['row-reverse', null, 'row']}
             justifyContent="flex-end"
-            mt={['400', null, null, '300']}
-            mb={['400', null, null, '0']}
+            mt={['400', null, '300']}
+            mb={['400', null, '0']}
           >
             <SecondaryActions
               actions={secondaryActions}

--- a/packages/matchbox/src/components/Popover/Popover.js
+++ b/packages/matchbox/src/components/Popover/Popover.js
@@ -144,7 +144,7 @@ Popover.propTypes = {
    * By default, open state is handled automatically. Passing this value in will turn this into a controlled component.
    */
   open: PropTypes.bool,
-  left: PropTypes.oneOfType(PropTypes.bool, PropTypes.array),
+  left: PropTypes.oneOfType([PropTypes.bool, PropTypes.array]),
   right: PropTypes.bool,
   top: PropTypes.bool,
   bottom: PropTypes.bool,

--- a/packages/matchbox/src/components/Popover/Popover.js
+++ b/packages/matchbox/src/components/Popover/Popover.js
@@ -144,7 +144,7 @@ Popover.propTypes = {
    * By default, open state is handled automatically. Passing this value in will turn this into a controlled component.
    */
   open: PropTypes.bool,
-  left: PropTypes.bool,
+  left: PropTypes.oneOfType(PropTypes.bool, PropTypes.array),
   right: PropTypes.bool,
   top: PropTypes.bool,
   bottom: PropTypes.bool,

--- a/packages/matchbox/src/components/Popover/PopoverContent.js
+++ b/packages/matchbox/src/components/Popover/PopoverContent.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Transition } from 'react-transition-group';
 import styled from 'styled-components';
-import { padding, layout, compose } from 'styled-system';
+import { padding, layout, compose, variant } from 'styled-system';
 import { pick } from '@styled-system/props';
 import { Box } from '../Box';
 import { tokens } from '@sparkpost/design-tokens';
@@ -14,16 +14,29 @@ const StyledContent = styled('div')`
   ${system}
   ${content}
   ${transition}
+  ${'' /* TODO Expand this to include top and bottom */}
+  ${variant({
+    variants: {
+      isLeft: {
+        right: '0',
+        left: 'auto',
+      },
+      isRight: {
+        left: '0',
+        right: 'auto',
+      },
+    },
+  })}
 `;
 
 const Content = React.forwardRef(function Content(props, ref) {
   const {
     children,
     open,
-    top,
-    left,
+    top = false,
+    left = false,
     bottom = true,
-    right = true,
+    // right = true,
     sectioned,
     className = '',
     trigger,
@@ -32,6 +45,15 @@ const Content = React.forwardRef(function Content(props, ref) {
   } = props;
 
   const systemProps = pick(rest);
+
+  // Allows for responsive positioning arrays
+  const horizontalPosition = React.useMemo(() => {
+    if (typeof left === 'object') {
+      return left.map(bool => (bool ? 'isLeft' : 'isRight'));
+    }
+
+    return left ? 'isLeft' : 'isRight';
+  });
 
   return (
     <Transition
@@ -58,8 +80,7 @@ const Content = React.forwardRef(function Content(props, ref) {
             minWidth="13rem" // 208px
             isTop={top}
             isBottom={bottom}
-            isLeft={left}
-            isRight={right}
+            variant={horizontalPosition}
             state={state}
             {...style}
             {...systemProps}

--- a/packages/matchbox/src/components/Popover/styles.js
+++ b/packages/matchbox/src/components/Popover/styles.js
@@ -9,8 +9,6 @@ export const content = props => `
   margin-top: ${props.isTop ? tokens.spacing_0 : tokens.spacing_100};
   margin-bottom: ${props.isTop ? tokens.spacing_100 : tokens.spacing_0};
 
-  left: ${props.isLeft ? 'auto' : '0'};
-  right: ${!props.isLeft ? 'auto' : '0'};
   top: ${props.isTop ? 'auto' : '100%'};
   bottom: ${!props.isTop ? 'auto' : '100%'};
 `;


### PR DESCRIPTION
Closes #517 

### What Changed

- Page secondary action buttons use `outlineBorder` now and render as a square correctly
- Adjusted the Page breakpoints so the actions dont collapse so soon
- The `left` prop on Popover now supports responsive arrays

### How To Test or Verify

- Run storybook
- Visit Page stories and verify the right button style is used and the kebab is centered with multiple secondary actions
- Test responsive behavior

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
