### PR TITLE
Resolves #582 - Adds missing semicolon to CodeBlock component styles

### DIFF
--- a/packages/matchbox/src/components/CodeBlock/styles.js
+++ b/packages/matchbox/src/components/CodeBlock/styles.js
@@ -8,7 +8,7 @@ export const pre = props => `
   display: grid;
   grid-template-columns: ${tokens.spacing_700} auto;
   font-family: ${tokens.fontFamily_monospace};
-  border-radius: ${tokens.borderRadius_100}
+  border-radius: ${tokens.borderRadius_100};
   background-color: ${props.dark ? tokens.color_gray_900 : tokens.color_gray_100};
   border: 1px solid ${tokens.color_gray_400};
   overflow: scroll;

--- a/stories/utility/CodeBlock.stories.js
+++ b/stories/utility/CodeBlock.stories.js
@@ -21,7 +21,7 @@ https://api.sparkpost.com/api/v1/transmissions
 }'`;
 
 export default {
-  title: 'Utility|Code Block',
+  title: 'Utility|CodeBlock',
 };
 
 export const Chevrons = withInfo({ propTables: [CodeBlock] })(() => (


### PR DESCRIPTION
Resolves #582 

### What Changed
- Adds a missing semicolon to the `<CodeBlock />` component styles
- Updates Storybook story name to match formatting

### How To Test or Verify
- Start Storybook and go to `/?path=/story/utility-codeblock--chevrons` to verify the background color renders correctly

### PR Checklist

- [X ] Add the correct `type` label
