### PR TITLE
UX-284 Darken button hover background colors

### DIFF
--- a/config/helpers.js
+++ b/config/helpers.js
@@ -20,7 +20,16 @@ jest.mock('../packages/matchbox/src/components/ThemeProvider/theme', () => ({
   colors: {
     gray: {
       700: 'gray',
+      900: 'gray',
     },
+    red: {
+      700: 'red',
+      900: 'red',
+    },
+    blue: {
+      700: 'blue',
+    },
+    white: 'white',
   },
 }));
 

--- a/packages/matchbox/src/components/Banner/tests/Banner.test.js
+++ b/packages/matchbox/src/components/Banner/tests/Banner.test.js
@@ -74,7 +74,7 @@ describe('Banner', () => {
       .at(0)
       .simulate('click');
     expect(action.onClick).toHaveBeenCalledTimes(1);
-    expect(wrapper.find('button').at(0)).toHaveStyleRule('background', tokens.color_gray_900);
+    expect(wrapper.find('button').at(0)).toHaveStyleRule('background', 'gray');
   });
 
   it('renders multiple banner actions', () => {
@@ -89,7 +89,7 @@ describe('Banner', () => {
       .at(0)
       .simulate('click');
     expect(actions[0].onClick).toHaveBeenCalledTimes(1);
-    expect(wrapper.find('button').at(0)).toHaveStyleRule('background', tokens.color_blue_700);
+    expect(wrapper.find('button').at(0)).toHaveStyleRule('background', 'blue');
 
     wrapper
       .find('button')

--- a/packages/matchbox/src/components/Button/styles.js
+++ b/packages/matchbox/src/components/Button/styles.js
@@ -90,25 +90,25 @@ export const colorVariant = props => {
   switch (props.buttonColor) {
     case 'orange': // To be deprecated
     case 'blue':
-      color = tokens.color_blue_700;
-      darkHoverColor = tokens.color_blue_800;
-      lightActiveColor = tokens.color_blue_200;
-      lightHoverColor = tokens.color_blue_100;
+      color = props.theme.colors.blue['700'];
+      darkHoverColor = props.theme.colors.blue['800'];
+      lightActiveColor = props.theme.colors.blue['300'];
+      lightHoverColor = props.theme.colors.blue['200'];
       break;
 
     case 'red':
-      color = tokens.color_red_700;
-      darkHoverColor = tokens.color_red_800;
-      lightActiveColor = tokens.color_red_200;
-      lightHoverColor = tokens.color_red_100;
+      color = props.theme.colors.red['700'];
+      darkHoverColor = props.theme.colors.red['800'];
+      lightActiveColor = props.theme.colors.red['300'];
+      lightHoverColor = props.theme.colors.red['200'];
       break;
 
     case 'gray':
     default:
-      color = tokens.color_gray_900;
-      darkHoverColor = tokens.color_gray_1000;
-      lightActiveColor = tokens.color_gray_200;
-      lightHoverColor = tokens.color_gray_100;
+      color = props.theme.colors.gray['900'];
+      darkHoverColor = props.theme.colors.gray['1000'];
+      lightActiveColor = props.theme.colors.gray['400'];
+      lightHoverColor = props.theme.colors.gray['300'];
       break;
   }
 
@@ -117,13 +117,13 @@ export const colorVariant = props => {
       return `
         &, &:visited {
           background: ${color};
-          color: ${tokens.color_white};
+          color: ${props.theme.colors.white};
 
           &:hover {
             ${!props.disabled ? `background: ${darkHoverColor};` : ''}
           }
           &:focus, &:hover {
-            color: ${tokens.color_white};
+            color: ${props.theme.colors.white};
           }
           &:active {
             background: ${color};
@@ -151,7 +151,9 @@ export const colorVariant = props => {
     default:
       return `
         &, &:visited {
-          border: 1px solid ${props.visualWeight == 'outline' ? tokens.color_gray_400 : color};
+          border: 1px solid ${
+            props.visualWeight == 'outline' ? props.theme.colors.gray['400'] : color
+          };
           background: transparent;
           color: ${color};
           &:hover {

--- a/packages/matchbox/src/components/Button/tests/Button.test.js
+++ b/packages/matchbox/src/components/Button/tests/Button.test.js
@@ -10,20 +10,20 @@ describe('Button', () => {
       props: {},
       assert: [
         ['height', '2.5rem'],
-        ['color', '#ffffff'],
-        ['background', '#39444d'],
+        ['color', 'white'],
+        ['background', 'gray'],
       ],
     },
     { name: 'large size', props: { size: 'large' }, assert: ['height', '3.5rem'] },
     { name: 'disabled', props: { disabled: true }, assert: ['opacity', '0.6'] },
-    { name: 'destructive', props: { destructive: true }, assert: ['background', '#d9363e'] },
+    { name: 'destructive', props: { destructive: true }, assert: ['background', 'red'] },
     { name: 'flat', props: { flat: true }, assert: ['background', 'transparent'] },
     {
       name: 'flat with color',
       props: { flat: true, color: 'blue' },
       assert: [
         ['background', 'transparent'],
-        ['color', '#1273e6'],
+        ['color', 'blue'],
       ],
     },
     {
@@ -31,7 +31,7 @@ describe('Button', () => {
       props: { flat: true, color: 'red', disabled: true },
       assert: [
         ['background', 'transparent'],
-        ['color', '#d9363e'],
+        ['color', 'red'],
         ['opacity', '0.6'],
       ],
     },
@@ -39,7 +39,7 @@ describe('Button', () => {
       name: 'outline enabled',
       props: { outlineBorder: true },
       assert: [
-        ['border', '1px solid #39444d'],
+        ['border', '1px solid gray'],
         ['background', 'transparent'],
       ],
     },
@@ -56,7 +56,7 @@ describe('Button', () => {
     {
       name: 'deprecated prop - primary',
       props: { primary: true },
-      assert: ['background', '#1273e6'],
+      assert: ['background', 'blue'],
     },
   ];
 

--- a/packages/matchbox/src/components/Pagination/tests/Pagination.test.js
+++ b/packages/matchbox/src/components/Pagination/tests/Pagination.test.js
@@ -28,8 +28,8 @@ describe('Pagination', () => {
   });
 
   it('renders active page styles correctly', () => {
-    expect(wrapper.find('button').at(1)).toHaveStyleRule('background', tokens.color_blue_700);
-    expect(wrapper.find('button').at(1)).toHaveStyleRule('color', tokens.color_white);
+    expect(wrapper.find('button').at(1)).toHaveStyleRule('background', 'blue');
+    expect(wrapper.find('button').at(1)).toHaveStyleRule('color', 'white');
   });
 
   it('invokes onChange on page', () => {

--- a/packages/matchbox/src/components/ThemeProvider/theme.js
+++ b/packages/matchbox/src/components/ThemeProvider/theme.js
@@ -108,6 +108,7 @@ const theme = {
       gray: tokens.color_brand_gray,
       blue: tokens.color_brand_blue,
     },
+    white: tokens.color_white,
   },
 
   // Example: <Box marginBottom="400" padding={400} />

--- a/packages/matchbox/src/components/Tooltip/tests/Tooltip.test.js
+++ b/packages/matchbox/src/components/Tooltip/tests/Tooltip.test.js
@@ -59,9 +59,9 @@ describe('Tooltip', () => {
   });
 
   it('should pass through system props', () => {
-    const wrapper = subject({ bg: 'blue', fontSize: '400', pr: '500' });
+    const wrapper = subject({ bg: 'bg', fontSize: '400', pr: '500' });
     wrapper.find('button').simulate('mouseOver');
-    expect(content(wrapper)).toHaveStyleRule('background-color', 'blue');
+    expect(content(wrapper)).toHaveStyleRule('background-color', 'bg');
     expect(content(wrapper)).toHaveStyleRule('font-size', '1rem');
     expect(content(wrapper)).toHaveStyleRule('padding-right', '1.5rem');
   });

--- a/stories/action/Button.stories.js
+++ b/stories/action/Button.stories.js
@@ -15,7 +15,7 @@ export const Sizing = withInfo()(() => (
 ));
 
 export const Colors = withInfo({ propTables: [Button] })(() => (
-  <>
+  <Box bg="gray.100">
     <Inline>
       <Button>Button</Button>
       <Button disabled>Disabled</Button>
@@ -64,7 +64,7 @@ export const Colors = withInfo({ propTables: [Button] })(() => (
         Outline
       </Button>
     </Inline>
-  </>
+  </Box>
 ));
 
 export const Destructive = withInfo()(() => (


### PR DESCRIPTION

### What Changed
- Darkens background hover colors for `outline` `outlineBorder` and `flat` buttons

### How To Test or Verify
- Run storybook and visit the button color story

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
