### PR TITLE
UX-286 Add indeterminate checkbox support

### DIFF
--- a/packages/matchbox/src/components/Checkbox/Checkbox.js
+++ b/packages/matchbox/src/components/Checkbox/Checkbox.js
@@ -11,12 +11,20 @@ import { pick } from '@styled-system/props';
 import { omit } from '../../helpers/systemProps';
 import { createPropTypes } from '@styled-system/prop-types';
 import { margin } from 'styled-system';
-import { StyledLabel, StyledCheck, StyledBox, StyledInput, Wrapper } from './styles';
+import {
+  StyledLabel,
+  StyledCheck,
+  StyledBox,
+  StyledInput,
+  StyledIndeterminate,
+  Wrapper,
+} from './styles';
 
 function Checkbox(props) {
   const {
     id,
     checked,
+    defaultChecked,
     disabled,
     error,
     helpText,
@@ -39,13 +47,18 @@ function Checkbox(props) {
     hasError: !!error,
   });
 
+  const isIndeterminate = checked === 'indeterminate';
+  const indeterminateAttributes = isIndeterminate
+    ? { indeterminate: 'true', 'aria-checked': 'mixed' }
+    : { 'aria-checked': checked, checked };
+
   return (
     <Wrapper {...systemProps}>
       <StyledLabel error={error} htmlFor={id} disabled={disabled}>
         <StyledInput
           id={id}
           value={value}
-          checked={checked}
+          defaultChecked={defaultChecked}
           disabled={disabled}
           onChange={onChange}
           onFocus={onFocus}
@@ -53,6 +66,7 @@ function Checkbox(props) {
           type="checkbox"
           required={required}
           error={error}
+          {...indeterminateAttributes}
           {...describedBy}
           {...componentProps}
         />
@@ -71,8 +85,18 @@ function Checkbox(props) {
             size="1rem"
             lineHeight="200"
             error={error}
+            indeterminate={isIndeterminate}
           />
           <StyledCheck position="absolute" width="1rem" height="1rem" as={Check} />
+          <StyledIndeterminate
+            position="absolute"
+            left="100"
+            right="100"
+            height="2px"
+            bg="white"
+            borderRadius="200"
+            indeterminate={isIndeterminate}
+          />
         </Box>
         <Box flex="1" pl="200">
           <Label
@@ -105,7 +129,11 @@ Checkbox.displayName = 'Checkbox';
 Checkbox.Group = Group;
 Checkbox.propTypes = {
   id: PropTypes.string.isRequired,
-  checked: PropTypes.bool,
+  checked: PropTypes.oneOf([true, false, 'indeterminate']),
+  /**
+   * 'indeterminate' does not work with defaultChecked
+   */
+  defaultChecked: PropTypes.oneOf([true, false]),
   label: PropTypes.node,
   labelHidden: PropTypes.bool,
   disabled: PropTypes.bool,

--- a/packages/matchbox/src/components/Checkbox/Checkbox.js
+++ b/packages/matchbox/src/components/Checkbox/Checkbox.js
@@ -133,7 +133,7 @@ Checkbox.propTypes = {
   /**
    * 'indeterminate' does not work with defaultChecked
    */
-  defaultChecked: PropTypes.oneOf([true, false]),
+  defaultChecked: PropTypes.bool,
   label: PropTypes.node,
   labelHidden: PropTypes.bool,
   disabled: PropTypes.bool,

--- a/packages/matchbox/src/components/Checkbox/styles.js
+++ b/packages/matchbox/src/components/Checkbox/styles.js
@@ -3,21 +3,26 @@ import { Box } from '../Box';
 import { visuallyHidden } from '../../styles/helpers';
 import styled from 'styled-components';
 import { margin } from 'styled-system';
+import { focusOutline } from '../../styles/helpers';
 
 export const Wrapper = styled('div')`
   ${margin}
-`;
-
-export const StyledBox = styled(Box)`
-  border: 2px solid ${props => (props.error ? tokens.color_red_700 : tokens.color_gray_700)};
-  transition: ${tokens.motionDuration_fast} ${tokens.motionEase_in_out};
-  transition-property: border, background;
 `;
 
 export const StyledCheck = styled(Box)`
   opacity: 0;
   color: ${tokens.color_white};
   transition: opacity ${tokens.motionDuration_fast} ${tokens.motionEase_in_out};
+
+  input:checked ~ span & {
+    opacity: 1;
+  }
+`;
+
+export const StyledIndeterminate = styled(Box)`
+  ${({ indeterminate }) => `
+    opacity: ${indeterminate ? '1' : '0'};
+  `}
 `;
 
 export const StyledLabel = styled('label')`
@@ -27,41 +32,52 @@ export const StyledLabel = styled('label')`
   padding: 0;
   white-space: nowrap;
   user-select: none;
-
-  &:hover {
-    cursor: ${props => (props.disabled ? 'not-allowed' : 'pointer')};
-
-    ${StyledBox} {
-      ${props => (!props.disabled ? `border: 2px solid ${tokens.color_gray_800};` : '')}
-    }
-  }
+  cursor: ${props => (props.disabled ? 'not-allowed' : 'pointer')};
 `;
 
-export const StyledInput = styled('input')`
-  ${visuallyHidden}
+export const StyledBox = styled(Box)`
+  border: 2px solid ${props => (props.error ? tokens.color_red_700 : tokens.color_gray_700)};
+  transition: ${tokens.motionDuration_fast} ${tokens.motionEase_in_out};
+  transition-property: border, background;
 
-  &:focus ~ span ${StyledBox} {
-    box-shadow: 0 0 0 2px ${tokens.color_white}, 0 0 0 4px ${tokens.color_blue_700}
+  ${focusOutline({ modifier: 'input:focus ~ span &' })}
+
+  ${StyledLabel}:hover & {
+    ${props =>
+      !props.disabled && !props.indeterminate && !props.error
+        ? `border: 2px solid ${tokens.color_gray_800};`
+        : ''}
   }
 
-  &:checked {
-    & ~ span ${StyledBox} {
-      border: 2px solid ${props => (props.error ? tokens.color_red_700 : tokens.color_blue_700)};
-      background: ${props => (props.error ? tokens.color_red_700 : tokens.color_blue_700)};
-    }
+  input:checked ~ span & {
+    border: 2px solid ${props => (props.error ? tokens.color_red_700 : tokens.color_blue_700)};
+    background: ${props => (props.error ? tokens.color_red_700 : tokens.color_blue_700)};
 
-    & ~ span ${StyledCheck} {
-      opacity: 1;
+    ${StyledLabel}:hover & {
+      ${props =>
+        !props.disabled && !props.error ? `border: 2px solid ${tokens.color_blue_700};` : ''}
     }
   }
 
-  &:disabled ~ span ${StyledBox} {
+  input:disabled ~ span & {
     background: ${tokens.color_gray_300};
     border: 2px solid ${tokens.color_gray_600};
   }
 
-  &:disabled:checked ~ span ${StyledBox} {
+  input:disabled:checked ~ span & {
     background: ${tokens.color_gray_600};
     border: 2px solid ${tokens.color_gray_600};
   }
+
+  ${props =>
+    props.indeterminate
+      ? `
+        background: ${tokens.color_blue_700};
+        border: 2px solid ${tokens.color_blue_700};
+      `
+      : null}
+`;
+
+export const StyledInput = styled('input')`
+  ${visuallyHidden}
 `;

--- a/packages/matchbox/src/components/Checkbox/tests/Checkbox.test.js
+++ b/packages/matchbox/src/components/Checkbox/tests/Checkbox.test.js
@@ -11,7 +11,6 @@ describe('Checkbox', () => {
     onFocus: jest.fn(),
   };
   const subject = props => global.mountStyled(<Checkbox id="test-id" {...events} {...props} />);
-  const box = `:checked ~ span ${StyledBox}`;
 
   it('renders with id', () => {
     const wrapper = subject();
@@ -23,13 +22,7 @@ describe('Checkbox', () => {
     const wrapper = subject({ checked: true, value: 'test-value' });
     expect(wrapper.find('input')).toHaveAttributeValue('checked', '');
     expect(wrapper.find('input')).toHaveAttributeValue('value', 'test-value');
-    expect(wrapper.find('label')).toHaveStyleRule('cursor', 'pointer', { modifier: ':hover' });
-
-    // This assertion tests the lack of an error
-    // Not possible to check for checked/unchecked styles since the selectors use html input attributes
-    expect(wrapper.find('input')).toHaveStyleRule('background', tokens.color_blue_700, {
-      modifier: box,
-    });
+    expect(wrapper.find('label')).toHaveStyleRule('cursor', 'pointer');
   });
 
   it('renders a label', () => {
@@ -40,17 +33,14 @@ describe('Checkbox', () => {
   it('renders error', () => {
     const wrapper = subject({ error: 'test-error' });
     expect(wrapper.find(StyledBox)).toHaveStyleRule('border', `2px solid ${tokens.color_red_700}`);
-    expect(wrapper.find('input')).toHaveStyleRule('background', tokens.color_red_700, {
-      modifier: box,
-    });
     expect(wrapper.text()).toEqual('test-error');
     expect(wrapper.find('input')).toHaveAttributeValue('aria-describedby', 'test-id-error');
-    expect(wrapper.find('div').at(2)).toHaveAttributeValue('id', 'test-id-error');
+    expect(wrapper.find('div').at(3)).toHaveAttributeValue('id', 'test-id-error');
   });
 
   it('renders disabled', () => {
     const wrapper = subject({ disabled: true });
-    expect(wrapper.find('label')).toHaveStyleRule('cursor', 'not-allowed', { modifier: ':hover' });
+    expect(wrapper.find('label')).toHaveStyleRule('cursor', 'not-allowed');
     expect(wrapper.find('input')).toBeDisabled();
   });
 

--- a/stories/form/Checkbox.stories.js
+++ b/stories/form/Checkbox.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { withInfo } from '@storybook/addon-info';
-import { Checkbox, UnstyledLink } from '@sparkpost/matchbox';
+import { Box, Checkbox, UnstyledLink } from '@sparkpost/matchbox';
 
 export default {
   title: 'Form|Checkbox',
@@ -65,3 +65,56 @@ export const GroupWithHiddenLabel = withInfo()(() => (
     </Checkbox.Group>
   </div>
 ));
+
+export const IndeterminateGroup = withInfo()(() => {
+  const [checked1, setChecked1] = React.useState(false);
+  const [checked2, setChecked2] = React.useState(false);
+  const [indeterminate, setIndeterminate] = React.useState(false);
+
+  React.useLayoutEffect(() => {
+    if (checked1 || checked2) {
+      setIndeterminate('indeterminate');
+    }
+    if (checked1 && checked2) {
+      setIndeterminate(true);
+    }
+
+    if (!checked1 && !checked2) {
+      setIndeterminate(false);
+    }
+  }, [checked1, checked2]);
+
+  function handleIndeterminate() {
+    setIndeterminate(!indeterminate);
+    setChecked1(!indeterminate);
+    setChecked2(!indeterminate);
+  }
+
+  function flip(cb, value) {
+    return () => {
+      cb(!value);
+    };
+  }
+
+  return (
+    <div>
+      <Checkbox.Group label="Example">
+        <Checkbox id="id" label="Check Me" checked={indeterminate} onChange={handleIndeterminate} />
+        <Box pl="500">
+          <Checkbox
+            id="child1"
+            onChange={flip(setChecked1, checked1)}
+            checked={checked1}
+            label="Check Me"
+          />
+          <Checkbox
+            id="child2"
+            onChange={flip(setChecked2, checked2)}
+            checked={checked2}
+            label="Check Me"
+          />
+        </Box>
+      </Checkbox.Group>
+    </div>
+  );
+});


### PR DESCRIPTION
### What Changed
- Adds support for `indeterminate` checked state
- Specifies `defaultChecked` prop doesn't work with intermediate, input must be fully controlled

### How To Test or Verify
- Run storybook and visit http://localhost:9001/?path=/story/form-checkbox--indeterminate-group

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
