### PR TITLE
UX-292 Add Button.Icon

### DIFF
--- a/packages/matchbox/src/components/Button/Button.js
+++ b/packages/matchbox/src/components/Button/Button.js
@@ -9,7 +9,7 @@ import { omit } from '@styled-system/props';
 import { pick } from '../../helpers/systemProps';
 import { Box } from '../Box';
 import { Spinner } from '../Spinner';
-
+import Icon from './Icon';
 import Group from './Group';
 import {
   base,
@@ -185,6 +185,7 @@ const Button = React.forwardRef(function Button(props, ref) {
 
 Button.displayName = 'Button';
 Button.Group = Group;
+Button.Icon = Icon;
 
 Button.propTypes = {
   color: PropTypes.oneOf(['gray', 'orange', 'blue', 'navy', 'purple', 'red']),

--- a/packages/matchbox/src/components/Button/Icon.js
+++ b/packages/matchbox/src/components/Button/Icon.js
@@ -1,21 +1,38 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { margin } from 'styled-system';
 import styled from 'styled-components';
+import { pick } from '../../helpers/systemProps';
 
 const StyledIcon = styled.svg`
   ${margin}
 `;
 
 const Icon = React.forwardRef(function Icon(props, ref) {
-  const { as } = props;
+  const { as, size, width, height, label, ...rest } = props;
+  const systemProps = pick(rest, margin.propNames);
   return (
-    <StyledIcon as={as} ref={ref}>
-      test
-    </StyledIcon>
+    <StyledIcon
+      as={as}
+      size={size}
+      width={width}
+      height={height}
+      label={label}
+      ref={ref}
+      mt="-2px"
+      {...systemProps}
+    />
   );
 });
 
 Icon.displayName = 'Button.Icon';
-Icon.propTypes = {};
+Icon.propTypes = {
+  as: PropTypes.elementType,
+  // These should be the same props as IconBase
+  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  label: PropTypes.string,
+};
 
 export default Icon;

--- a/packages/matchbox/src/components/Button/Icon.js
+++ b/packages/matchbox/src/components/Button/Icon.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { margin } from 'styled-system';
+import styled from 'styled-components';
+
+const StyledIcon = styled.svg`
+  ${margin}
+`;
+
+const Icon = React.forwardRef(function Icon(props, ref) {
+  const { as } = props;
+  return (
+    <StyledIcon as={as} ref={ref}>
+      test
+    </StyledIcon>
+  );
+});
+
+Icon.displayName = 'Button.Icon';
+Icon.propTypes = {};
+
+export default Icon;

--- a/packages/matchbox/src/components/Button/tests/Button.test.js
+++ b/packages/matchbox/src/components/Button/tests/Button.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Button from '../Button';
 import cases from 'jest-in-case';
 import 'jest-styled-components';
+import { Assessment } from '@sparkpost/matchbox-icons';
 
 describe('Button', () => {
   const styleCases = [
@@ -145,5 +146,30 @@ describe('wrappers', () => {
     );
     expect(wrapper.find('span').first()).toExist();
     expect(wrapper.find('span').first()).toHaveAttributeValue('to', '/test');
+  });
+});
+
+describe('Button.Icon', () => {
+  it('should render correctly', () => {
+    const wrapper = global.mountStyled(
+      <Button to="/test" component="span">
+        Hola!
+        <Button.Icon as={Assessment} />
+      </Button>,
+    );
+    expect(wrapper.find('svg')).toExist();
+    expect(wrapper.find('Assessment')).toExist();
+  });
+
+  it('should renders label and size correctly', () => {
+    const wrapper = global.mountStyled(
+      <Button to="/test" component="span">
+        Hola!
+        <Button.Icon as={Assessment} label="test-label" size={24} />
+      </Button>,
+    );
+    expect(wrapper.find('[aria-label="test-label"]')).toExist();
+    expect(wrapper.find('[aria-label="test-label"]').props().width).toEqual(24);
+    expect(wrapper.find('[aria-label="test-label"]').props().height).toEqual(24);
   });
 });

--- a/stories/action/Button.stories.js
+++ b/stories/action/Button.stories.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { withInfo } from '@storybook/addon-info';
 import { Button, Inline, Box, Stack } from '@sparkpost/matchbox';
+import { Assessment, AddCircleOutline, ArrowDropDown } from '@sparkpost/matchbox-icons';
 
 export default {
   title: 'Action|Button',
@@ -155,6 +156,21 @@ export const Group = withInfo()(() => (
       Sq Rt
     </Button>
   </Button.Group>
+));
+
+export const Icon = withInfo()(() => (
+  <Inline>
+    <Button outlineBorder>
+      <Button.Icon as={Assessment} mr="100"></Button.Icon>
+      Button
+    </Button>
+    <Button outline>
+      Button<Button.Icon as={AddCircleOutline} size={20} ml="100"></Button.Icon>
+    </Button>
+    <Button color="blue">
+      Button<Button.Icon as={ArrowDropDown} ml="200"></Button.Icon>
+    </Button>
+  </Inline>
 ));
 
 export const SystemProps = withInfo()(() => (


### PR DESCRIPTION
Closes #522 

### What Changed

- Adds new `Button.Icon` component to handle vertically centering icons easily inside buttons

### How To Test or Verify

- Run storybook and visit http://localhost:9001/?path=/story/action-button--icon

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
