### PR TITLE
UX-291 Fix global anchor tag hover styles

### DIFF
--- a/packages/matchbox/src/components/ThemeProvider/globalStyles.js
+++ b/packages/matchbox/src/components/ThemeProvider/globalStyles.js
@@ -113,13 +113,13 @@ export default `
   a:visited {
     color: ${tokens.color_blue_700};
     text-decoration: underline;
-
-    &:hover,
-    &:active,
-    &:focus {
-      color: ${tokens.color_blue_800}
-      cursor: pointer;
-    }
+    cursor: pointer;
+  }
+  
+  a:hover,
+  a:active,
+  a:focus {
+    color: ${tokens.color_blue_800}    
   }
 
   ul,


### PR DESCRIPTION
### What Changed
- Un-nests the hover styles in global CSS


### How To Test or Verify
- Bug is not reproducible through storybook or playroom, I published a test version at `4.0.14-beta.0`
- Compare these two versions of matchbox:
  - Hover - https://codesandbox.io/s/wonderful-euler-xzdue
  - No hover - https://codesandbox.io/s/little-meadow-6is53
(Edit: updated the links)

### PR Checklist

- [x] Add the correct `type` label
- [x] Pull request approval from #uxfe or #design-guild
