### PR TITLE
UX-281 Focus on Drawer container on open

### DIFF
--- a/packages/matchbox/src/components/Drawer/Drawer.js
+++ b/packages/matchbox/src/components/Drawer/Drawer.js
@@ -14,7 +14,7 @@ import { onKey } from '../../helpers/keyEvents';
 import { secondsToMS } from '../../helpers/string';
 import { getRectFor } from '../../helpers/geometry';
 import { getChild } from '../../helpers/children';
-import { isInIframe } from '../../helpers/window';
+import { getWindow, isInIframe } from '../../helpers/window';
 import { Overlay, Container } from './styles';
 
 const Drawer = React.forwardRef(function Drawer(props, ref) {
@@ -81,6 +81,22 @@ const Drawer = React.forwardRef(function Drawer(props, ref) {
     }
   }, [footerRef.current, open]);
 
+  /**
+   * On drawer open, moves focus to the container
+   * Without this, focus gets moved to the close button first
+   */
+  React.useLayoutEffect(() => {
+    let timer;
+    if (open) {
+      timer = getWindow().setTimeout(() => {
+        childrenRef.current.focus();
+      }, secondsToMS(tokens.motionDuration_medium));
+    }
+    return () => {
+      getWindow().clearTimeout(timer);
+    };
+  }, [open]);
+
   return (
     <>
       <ScrollLock isActive={open} />
@@ -95,7 +111,7 @@ const Drawer = React.forwardRef(function Drawer(props, ref) {
           }}
         >
           {state => (
-            <FocusLock returnFocus disabled={!open || isInIframe()}>
+            <FocusLock returnFocus disabled={!open || isInIframe()} autoFocus={false}>
               <Box
                 data-id="drawer-wrapper"
                 height="100vh"
@@ -126,6 +142,7 @@ const Drawer = React.forwardRef(function Drawer(props, ref) {
                   ref={childrenRef}
                   role="dialog"
                   state={state}
+                  tabIndex="-1"
                   viewportPosition={position}
                   bg="white"
                   position="absolute"


### PR DESCRIPTION
### What Changed
- Focus is now placed on the Drawer container when it is opened

### How To Test or Verify
- Run storybook, visit http://localhost:9001/iframe.html?id=overlays-drawer--drawer-example
  - **Focus lock does not work if its in an iframe - use this link**
- Verify the container is focused on open, you can try removing `tabIndex='-1'` to make focus outline visible

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
