### PR TITLE
UX-270 Create Layout Component

### DIFF
--- a/packages/matchbox/src/components/Column/Column.js
+++ b/packages/matchbox/src/components/Column/Column.js
@@ -34,6 +34,7 @@ const Column = React.forwardRef(function Column(props, ref) {
       pt={collapsed ? space : null}
       gutter={space}
       ref={ref}
+      tabIndex="-1"
     >
       {children}
     </StyledColumn>

--- a/packages/matchbox/src/components/Columns/Columns.js
+++ b/packages/matchbox/src/components/Columns/Columns.js
@@ -48,6 +48,7 @@ const Columns = React.forwardRef(function Columns(props, ref) {
         reverse={reverse}
         gutter={space}
         flexWrap={collapsed ? 'wrap' : 'nowrap'}
+        tabIndex="-1"
       >
         <ColumnsContext.Provider value={{ space, collapsed }}>{children}</ColumnsContext.Provider>
       </StyledColumns>

--- a/packages/matchbox/src/components/Layout/Layout.js
+++ b/packages/matchbox/src/components/Layout/Layout.js
@@ -11,7 +11,7 @@ const Layout = React.forwardRef(function Layout(props, ref) {
   const { children, collapseBelow } = props;
 
   return (
-    <Columns collapseBelow={collapseBelow} space="500" mb="36px" ref={ref}>
+    <Columns collapseBelow={collapseBelow} space={['400', null, '500']} mb="600" ref={ref}>
       {children}
     </Columns>
   );

--- a/packages/matchbox/src/components/Layout/Layout.js
+++ b/packages/matchbox/src/components/Layout/Layout.js
@@ -11,7 +11,13 @@ const Layout = React.forwardRef(function Layout(props, ref) {
   const { children, collapseBelow } = props;
 
   return (
-    <Columns collapseBelow={collapseBelow} space={['400', null, '500']} mb="600" ref={ref}>
+    <Columns
+      collapseBelow={collapseBelow}
+      space={['400', null, '500']}
+      mb="600"
+      ref={ref}
+      tabIndex="-1"
+    >
       {children}
     </Columns>
   );

--- a/packages/matchbox/src/components/Layout/Layout.js
+++ b/packages/matchbox/src/components/Layout/Layout.js
@@ -11,13 +11,7 @@ const Layout = React.forwardRef(function Layout(props, ref) {
   const { children, collapseBelow } = props;
 
   return (
-    <Columns
-      collapseBelow={collapseBelow}
-      space={['400', null, '500']}
-      mb="600"
-      ref={ref}
-      tabIndex="-1"
-    >
+    <Columns collapseBelow={collapseBelow} space={['400', null, '500']} mb="600" ref={ref}>
       {children}
     </Columns>
   );

--- a/packages/matchbox/src/components/Layout/Layout.js
+++ b/packages/matchbox/src/components/Layout/Layout.js
@@ -1,17 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { tokens } from '@sparkpost/design-tokens';
-import { Box } from '../Box';
+import { Columns } from '../Columns';
 
 import Section from './Section';
 
+const breakpoints = ['xs', 'sm', 'md', 'lg', 'xl'];
+
 const Layout = React.forwardRef(function Layout(props, ref) {
-  const { children } = props;
+  const { children, collapseBelow } = props;
 
   return (
-    <Box display="flex" flexWrap="wrap" ml={`-${tokens.spacing_500}`} ref={ref}>
+    <Columns collapseBelow={collapseBelow} space="500" mb="36px" ref={ref}>
       {children}
-    </Box>
+    </Columns>
   );
 });
 
@@ -22,6 +23,14 @@ Layout.propTypes = {
    * Layout Children
    */
   children: PropTypes.node,
+  /**
+   * When to collapse the columns. 'xs', 'sm', 'md', 'lg', or 'xl'
+   */
+  collapseBelow: PropTypes.oneOf(breakpoints),
+};
+
+Layout.defaultProps = {
+  collapseBelow: 'md',
 };
 
 Layout.Section = Section;

--- a/packages/matchbox/src/components/Layout/Layout.js
+++ b/packages/matchbox/src/components/Layout/Layout.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Columns } from '../Columns';
 
 import Section from './Section';
+import SectionTitle from './SectionTitle';
 
 const breakpoints = ['xs', 'sm', 'md', 'lg', 'xl'];
 
@@ -34,5 +35,6 @@ Layout.defaultProps = {
 };
 
 Layout.Section = Section;
+Layout.SectionTitle = SectionTitle;
 
 export default Layout;

--- a/packages/matchbox/src/components/Layout/Layout.js
+++ b/packages/matchbox/src/components/Layout/Layout.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { tokens } from '@sparkpost/design-tokens';
+import { Box } from '../Box';
+
+import Section from './Section';
+
+const Layout = React.forwardRef(function Layout(props, ref) {
+  const { children } = props;
+
+  return (
+    <Box display="flex" flexWrap="wrap" ml={`-${tokens.spacing_500}`} ref={ref}>
+      {children}
+    </Box>
+  );
+});
+
+Layout.displayName = 'Layout';
+
+Layout.propTypes = {
+  /**
+   * Layout Children
+   */
+  children: PropTypes.node,
+};
+
+Layout.Section = Section;
+
+export default Layout;

--- a/packages/matchbox/src/components/Layout/Section.js
+++ b/packages/matchbox/src/components/Layout/Section.js
@@ -1,28 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Box } from '../Box';
+import { Column } from '../Column';
 
 function Section(props) {
-  const { variant, children } = props;
-  let width = '100%';
+  const { annotated, children } = props;
 
-  if (variant === 'twoColumn') {
-    width = '50%';
-  }
-
-  if (variant === 'annotatedLeft') {
-    width = '300px';
-  }
-
-  if (variant === 'annotatedRight') {
-    width = 'calc(100% - 300px)';
-  }
-
-  return (
-    <Box width={['100%', null, width]} mb="36px" pl="500">
-      {children}
-    </Box>
-  );
+  return <Column width={annotated ? 1 / 3 : 1}>{children}</Column>;
 }
 
 Section.displayName = 'Layout.Section';
@@ -35,7 +18,7 @@ Section.propTypes = {
   /**
    * The section type (i.e. one column, two columns, or annotated)
    */
-  variant: PropTypes.oneOf(['oneColumn', 'twoColumn', 'annotatedLeft', 'annotatedRight']),
+  annotated: PropTypes.bool,
 };
 
 Section.defaultProps = {

--- a/packages/matchbox/src/components/Layout/Section.js
+++ b/packages/matchbox/src/components/Layout/Section.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Box } from '../Box';
+
+function Section(props) {
+  const { variant, children } = props;
+  let width = '100%';
+
+  if (variant === 'twoColumn') {
+    width = '50%';
+  }
+
+  if (variant === 'annotatedLeft') {
+    width = '300px';
+  }
+
+  if (variant === 'annotatedRight') {
+    width = 'calc(100% - 300px)';
+  }
+
+  return (
+    <Box width={['100%', null, width]} mb="36px" pl="500">
+      {children}
+    </Box>
+  );
+}
+
+Section.displayName = 'Layout.Section';
+
+Section.propTypes = {
+  /**
+   * Section Children
+   */
+  children: PropTypes.node,
+  /**
+   * The section type (i.e. one column, two columns, or annotated)
+   */
+  variant: PropTypes.oneOf(['oneColumn', 'twoColumn', 'annotatedLeft', 'annotatedRight']),
+};
+
+Section.defaultProps = {
+  variant: 'oneColumn',
+};
+
+export default Section;

--- a/packages/matchbox/src/components/Layout/Section.js
+++ b/packages/matchbox/src/components/Layout/Section.js
@@ -16,13 +16,9 @@ Section.propTypes = {
    */
   children: PropTypes.node,
   /**
-   * The section type (i.e. one column, two columns, or annotated)
+   * Use for annotated sections, sets width to 1/3
    */
   annotated: PropTypes.bool,
-};
-
-Section.defaultProps = {
-  variant: 'oneColumn',
 };
 
 export default Section;

--- a/packages/matchbox/src/components/Layout/SectionTitle.js
+++ b/packages/matchbox/src/components/Layout/SectionTitle.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import { Text } from '../Text';
+
+function SectionTitle(props) {
+  const { children } = props;
+
+  return (
+    <Text as="h4" fontSize={['300', null, '400']} pb="300">
+      {children}
+    </Text>
+  );
+}
+
+SectionTitle.displayName = 'Layout.SectionTitle';
+
+export default SectionTitle;

--- a/packages/matchbox/src/components/Layout/SectionTitle.js
+++ b/packages/matchbox/src/components/Layout/SectionTitle.js
@@ -1,16 +1,25 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import { Text } from '../Text';
 
 function SectionTitle(props) {
-  const { children } = props;
+  const { children, as } = props;
 
   return (
-    <Text as="h4" fontSize={['300', null, '400']} pb="300">
+    <Text as={as} fontSize={['300', null, '400']} pb="300">
       {children}
     </Text>
   );
 }
+
+SectionTitle.propTypes = {
+  as: PropTypes.elementType,
+};
+
+SectionTitle.defaultProps = {
+  as: 'h2',
+};
 
 SectionTitle.displayName = 'Layout.SectionTitle';
 

--- a/packages/matchbox/src/components/Layout/index.js
+++ b/packages/matchbox/src/components/Layout/index.js
@@ -1,0 +1,1 @@
+export { default as Layout } from './Layout';

--- a/packages/matchbox/src/components/Layout/tests/Layout.test.js
+++ b/packages/matchbox/src/components/Layout/tests/Layout.test.js
@@ -1,13 +1,18 @@
 import React from 'react';
 import 'jest-styled-components';
-import { tokens } from '@sparkpost/design-tokens';
 
 import Layout from '../Layout';
 
+const resizeWindow = (x, y) => {
+  window.innerWidth = x;
+  window.innerHeight = y;
+  window.dispatchEvent(new Event('resize'));
+};
+
 describe('Layout', () => {
-  const subject = () =>
+  const subject = props =>
     global.mountStyled(
-      <Layout>
+      <Layout {...props}>
         <Layout.Section>Layout Section Content</Layout.Section>
       </Layout>,
     );
@@ -18,11 +23,10 @@ describe('Layout', () => {
     expect(wrapper.text()).toEqual('Layout Section Content');
   });
 
-  it('renders layout styles correctly', () => {
-    const wrapper = subject();
+  it('renders default collapseBelow prop', () => {
+    resizeWindow(500, 500);
 
-    expect(wrapper.find('div').at(0)).toHaveStyleRule('display', 'flex');
-    expect(wrapper.find('div').at(0)).toHaveStyleRule('margin-left', `-${tokens.spacing_500}`);
-    expect(wrapper.find('div').at(0)).toHaveStyleRule('flex-wrap', 'wrap');
+    const wrapper = subject();
+    expect(wrapper.find('div').at(1)).toHaveStyleRule('flex-wrap', 'wrap');
   });
 });

--- a/packages/matchbox/src/components/Layout/tests/Layout.test.js
+++ b/packages/matchbox/src/components/Layout/tests/Layout.test.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import 'jest-styled-components';
+import { tokens } from '@sparkpost/design-tokens';
+
+import Layout from '../Layout';
+
+describe('Layout', () => {
+  const subject = () =>
+    global.mountStyled(
+      <Layout>
+        <Layout.Section>Layout Section Content</Layout.Section>
+      </Layout>,
+    );
+
+  it('renders layout with content', () => {
+    const wrapper = subject();
+
+    expect(wrapper.text()).toEqual('Layout Section Content');
+  });
+
+  it('renders layout styles correctly', () => {
+    const wrapper = subject();
+
+    expect(wrapper.find('div').at(0)).toHaveStyleRule('display', 'flex');
+    expect(wrapper.find('div').at(0)).toHaveStyleRule('margin-left', `-${tokens.spacing_500}`);
+    expect(wrapper.find('div').at(0)).toHaveStyleRule('flex-wrap', 'wrap');
+  });
+});

--- a/packages/matchbox/src/components/Layout/tests/Section.test.js
+++ b/packages/matchbox/src/components/Layout/tests/Section.test.js
@@ -24,14 +24,34 @@ describe('Layout', () => {
   it('renders two column section', () => {
     const wrapper = subject();
 
-    expect(wrapper.find('div').at(2)).toHaveStyleRule('width', '50%');
-    expect(wrapper.find('div').at(3)).toHaveStyleRule('width', '50%');
+    expect(
+      wrapper
+        .find('div')
+        .at(2)
+        .text(),
+    ).toEqual('Two Column Layout');
+    expect(
+      wrapper
+        .find('div')
+        .at(3)
+        .text(),
+    ).toEqual('Two Column Layout');
   });
 
   it('renders annotated section', () => {
     const wrapper = subject();
 
-    expect(wrapper.find('div').at(4)).toHaveStyleRule('width', '300px');
-    expect(wrapper.find('div').at(5)).toHaveStyleRule('width', 'calc(100% - 300px)');
+    expect(
+      wrapper
+        .find('div')
+        .at(4)
+        .text(),
+    ).toEqual('Annotated Layout');
+    expect(
+      wrapper
+        .find('div')
+        .at(5)
+        .text(),
+    ).toEqual('Annotated Layout');
   });
 });

--- a/packages/matchbox/src/components/Layout/tests/Section.test.js
+++ b/packages/matchbox/src/components/Layout/tests/Section.test.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import 'jest-styled-components';
+
+import Layout from '../Layout';
+
+describe('Layout', () => {
+  const subject = () =>
+    global.mountStyled(
+      <Layout>
+        <Layout.Section variant="oneColumn">One Column Layout</Layout.Section>
+        <Layout.Section variant="twoColumn">Two Column Layout</Layout.Section>
+        <Layout.Section variant="twoColumn">Two Column Layout</Layout.Section>
+        <Layout.Section variant="annotatedLeft">Annotated Layout</Layout.Section>
+        <Layout.Section variant="annotatedRight">Annotated Layout</Layout.Section>
+      </Layout>,
+    );
+
+  it('renders one column section', () => {
+    const wrapper = subject();
+
+    expect(wrapper.find('div').at(1)).toHaveStyleRule('width', '100%');
+  });
+
+  it('renders two column section', () => {
+    const wrapper = subject();
+
+    expect(wrapper.find('div').at(2)).toHaveStyleRule('width', '50%');
+    expect(wrapper.find('div').at(3)).toHaveStyleRule('width', '50%');
+  });
+
+  it('renders annotated section', () => {
+    const wrapper = subject();
+
+    expect(wrapper.find('div').at(4)).toHaveStyleRule('width', '300px');
+    expect(wrapper.find('div').at(5)).toHaveStyleRule('width', 'calc(100% - 300px)');
+  });
+});

--- a/packages/matchbox/src/components/Layout/tests/Section.test.js
+++ b/packages/matchbox/src/components/Layout/tests/Section.test.js
@@ -7,51 +7,25 @@ describe('Layout', () => {
   const subject = () =>
     global.mountStyled(
       <Layout>
-        <Layout.Section variant="oneColumn">One Column Layout</Layout.Section>
-        <Layout.Section variant="twoColumn">Two Column Layout</Layout.Section>
-        <Layout.Section variant="twoColumn">Two Column Layout</Layout.Section>
-        <Layout.Section variant="annotatedLeft">Annotated Layout</Layout.Section>
-        <Layout.Section variant="annotatedRight">Annotated Layout</Layout.Section>
+        <Layout.Section>Two Column Layout</Layout.Section>
+        <Layout.Section>Two Column Layout</Layout.Section>
       </Layout>,
     );
 
-  it('renders one column section', () => {
+  it('renders columns', () => {
     const wrapper = subject();
 
-    expect(wrapper.find('div').at(1)).toHaveStyleRule('width', '100%');
+    expect(wrapper.text()).toEqual('Two Column LayoutTwo Column Layout');
   });
 
-  it('renders two column section', () => {
-    const wrapper = subject();
+  it('renders annotated columns', () => {
+    const wrapper = global.mountStyled(
+      <Layout>
+        <Layout.Section annotated>Annotated</Layout.Section>
+        <Layout.Section>Column</Layout.Section>
+      </Layout>,
+    );
 
-    expect(
-      wrapper
-        .find('div')
-        .at(2)
-        .text(),
-    ).toEqual('Two Column Layout');
-    expect(
-      wrapper
-        .find('div')
-        .at(3)
-        .text(),
-    ).toEqual('Two Column Layout');
-  });
-
-  it('renders annotated section', () => {
-    const wrapper = subject();
-
-    expect(
-      wrapper
-        .find('div')
-        .at(4)
-        .text(),
-    ).toEqual('Annotated Layout');
-    expect(
-      wrapper
-        .find('div')
-        .at(5)
-        .text(),
-    ).toEqual('Annotated Layout');
+    expect(wrapper.find('div').at(2)).toHaveStyleRule('width', `${100 * (1 / 3)}%`);
   });
 });

--- a/packages/matchbox/src/components/Layout/tests/SectionTitle.test.js
+++ b/packages/matchbox/src/components/Layout/tests/SectionTitle.test.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import 'jest-styled-components';
+
+import SectionTitle from '../SectionTitle';
+
+describe('Layout', () => {
+  const subject = () => global.mountStyled(<SectionTitle>The Title</SectionTitle>);
+
+  it('renders section title', () => {
+    const wrapper = subject();
+
+    expect(wrapper.text()).toEqual('The Title');
+  });
+});

--- a/packages/matchbox/src/components/index.js
+++ b/packages/matchbox/src/components/index.js
@@ -17,6 +17,7 @@ export * from './HelpText';
 export * from './Inline';
 export * from './KeyboardKey';
 export * from './Label';
+export * from './Layout';
 export * from './Modal';
 export * from './OptionalLabel';
 export * from './Page';

--- a/stories/layout/Layout.stories.js
+++ b/stories/layout/Layout.stories.js
@@ -21,23 +21,43 @@ const breadcrumbAction = {
 };
 
 export const ColumnExample = withInfo()(() => (
-  <Layout>
-    <Layout.Section variant="oneColumn">
-      <DemoBox>One Column Layout</DemoBox>
-    </Layout.Section>
-    <Layout.Section variant="twoColumn">
-      <DemoBox>Two Column Layout</DemoBox>
-    </Layout.Section>
-    <Layout.Section variant="twoColumn">
-      <DemoBox>Two Column Layout</DemoBox>
-    </Layout.Section>
-  </Layout>
+  <>
+    <Layout>
+      <Layout.Section>
+        <DemoBox>One Column Layout</DemoBox>
+      </Layout.Section>
+    </Layout>
+    <Layout>
+      <Layout.Section>
+        <DemoBox>Two Column Layout</DemoBox>
+      </Layout.Section>
+      <Layout.Section>
+        <DemoBox>Two Column Layout</DemoBox>
+      </Layout.Section>
+    </Layout>
+  </>
+));
+
+export const CollapseBelowExample = withInfo()(() => (
+  <>
+    <Layout collapseBelow="lg">
+      <Layout.Section>
+        <DemoBox>Three Column Layout</DemoBox>
+      </Layout.Section>
+      <Layout.Section>
+        <DemoBox>Three Column Layout</DemoBox>
+      </Layout.Section>
+      <Layout.Section>
+        <DemoBox>Three Column Layout</DemoBox>
+      </Layout.Section>
+    </Layout>
+  </>
 ));
 
 export const AnnotatedExample = withInfo()(() => (
   <Page title="Domain Details" breadcrumbAction={breadcrumbAction}>
     <Layout>
-      <Layout.Section variant="annotatedLeft">
+      <Layout.Section annotated>
         <Text as="h4" mb="300">
           Domain Status
         </Text>
@@ -45,7 +65,7 @@ export const AnnotatedExample = withInfo()(() => (
           Domain status text
         </Text>
       </Layout.Section>
-      <Layout.Section variant="annotatedRight">
+      <Layout.Section>
         <Panel>
           <Panel.Section>
             <Columns collapseBelow="md">
@@ -75,16 +95,9 @@ export const AnnotatedExample = withInfo()(() => (
           </Panel.Section>
         </Panel>
       </Layout.Section>
-
-      <Layout.Section variant="annotatedLeft">
-        <Text as="h4" mb="300">
-          DNS Details
-        </Text>
-        <Text fontSize="200" color="gray.700">
-          Something about these records being successfully placed in Go-Daddy?
-        </Text>
-      </Layout.Section>
-      <Layout.Section variant="annotatedRight">
+    </Layout>
+    <Layout>
+      <Layout.Section>
         <Panel>
           <Panel.Section>
             <Text>Below are the records for this domain hosted at Go-Daddy</Text>
@@ -93,6 +106,14 @@ export const AnnotatedExample = withInfo()(() => (
             <Text>TXT Record details here</Text>
           </Panel.Section>
         </Panel>
+      </Layout.Section>
+      <Layout.Section annotated>
+        <Text as="h4" mb="300">
+          DNS Details
+        </Text>
+        <Text fontSize="200" color="gray.700">
+          Something about these records being successfully placed in Go-Daddy?
+        </Text>
       </Layout.Section>
     </Layout>
   </Page>

--- a/stories/layout/Layout.stories.js
+++ b/stories/layout/Layout.stories.js
@@ -58,9 +58,7 @@ export const AnnotatedExample = withInfo()(() => (
   <Page title="Domain Details" breadcrumbAction={breadcrumbAction}>
     <Layout>
       <Layout.Section annotated>
-        <Text as="h4" mb="300">
-          Domain Status
-        </Text>
+        <Layout.SectionTitle>Domain Status</Layout.SectionTitle>
         <Text fontSize="200" color="gray.700">
           Domain status text
         </Text>

--- a/stories/layout/Layout.stories.js
+++ b/stories/layout/Layout.stories.js
@@ -1,0 +1,99 @@
+import React from 'react';
+import { withInfo } from '@storybook/addon-info';
+import { action } from '@storybook/addon-actions';
+import { Page, Layout, Panel, Box, Text, Columns, Column, Tag } from '@sparkpost/matchbox';
+
+export default {
+  title: 'Layout|Layout',
+};
+
+function DemoBox({ children }) {
+  return (
+    <Box p="300" width="100%" bg="blue.300">
+      {children}
+    </Box>
+  );
+}
+
+const breadcrumbAction = {
+  content: 'All Domains',
+  onClick: action('All Domains Clicked'),
+};
+
+export const ColumnExample = withInfo()(() => (
+  <Layout>
+    <Layout.Section variant="oneColumn">
+      <DemoBox>One Column Layout</DemoBox>
+    </Layout.Section>
+    <Layout.Section variant="twoColumn">
+      <DemoBox>Two Column Layout</DemoBox>
+    </Layout.Section>
+    <Layout.Section variant="twoColumn">
+      <DemoBox>Two Column Layout</DemoBox>
+    </Layout.Section>
+  </Layout>
+));
+
+export const AnnotatedExample = withInfo()(() => (
+  <Page title="Domain Details" breadcrumbAction={breadcrumbAction}>
+    <Layout>
+      <Layout.Section variant="annotatedLeft">
+        <Text as="h4" mb="300">
+          Domain Status
+        </Text>
+        <Text fontSize="200" color="gray.700">
+          Domain status text
+        </Text>
+      </Layout.Section>
+      <Layout.Section variant="annotatedRight">
+        <Panel>
+          <Panel.Section>
+            <Columns collapseBelow="md">
+              <Column width={2 / 6}>
+                <Text as="h6">Domain</Text>
+                <Text fontWeight="light" mt="300">
+                  domainnamegoeshere.com
+                </Text>
+              </Column>
+              <Column width={3 / 6}>
+                <Text as="h6">Status</Text>
+                <Tag mt="300">Bounce</Tag>
+              </Column>
+              <Column width={1 / 6}>
+                <Text as="h6">Date added</Text>
+                <Text fontWeight="light" mt="300">
+                  Jan 9, 2020
+                </Text>
+              </Column>
+            </Columns>
+          </Panel.Section>
+          <Panel.Section>
+            <Text as="h6">Subaccount Assignment</Text>
+            <Text fontWeight="light" mt="300">
+              Subaccount_012345
+            </Text>
+          </Panel.Section>
+        </Panel>
+      </Layout.Section>
+
+      <Layout.Section variant="annotatedLeft">
+        <Text as="h4" mb="300">
+          DNS Details
+        </Text>
+        <Text fontSize="200" color="gray.700">
+          Something about these records being successfully placed in Go-Daddy?
+        </Text>
+      </Layout.Section>
+      <Layout.Section variant="annotatedRight">
+        <Panel>
+          <Panel.Section>
+            <Text>Below are the records for this domain hosted at Go-Daddy</Text>
+          </Panel.Section>
+          <Panel.Section>
+            <Text>TXT Record details here</Text>
+          </Panel.Section>
+        </Panel>
+      </Layout.Section>
+    </Layout>
+  </Page>
+));

--- a/stories/layout/Layout.stories.js
+++ b/stories/layout/Layout.stories.js
@@ -106,9 +106,7 @@ export const AnnotatedExample = withInfo()(() => (
         </Panel>
       </Layout.Section>
       <Layout.Section annotated>
-        <Text as="h4" mb="300">
-          DNS Details
-        </Text>
+        <Layout.SectionTitle>DNS Details</Layout.SectionTitle>
         <Text fontSize="200" color="gray.700">
           Something about these records being successfully placed in Go-Daddy?
         </Text>


### PR DESCRIPTION
New Layout Component
<img width="1651" alt="Screen Shot 2020-07-22 at 5 30 35 PM" src="https://user-images.githubusercontent.com/3878251/88235729-14ac5400-cc41-11ea-82f0-0d4251940949.png">


### What Changed

- Added `Layout` Component
- Added `Layout.Section` Component
- `Layout.Section` accepts `variant` prop with options `oneColumn, twoColumn, leftAnnotated, rightAnnotated`

### How To Test or Verify

- `npm run start:storybook`
-  Verify Layout story in storybook

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
