### PR TITLE
UX-279 Export all styled-component helpers

### DIFF
--- a/packages/matchbox/src/components/ComboBox/styles.js
+++ b/packages/matchbox/src/components/ComboBox/styles.js
@@ -16,7 +16,7 @@ export const StyledInputWrapper = styled(Box)`
   border-radius: ${tokens.borderRadius_100};
   min-height: ${inputHeight};
 
-  ${focusOutline({ within: true })}
+  ${focusOutline({ modifier: '&:focus-within' })}
 `;
 
 export const StyledInput = styled('input')`

--- a/packages/matchbox/src/components/Select/Select.js
+++ b/packages/matchbox/src/components/Select/Select.js
@@ -50,7 +50,7 @@ function Options({ options, placeholder, placeholderValue }) {
 }
 
 const StyledInputWrapper = styled(Box)`
-  ${focusOutline({ within: true, offset: '2px' })}
+  ${focusOutline({ modifier: '&:focus-within', offset: '2px' })}
 `;
 
 const StyledInput = styled(Box)`

--- a/packages/matchbox/src/components/TextField/TextField.js
+++ b/packages/matchbox/src/components/TextField/TextField.js
@@ -22,7 +22,7 @@ const StyledWrapper = styled('div')`
 `;
 
 const StyledInputWrapper = styled(Box)`
-  ${focusOutline({ within: true, offset: '2px' })}
+  ${focusOutline({ modifier: '&:focus-within', offset: '2px' })}
 `;
 
 const StyledInput = styled(Box)`

--- a/packages/matchbox/src/index.js
+++ b/packages/matchbox/src/index.js
@@ -1,2 +1,3 @@
 export * from './components';
 export * from './hooks';
+export { default as styles } from './styles';

--- a/packages/matchbox/src/styles/helpers.js
+++ b/packages/matchbox/src/styles/helpers.js
@@ -38,6 +38,11 @@ export const visuallyHidden = `
  * @param string color, defaults to 'color_blue_700'
  * @param modifier CSS selector to target the pseudo-element, defaults to '&:focus'
  * @param offset string, pixel value, defaults to '3px'
+ *
+ * @example
+ * const Styled = styled.div`
+ *   ${focusOutline({ color: 'gray', modifier: '&:focus-within' })}
+ * `;
  */
 export const focusOutline = ({
   color = tokens.color_blue_700,

--- a/packages/matchbox/src/styles/helpers.js
+++ b/packages/matchbox/src/styles/helpers.js
@@ -35,11 +35,15 @@ export const visuallyHidden = `
 
 /**
  * Creates focus styles on an :after pseudo-element. Defaults to blue 700.
- * @param string color
- * @param within boolean
- * @param offset string, pixel value
+ * @param string color, defaults to 'color_blue_700'
+ * @param modifier CSS selector to target the pseudo-element, defaults to '&:focus'
+ * @param offset string, pixel value, defaults to '3px'
  */
-export const focusOutline = ({ color = tokens.color_blue_700, within = false, offset = '3px' }) => `
+export const focusOutline = ({
+  color = tokens.color_blue_700,
+  modifier = '&:focus',
+  offset = '3px',
+} = {}) => `
   position: relative;
   outline: none;
 
@@ -51,15 +55,14 @@ export const focusOutline = ({ color = tokens.color_blue_700, within = false, of
     left: -${offset};
     right: -${offset};
     bottom: -${offset};
-    transition: ${tokens.motionDuration_fast};
+    transition: box-shadow ${tokens.motionDuration_fast};
     border-radius: ${tokens.borderRadius_200};
     box-shadow: none;
     pointer-events: none;
   } 
 
-  &:focus${within ? '-within' : ''}:after {
+  ${modifier}:after {
     z-index: ${tokens.zIndex_default};
-    opacity: 1;
     box-shadow: 0 0 0 2px ${color};
   }
 `;

--- a/packages/matchbox/src/styles/index.js
+++ b/packages/matchbox/src/styles/index.js
@@ -1,0 +1,7 @@
+import { buttonReset, visuallyHidden, focusOutline } from './helpers';
+
+export default {
+  buttonReset,
+  focusOutline,
+  visuallyHidden,
+};

--- a/stories/utility/Styles.stories.js
+++ b/stories/utility/Styles.stories.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { styles } from '@sparkpost/matchbox';
+import styled from 'styled-components';
+
+export default {
+  title: 'Utility|StyleHelpers',
+};
+
+const Hidden = styled.div`
+  ${styles.visuallyHidden}
+`;
+
+export const VisuallyHidden = () => {
+  return (
+    <>
+      <Hidden>This should be hidden</Hidden>
+      <div>But this is not hidden</div>
+    </>
+  );
+};
+
+const Reset = styled.button`
+  ${styles.buttonReset}
+`;
+
+export const ButtonReset = () => {
+  return (
+    <>
+      <Reset>This is a reset button</Reset>
+      <button>But this one is not reset</button>
+    </>
+  );
+};
+
+const Focus = styled.button`
+  ${styles.focusOutline()}
+`;
+
+export const FocusOutline = () => {
+  return (
+    <>
+      <Focus>This input has focus styled</Focus>
+      <button>This one does not</button>
+    </>
+  );
+};


### PR DESCRIPTION
##### Notes
- Ticket notes only to export the focusOutline helper, but thought it would be a good idea to export all of them
- There are some changes included with the `modifier` parameter, these were initially made in #554 and are merged into rc/4.1.0. This just promotes it up to 4.0.x.

### What Changed
- Exports all styled-component helpers, under a `styles` object

### How To Test or Verify
- Visit the stories under Utility/StyleHelpers

### PR Checklist
- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
