### PR TITLE
Resolves #540 - Pass through role to UnstyledLinks with wrappers or to links

### DIFF
--- a/packages/matchbox/src/components/UnstyledLink/UnstyledLink.js
+++ b/packages/matchbox/src/components/UnstyledLink/UnstyledLink.js
@@ -30,7 +30,15 @@ const UnstyledLink = React.forwardRef(function UnstyledLink(props, ref) {
 
   if (WrapperComponent) {
     return (
-      <Text as={WrapperComponent} to={to} title={linkTitle} onClick={onClick} ref={ref} {...rest}>
+      <Text
+        as={WrapperComponent}
+        onClick={onClick}
+        ref={ref}
+        role={linkRole}
+        title={linkTitle}
+        to={to}
+        {...rest}
+      >
         {children}
       </Text>
     );

--- a/packages/matchbox/src/components/UnstyledLink/UnstyledLink.js
+++ b/packages/matchbox/src/components/UnstyledLink/UnstyledLink.js
@@ -20,6 +20,7 @@ const UnstyledLink = React.forwardRef(function UnstyledLink(props, ref) {
         rel={external ? 'noopener noreferrer' : ''}
         title={linkTitle}
         onClick={onClick}
+        role={role}
         ref={ref}
         {...rest}
       >
@@ -34,7 +35,7 @@ const UnstyledLink = React.forwardRef(function UnstyledLink(props, ref) {
         as={WrapperComponent}
         onClick={onClick}
         ref={ref}
-        role={linkRole}
+        role={role}
         title={linkTitle}
         to={to}
         {...rest}

--- a/packages/matchbox/src/components/UnstyledLink/tests/UnstyledLink.test.js
+++ b/packages/matchbox/src/components/UnstyledLink/tests/UnstyledLink.test.js
@@ -45,7 +45,7 @@ describe('UnstyledLink', () => {
     expect(wrapper.find('button').prop('role')).toEqual('test-role');
   });
 
-  it('renders with a role as a to-linke', () => {
+  it('renders with a role as a to-link', () => {
     let wrapper = subject({ to: '/test', role: 'test-role' });
     expect(wrapper.find('a').text()).toEqual('Hola!');
     expect(wrapper.find('a').prop('role')).toEqual('test-role');

--- a/packages/matchbox/src/components/UnstyledLink/tests/UnstyledLink.test.js
+++ b/packages/matchbox/src/components/UnstyledLink/tests/UnstyledLink.test.js
@@ -38,4 +38,10 @@ describe('UnstyledLink', () => {
     expect(wrapper.find('button').text()).toEqual('Hola!');
     expect(wrapper.prop('role')).toBeUndefined();
   });
+
+  it('renders with wrapper component with a role', () => {
+    let wrapper = subject({ component: 'button', role: 'button' });
+    expect(wrapper.find('button').text()).toEqual('Hola!');
+    expect(wrapper.find('button').prop('role')).toEqual('button');
+  });
 });

--- a/packages/matchbox/src/components/UnstyledLink/tests/UnstyledLink.test.js
+++ b/packages/matchbox/src/components/UnstyledLink/tests/UnstyledLink.test.js
@@ -40,8 +40,14 @@ describe('UnstyledLink', () => {
   });
 
   it('renders with wrapper component with a role', () => {
-    let wrapper = subject({ component: 'button', role: 'button' });
+    let wrapper = subject({ component: 'button', role: 'test-role' });
     expect(wrapper.find('button').text()).toEqual('Hola!');
-    expect(wrapper.find('button').prop('role')).toEqual('button');
+    expect(wrapper.find('button').prop('role')).toEqual('test-role');
+  });
+
+  it('renders with a role as a to-linke', () => {
+    let wrapper = subject({ to: '/test', role: 'test-role' });
+    expect(wrapper.find('a').text()).toEqual('Hola!');
+    expect(wrapper.find('a').prop('role')).toEqual('test-role');
   });
 });


### PR DESCRIPTION
Closes #540 

### What Changed
- Passes `role` to all UnstyledLink variations

### How To Test or Verify
- Ensure unit tests pass

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
