### PR TITLE
UX-247 Add useCopyToClipboard hook

### DIFF
--- a/packages/matchbox/package-lock.json
+++ b/packages/matchbox/package-lock.json
@@ -1914,6 +1914,14 @@
       "dev": true,
       "optional": true
     },
+    "copy-to-clipboard": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
+      "integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
+      "requires": {
+        "toggle-selection": "^1.0.6"
+      }
+    },
     "core-js-compat": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.3.3.tgz",
@@ -8549,6 +8557,11 @@
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
       }
+    },
+    "toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI="
     },
     "tslib": {
       "version": "1.13.0",

--- a/packages/matchbox/package.json
+++ b/packages/matchbox/package.json
@@ -28,6 +28,7 @@
     "@sparkpost/design-tokens": "^1.0.1",
     "@styled-system/prop-types": "^5.1.2",
     "@styled-system/props": "^5.1.5",
+    "copy-to-clipboard": "^3.3.1",
     "prop-types": "^15.7.2",
     "react-focus-lock": "^2.4.0",
     "react-scrolllock": "^5.0.1",

--- a/packages/matchbox/rollup/config.js
+++ b/packages/matchbox/rollup/config.js
@@ -7,6 +7,7 @@ export const inputOptions = {
   input: 'src/index.js',
   plugins: [...jsPlugins],
   external: [
+    'copy-to-clipboard',
     'react',
     'react-dom',
     'prop-types',

--- a/packages/matchbox/src/hooks/index.js
+++ b/packages/matchbox/src/hooks/index.js
@@ -1,3 +1,4 @@
+export { default as useCopyToClipboard } from './useCopyToClipboard';
 export { default as useDrawer } from './useDrawer';
 export { default as useTabs } from './useTabs';
 export { default as useWindowEvent } from './useWindowEvent';

--- a/packages/matchbox/src/hooks/tests/useCopyToClipboard.test.js
+++ b/packages/matchbox/src/hooks/tests/useCopyToClipboard.test.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import useCopyToClipboard from '../useCopyToClipboard';
+import copy from 'copy-to-clipboard';
+
+jest.mock('copy-to-clipboard');
+
+describe('useCopyToClipboard', () => {
+  const Component = () => {
+    const { copy, copied } = useCopyToClipboard();
+    return (
+      <button onClick={() => copy('copied text')}>{copied ? 'Copied!' : 'Click to Copy'}</button>
+    );
+  };
+
+  it('handles copying correctly', () => {
+    copy.default = jest.fn();
+    const wrapper = shallow(<Component />);
+
+    expect(wrapper.find('button').text()).toEqual('Click to Copy');
+    wrapper.find('button').simulate('click');
+    expect(copy).toHaveBeenCalledTimes(1);
+    expect(wrapper.find('button').text()).toEqual('Copied!');
+  });
+});

--- a/packages/matchbox/src/hooks/useCopyToClipboard.js
+++ b/packages/matchbox/src/hooks/useCopyToClipboard.js
@@ -1,34 +1,28 @@
 import React from 'react';
 import { getWindow } from '../helpers/window';
+import copy from 'copy-to-clipboard';
+
 /**
- import { useCopyToClipboard } from '@sparkpost/matchbox'
-
-  const {
-    copy,  // function to programatically copy a string to clipboard
-    copied // Copied state, resets after specified timeout
-  } = useCopyToClipboard(
-    timeout = 1000 // Timeout to reset copied state
-  );
-
-  function handleCopy() {
-    copy('copy me')
-  }
-
-  <Button onClick={handleCopy}>
-    {copied ? 'string has been copied' : 'copy to clipboard'}
-  </Button>
+ * Copies a string to the clipboard and provides copied state
+ *
+ * @example
+ * const { copy, copied } = useCopyToClipboard({ timeout: 2000 });
+ *
+ * <Button onClick={() => copy('string')}>
+ *  {copied ? 'String has been copied' : 'Copy to clipboard'}
+ * </Button>
  */
-
-function useCopyToClipboard(args) {
+function useCopyToClipboard({ timeout = 1000 } = {}) {
   const environment = getWindow();
-  const { timeout = 1000 } = args;
   const [copied, setCopied] = React.useState(false);
 
-  function copy() {}
+  function handleCopy(string) {
+    copy(string);
+    setCopied(true);
+  }
 
   React.useEffect(() => {
     let timer;
-
     if (copied) {
       timer = environment.setTimeout(() => setCopied(false), timeout);
     }
@@ -38,7 +32,7 @@ function useCopyToClipboard(args) {
   }, [copied, timeout]);
 
   return {
-    copy,
+    copy: handleCopy,
     copied,
   };
 }

--- a/packages/matchbox/src/hooks/useCopyToClipboard.js
+++ b/packages/matchbox/src/hooks/useCopyToClipboard.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { getWindow } from '../helpers/window';
+/**
+ import { useCopyToClipboard } from '@sparkpost/matchbox'
+
+  const {
+    copy,  // function to programatically copy a string to clipboard
+    copied // Copied state, resets after specified timeout
+  } = useCopyToClipboard(
+    timeout = 1000 // Timeout to reset copied state
+  );
+
+  function handleCopy() {
+    copy('copy me')
+  }
+
+  <Button onClick={handleCopy}>
+    {copied ? 'string has been copied' : 'copy to clipboard'}
+  </Button>
+ */
+
+function useCopyToClipboard(args) {
+  const environment = getWindow();
+  const { timeout = 1000 } = args;
+  const [copied, setCopied] = React.useState(false);
+
+  function copy() {}
+
+  React.useEffect(() => {
+    let timer;
+
+    if (copied) {
+      timer = environment.setTimeout(() => setCopied(false), timeout);
+    }
+    return () => {
+      environment.clearTimeout(timer);
+    };
+  }, [copied, timeout]);
+
+  return {
+    copy,
+    copied,
+  };
+}
+
+export default useCopyToClipboard;

--- a/packages/matchbox/src/hooks/useCopyToClipboard.js
+++ b/packages/matchbox/src/hooks/useCopyToClipboard.js
@@ -3,7 +3,7 @@ import { getWindow } from '../helpers/window';
 import copy from 'copy-to-clipboard';
 
 /**
- * Copies a string to the clipboard and provides copied state
+ * SSR friendly hook that copies a string to the clipboard and provides copied state
  *
  * @example
  * const { copy, copied } = useCopyToClipboard({ timeout: 2000 });

--- a/stories/utility/useCopyToClipboard.stories.js
+++ b/stories/utility/useCopyToClipboard.stories.js
@@ -5,7 +5,7 @@ export default {
   title: 'Utility|useCopyToClipboard',
 };
 
-export const Chevrons = () => {
+export const exampleUsage = () => {
   const { copy, copied } = useCopyToClipboard();
   return (
     <Button onClick={() => copy('copied text')}>{copied ? 'Copied!' : 'Click to Copy'}</Button>

--- a/stories/utility/useCopyToClipboard.stories.js
+++ b/stories/utility/useCopyToClipboard.stories.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Button, useCopyToClipboard } from '@sparkpost/matchbox';
+
+export default {
+  title: 'Utility|useCopyToClipboard',
+};
+
+export const Chevrons = () => {
+  const { copy, copied } = useCopyToClipboard();
+  return (
+    <Button onClick={() => copy('copied text')}>{copied ? 'Copied!' : 'Click to Copy'}</Button>
+  );
+};


### PR DESCRIPTION
### What Changed

- Adds new `useCopyToClipboard` hook

Usage:
```js
const { copy, copied } = useCopyToClipboard({ timeout: 2000 });

<Button onClick={() => copy('string')}>
  {copied ? 'String has been copied' : 'Copy to clipboard'}
</Button>
```
### How To Test or Verify

- Run storybook and visit the copy to clipboard story
- Verify a string is copied when clicking the button

### PR Checklist

- [x] Add the correct `type` label
- [x] Pull request approval from #uxfe or #design-guild
