### PR TITLE
UX-278 Modal content now expands to its container

### DIFF
--- a/packages/matchbox/src/components/Modal/Modal.js
+++ b/packages/matchbox/src/components/Modal/Modal.js
@@ -92,8 +92,14 @@ const Modal = React.forwardRef(function Modal(props, userRef) {
             */}
             <Box p={['400', null, '700']} size="100%" ref={container}>
               <StyledWrapper>
-                <div ref={content}>
-                  <ModalContent open={open} maxWidth={maxWidth} ref={userRef}>
+                <Box
+                  display="flex"
+                  justifyContent="center"
+                  ref={content}
+                  width="100%"
+                  maxWidth={maxWidth}
+                >
+                  <ModalContent open={open} ref={userRef}>
                     <WindowEvent event="keydown" handler={handleKeydown} />
                     <WindowEvent event="click" handler={handleOutsideClick} />
 
@@ -106,7 +112,7 @@ const Modal = React.forwardRef(function Modal(props, userRef) {
                     )}
                     {children}
                   </ModalContent>
-                </div>
+                </Box>
               </StyledWrapper>
             </Box>
           </StyledBase>
@@ -117,10 +123,10 @@ const Modal = React.forwardRef(function Modal(props, userRef) {
 });
 
 const ModalContent = React.forwardRef(function ModalContent(props, userRef) {
-  const { open, children, maxWidth } = props;
+  const { open, children } = props;
 
   return (
-    <StyledFocusLock disabled={!open || isInIframe()} maxWidth={maxWidth}>
+    <StyledFocusLock disabled={!open || isInIframe()}>
       <Transition
         mountOnEnter
         unmountOnExit


### PR DESCRIPTION

### What Changed

- Fixes this bug:
<img width="583" alt="Screen Shot 2020-07-14 at 1 48 48 PM" src="https://user-images.githubusercontent.com/3903325/87462173-82230980-c5dd-11ea-92fa-735b7c8edc4f.png">

### How To Test or Verify

- Run storybook and visit modal toggle demo
- Verify modal panel expands to the max width of its container

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
