### PR TITLE
Resolve #529 - className is now accepted by Panel.Section

### DIFF
--- a/packages/matchbox/src/components/Panel/Section.js
+++ b/packages/matchbox/src/components/Panel/Section.js
@@ -31,7 +31,7 @@ function Section(props) {
     actions && actions.length ? <Actions>{buttonsFrom(actions, actionOverrides)}</Actions> : null;
 
   return (
-    <SectionOuter {...paddingContext} {...rest}>
+    <SectionOuter className={className} {...paddingContext} {...rest}>
       <SectionContent>{children}</SectionContent>
       {actionMarkup}
     </SectionOuter>

--- a/packages/matchbox/src/components/Panel/tests/Panel.test.js
+++ b/packages/matchbox/src/components/Panel/tests/Panel.test.js
@@ -196,6 +196,15 @@ describe('Panel', () => {
     expect(wrapper.find('.my-class')).toExist();
   });
 
+  it('renders with the passed in className on a section', () => {
+    wrapper = global.mountStyled(
+      <Panel>
+        <Panel.Section className="my-class">Hello, world.</Panel.Section>
+      </Panel>,
+    );
+    expect(wrapper.find('.my-class')).toExist();
+  });
+
   it('renders with with a ref', () => {
     function Test() {
       const ref = React.useRef();

--- a/stories/layout/Panel.stories.js
+++ b/stories/layout/Panel.stories.js
@@ -41,7 +41,7 @@ export const WithAFooter = withInfo()(() => (
 export const WithMultipleSections = withInfo()(() => (
   <Panel>
     <Panel.Section>This is a panel with sections</Panel.Section>
-    <Panel.Section>This is a panel with sections</Panel.Section>
+    <Panel.Section className="test-class">This is a panel with sections</Panel.Section>
     <Panel.Section>This is a panel with sections</Panel.Section>
   </Panel>
 ));


### PR DESCRIPTION
Closes #529 

### What Changed
- Passes `className` to `Panel.Section`

### How To Test or Verify
- Run storybook and visit the Panel story with multiple sections
- Verify the className is in the DOM

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
