### PR TITLE
UX-275 Removes datepicker's outside and disabled days click events

### DIFF
--- a/packages/matchbox/src/components/DatePicker/Day.js
+++ b/packages/matchbox/src/components/DatePicker/Day.js
@@ -11,6 +11,10 @@ import { StyledDay } from './styles';
  * */
 
 function renderDay(date, modifiers = {}) {
+  if (modifiers.outside) {
+    return '';
+  }
+
   return (
     <StyledDay
       alignItems="center"

--- a/packages/matchbox/src/components/DatePicker/styles.js
+++ b/packages/matchbox/src/components/DatePicker/styles.js
@@ -121,4 +121,8 @@ export const wrapper = props => `
   .DayPicker-Day {
     flex: 1 0;
   }
+
+  .DayPicker-Day--disabled {
+    pointer-events: none;
+  }
 `;

--- a/packages/matchbox/src/components/DatePicker/tests/DatePicker.test.js
+++ b/packages/matchbox/src/components/DatePicker/tests/DatePicker.test.js
@@ -79,7 +79,8 @@ describe('DatePicker', () => {
     });
 
     it('should not render outside days', () => {
-      const wrapper = subject({ initialMonth: date });
+      const click = jest.fn();
+      const wrapper = subject({ initialMonth: date, onDayClick: click });
       expect(wrapper.find('.DayPicker-Day--outside').first()).toHaveAttributeValue(
         'aria-disabled',
         'true',
@@ -90,6 +91,28 @@ describe('DatePicker', () => {
           .first()
           .text(),
       ).toBe('');
+    });
+
+    it('should not click on outside days', () => {
+      const click = jest.fn();
+      const wrapper = subject({ initialMonth: date, onDayClick: click });
+
+      wrapper
+        .find('.DayPicker-Day--outside')
+        .first()
+        .simulate('click');
+      expect(click).not.toHaveBeenCalled();
+    });
+
+    it('should click on a day', () => {
+      const click = jest.fn();
+      const wrapper = subject({ initialMonth: date, onDayClick: click });
+
+      wrapper
+        .find('.DayPicker-Day')
+        .first()
+        .simulate('click');
+      expect(click).toHaveBeenCalled();
     });
   });
 });

--- a/stories/form/DatePicker.stories.js
+++ b/stories/form/DatePicker.stories.js
@@ -32,6 +32,7 @@ export const BasicDatepicker = withInfo({ propTables: [DatePicker] })(() => (
     disabledDays={{ after: new Date() }}
     toMonth={new Date()}
     selectedDays={selectedDays}
+    onDayClick={d => console.log('click', d)}
     m="400"
   />
 ));


### PR DESCRIPTION

### What Changed

- Adds `pointer-events none` to disabled days
- Prevents days from rendering if they are outside

### How To Test or Verify

- Run storybook and visit the datepicker stories
- Try clicking on days outside the month or disabled days
- Should not see a console.log

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
