### PR TITLE
UX-224 Support composable ActionList components

### DIFF
--- a/packages/matchbox/src/components/ActionList/Action.js
+++ b/packages/matchbox/src/components/ActionList/Action.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { CheckBox } from '@sparkpost/matchbox-icons';
 import { deprecate } from '../../helpers/propTypes';
 import { Box } from '../Box';
+import { HelpText } from '../HelpText';
 import { StyledLink } from './styles';
 
 const Action = React.forwardRef(function Action(props, userRef) {
@@ -19,32 +20,21 @@ const Action = React.forwardRef(function Action(props, userRef) {
             <CheckBox size={20} />
           </Box>
         )}
-        {helpText && (
-          <Box
-            as="span"
-            color="gray.700"
-            fontSize="200"
-            lineHeight="200"
-            pl="100"
-            pt="100"
-            textAlign="right"
-          >
-            {helpText}
-          </Box>
-        )}
+        {helpText && <HelpText>{helpText}</HelpText>}
       </Box>
     );
   }, [content, selected, helpText]);
+
+  const isAttributes =
+    is === 'checkbox' ? { role: 'checkbox', 'aria-checked': !!selected, tabIndex: '0' } : {};
 
   return (
     <StyledLink
       as={is === 'button' ? 'button' : null}
       type={is === 'button' ? 'button' : null}
       isType={is}
-      {...(is === 'checkbox'
-        ? { role: 'checkbox', 'aria-checked': !!selected, tabIndex: '0' }
-        : {})}
       ref={userRef}
+      {...isAttributes}
       {...action}
     >
       {linkContent}

--- a/packages/matchbox/src/components/ActionList/Action.js
+++ b/packages/matchbox/src/components/ActionList/Action.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { CheckBox } from '@sparkpost/matchbox-icons';
+import { deprecate } from '../../helpers/propTypes';
+import { Box } from '../Box';
+import { StyledLink } from './styles';
+
+const Action = React.forwardRef(function Action(props, userRef) {
+  const { content, children, helpText, is = 'link', selected, ...action } = props;
+
+  const linkContent = React.useMemo(() => {
+    return (
+      <Box as="span" alignItems="flex-start" display="flex">
+        <Box as="span" flex="1" fontSize="300" lineHeight="300">
+          {content || children}
+        </Box>
+        {selected && (
+          <Box as="span" color="blue.700">
+            <CheckBox size={20} />
+          </Box>
+        )}
+        {helpText && (
+          <Box
+            as="span"
+            color="gray.700"
+            fontSize="200"
+            lineHeight="200"
+            pl="100"
+            pt="100"
+            textAlign="right"
+          >
+            {helpText}
+          </Box>
+        )}
+      </Box>
+    );
+  }, [content, selected, helpText]);
+
+  return (
+    <StyledLink
+      as={is === 'button' ? 'button' : null}
+      type={is === 'button' ? 'button' : null}
+      isType={is}
+      {...(is === 'checkbox'
+        ? { role: 'checkbox', 'aria-checked': !!selected, tabIndex: '0' }
+        : {})}
+      ref={userRef}
+      {...action}
+    >
+      {linkContent}
+    </StyledLink>
+  );
+});
+
+Action.displayName = 'ActionList.Action';
+Action.propTypes = {
+  content: PropTypes.node,
+  children: PropTypes.node,
+  /**
+   * Same as hover styles.
+   * Can be used for wrappers that manage focus within the menu, eg downshift
+   */
+  highlighted: PropTypes.bool,
+  is: PropTypes.oneOf(['link', 'button', 'checkbox']),
+  selected: deprecate(PropTypes.bool, 'Use the checkbox component instead'),
+  helpText: PropTypes.string,
+};
+
+export default Action;

--- a/packages/matchbox/src/components/ActionList/ActionList.js
+++ b/packages/matchbox/src/components/ActionList/ActionList.js
@@ -3,11 +3,10 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { createPropTypes } from '@styled-system/prop-types';
 import { margin, layout, compose } from 'styled-system';
-import { groupByValues, filterByVisible } from '../../helpers/array';
+import { groupByValues } from '../../helpers/array';
 import { deprecate } from '../../helpers/propTypes';
-import { Box } from '../Box';
-import { CheckBox } from '@sparkpost/matchbox-icons';
-import { StyledLink, StyledSection } from './styles';
+import Section from './Section';
+import Action from './Action';
 
 const system = compose(margin, layout);
 const Wrapper = styled('div')`
@@ -15,85 +14,13 @@ const Wrapper = styled('div')`
   overflow-y: auto;
 `;
 
-function Action(props) {
-  const { content, helpText, is = 'link', selected, ...action } = props;
-
-  const linkContent = React.useMemo(() => {
-    return (
-      <Box as="span" alignItems="flex-start" display="flex">
-        <Box as="span" flex="1" fontSize="300" lineHeight="300">
-          {content}
-        </Box>
-        {selected && (
-          <Box as="span" color="blue.700">
-            <CheckBox size={20} />
-          </Box>
-        )}
-        {helpText && (
-          <Box
-            as="span"
-            color="gray.700"
-            fontSize="200"
-            lineHeight="200"
-            pl="100"
-            pt="100"
-            textAlign="right"
-          >
-            {helpText}
-          </Box>
-        )}
-      </Box>
-    );
-  }, [content, selected, helpText]);
-
-  return (
-    <StyledLink
-      as={is === 'button' ? 'button' : null}
-      type={is === 'button' ? 'button' : null}
-      isType={is}
-      {...(is === 'checkbox'
-        ? { role: 'checkbox', 'aria-checked': !!selected, tabIndex: '0' }
-        : {})}
-      {...action}
-    >
-      {linkContent}
-    </StyledLink>
-  );
-}
-
-Action.displayName = 'ActionList.Action';
-Action.propTypes = {
-  content: PropTypes.node,
-  /**
-   * Same as hover styles.
-   * Can be used for wrappers that manage focus within the menu, eg downshift
-   */
-  highlighted: PropTypes.bool,
-  is: PropTypes.oneOf(['link', 'button', 'checkbox']),
-  selected: deprecate(PropTypes.bool, 'Use the checkbox component instead'),
-  helpText: PropTypes.string,
-};
-
-function Section({ section }) {
-  const visibleActions = filterByVisible(section).map((action, i) => (
-    <Action key={i} {...action} />
-  ));
-
-  if (!visibleActions.length) {
-    return null;
-  }
-
-  return <StyledSection>{visibleActions}</StyledSection>;
-}
-
-Section.displayName = 'ActionList.Section';
-
-function ActionList(props) {
+const ActionList = React.forwardRef(function ActionList(props, userRef) {
   const {
     actions = [],
     sections = [],
     maxHeight = 'none',
     groupByKey = 'section',
+    children,
     ...rest
   } = props;
 
@@ -105,11 +32,17 @@ function ActionList(props) {
   const listMarkup = list.map((section, index) => <Section section={section} key={index} />);
 
   return (
-    <Wrapper maxHeight={typeof maxHeight === 'number' ? `${maxHeight}px` : maxHeight} {...rest}>
+    <Wrapper
+      maxHeight={typeof maxHeight === 'number' ? `${maxHeight}px` : maxHeight}
+      ref={userRef}
+      tabIndex="-1"
+      {...rest}
+    >
       {listMarkup}
+      {children}
     </Wrapper>
   );
-}
+});
 
 ActionList.displayName = 'ActionList';
 ActionList.propTypes = {
@@ -119,13 +52,17 @@ ActionList.propTypes = {
    *
    * Note: each item can include an optional "section" key that will be used to auto group into sections, declaratively
    */
-  actions: PropTypes.arrayOf(PropTypes.shape({ content: PropTypes.node.isRequired })),
+  actions: deprecate(
+    PropTypes.arrayOf(PropTypes.shape({ content: PropTypes.node.isRequired })),
+    'Use the ActionList.Action component instead',
+  ),
   /**
    * Creates sections
    * e.g. [[{ content: 'action label', onClick: callback() }]]
    */
-  sections: PropTypes.arrayOf(
-    PropTypes.arrayOf(PropTypes.shape({ content: PropTypes.node.isRequired })),
+  sections: deprecate(
+    PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.shape({ content: PropTypes.node.isRequired }))),
+    'Use the ActionList.Section component instead',
   ),
 
   /**
@@ -136,9 +73,12 @@ ActionList.propTypes = {
   /**
    * Group by key used to auto group actions into sections, defaults to "section"
    */
-  groupByKey: PropTypes.string,
+  groupByKey: deprecate(PropTypes.string, 'Use the ActionList.Section component instead'),
+  children: PropTypes.node,
   ...createPropTypes(margin.propNames),
   ...createPropTypes(layout.propNames),
 };
 
+ActionList.Section = Section;
+ActionList.Action = Action;
 export default ActionList;

--- a/packages/matchbox/src/components/ActionList/Section.js
+++ b/packages/matchbox/src/components/ActionList/Section.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Action from './Action';
+import { filterByVisible } from '../../helpers/array';
+
+import { StyledSection } from './styles';
+
+const Section = React.forwardRef(function Section(props, userRef) {
+  const { section, children } = props;
+
+  if (children) {
+    return <StyledSection ref={userRef}>{children}</StyledSection>;
+  }
+
+  const visibleActions = section
+    ? filterByVisible(section).map((action, i) => <Action key={i} {...action} />)
+    : [];
+
+  if (!visibleActions.length) {
+    return null;
+  }
+
+  return <StyledSection ref={userRef}>{visibleActions}</StyledSection>;
+});
+
+Section.displayName = 'ActionList.Section';
+Action.propTypes = {
+  children: PropTypes.node,
+};
+
+export default Section;

--- a/packages/matchbox/src/components/ActionList/tests/ActionList.test.js
+++ b/packages/matchbox/src/components/ActionList/tests/ActionList.test.js
@@ -7,6 +7,73 @@ describe('ActionList', () => {
 
   it('renders actions correctly', () => {
     const wrapper = subject({
+      children: (
+        <>
+          <ActionList.Action>Action</ActionList.Action>
+          <ActionList.Action>Action 2</ActionList.Action>
+        </>
+      ),
+    });
+    expect(
+      wrapper
+        .find('a')
+        .at(0)
+        .text(),
+    ).toEqual('Action');
+  });
+
+  it('renders help text correctly', () => {
+    const wrapper = subject({
+      children: (
+        <>
+          <ActionList.Action helpText="help1">Action</ActionList.Action>
+          <ActionList.Action>Action 2</ActionList.Action>
+        </>
+      ),
+    });
+    expect(
+      wrapper
+        .find('a')
+        .at(0)
+        .text(),
+    ).toEqual('Actionhelp1');
+  });
+
+  it('renders sections correctly', () => {
+    const wrapper = subject({
+      children: (
+        <>
+          <ActionList.Section>
+            <ActionList.Action>Sectioned1</ActionList.Action>
+            <ActionList.Action>Sectioned2</ActionList.Action>
+          </ActionList.Section>
+          <ActionList.Section>
+            <ActionList.Action>Sectioned3</ActionList.Action>
+            <ActionList.Action>Sectioned4</ActionList.Action>
+          </ActionList.Section>
+        </>
+      ),
+    });
+    expect(
+      wrapper
+        .find('div')
+        .at(1)
+        .text(),
+    ).toEqual('Sectioned1Sectioned2');
+    expect(
+      wrapper
+        .find('div')
+        .at(2)
+        .text(),
+    ).toEqual('Sectioned3Sectioned4');
+  });
+});
+
+describe('Legacy ActionList', () => {
+  const subject = props => global.mountStyled(<ActionList {...props} />);
+
+  it('renders actions correctly', () => {
+    const wrapper = subject({
       actions: [{ content: 'Action' }, { content: 'Action 2' }],
     });
     expect(

--- a/packages/matchbox/src/components/ComboBox/ComboBoxMenu.js
+++ b/packages/matchbox/src/components/ComboBox/ComboBoxMenu.js
@@ -20,7 +20,11 @@ function ComboBoxMenu(props) {
     <Box ref={menuRef} {...rest} position="relative" zIndex="overlay">
       <PopoverContent open={isOpen} width="100%">
         {items.length > 0 ? (
-          <ActionList actions={items} maxHeight={maxHeight} />
+          <ActionList maxHeight={maxHeight}>
+            {items.map((action, i) => (
+              <ActionList.Action key={i} {...action} />
+            ))}
+          </ActionList>
         ) : (
           <Box p="200" color="gray.700">
             {emptyMessage}

--- a/packages/matchbox/src/components/Page/Page.js
+++ b/packages/matchbox/src/components/Page/Page.js
@@ -98,7 +98,11 @@ function SecondaryActions({ actions = [], hasPrimaryAction }) {
           </Button>
         }
       >
-        <ActionList actions={visibleActions} />
+        <ActionList>
+          {visibleActions.map((action, i) => (
+            <ActionList.Action key={i} {...action} />
+          ))}
+        </ActionList>
       </Popover>
     </Box>
   );

--- a/packages/matchbox/src/components/Tabs/Tabs.js
+++ b/packages/matchbox/src/components/Tabs/Tabs.js
@@ -142,7 +142,11 @@ const Tabs = React.forwardRef(function Tabs(props, userRef) {
                 </Button>
               }
             >
-              <ActionList actions={tabActions} />
+              <ActionList>
+                {tabActions.map((action, i) => (
+                  <ActionList.Action key={i} {...action} />
+                ))}
+              </ActionList>
             </Popover>
           </Box>
         </Box>

--- a/stories/action/ActionList.stories.js
+++ b/stories/action/ActionList.stories.js
@@ -6,7 +6,30 @@ export default {
   title: 'Action|ActionList',
 };
 
-export const WithinPopovers = withInfo({ propTables: [ActionList] })(() => (
+export const WithinPopovers = withInfo()(() => (
+  <Inline space="15rem">
+    <Popover open trigger={<Button>Actions</Button>} style={{ width: '200px' }}>
+      <ActionList>
+        <ActionList.Action to="#">Action1</ActionList.Action>
+        <ActionList.Action to="#">Action2</ActionList.Action>
+      </ActionList>
+    </Popover>
+    <Popover open trigger={<Button>Sections</Button>} style={{ width: '200px' }}>
+      <ActionList>
+        <ActionList.Section>
+          <ActionList.Action to="#">Sectioned1</ActionList.Action>
+          <ActionList.Action to="#">Testing really really really long text</ActionList.Action>
+        </ActionList.Section>
+        <ActionList.Section>
+          <ActionList.Action to="#">Sectioned3</ActionList.Action>
+          <ActionList.Action to="#">Sectioned4</ActionList.Action>
+        </ActionList.Section>
+      </ActionList>
+    </Popover>
+  </Inline>
+));
+
+export const DeprecatedUsage = withInfo({ propTables: [ActionList] })(() => (
   <Inline space="15rem">
     <Popover open trigger={<Button>Actions</Button>} style={{ width: '200px' }}>
       <ActionList
@@ -87,13 +110,17 @@ export const WithinPopovers = withInfo({ propTables: [ActionList] })(() => (
 export const SelectedActions = withInfo({ propTables: [ActionList] })(() => (
   <Box maxWidth="20rem">
     <Panel>
-      <ActionList
-        actions={[
-          { content: 'Action1', to: '#', selected: true },
-          { content: 'Action2', to: '#', selected: true },
-          { content: 'Action3', to: '#', selected: false },
-        ]}
-      />
+      <ActionList>
+        <ActionList.Action to="#" selected={true}>
+          Action1
+        </ActionList.Action>
+        <ActionList.Action to="#" selected={true}>
+          Action2
+        </ActionList.Action>
+        <ActionList.Action to="#" selected={false}>
+          Action3
+        </ActionList.Action>
+      </ActionList>
     </Panel>
   </Box>
 ));
@@ -101,13 +128,17 @@ export const SelectedActions = withInfo({ propTables: [ActionList] })(() => (
 export const HighlightedActions = withInfo({ propTables: [ActionList] })(() => (
   <Box maxWidth="20rem">
     <Panel>
-      <ActionList
-        actions={[
-          { content: 'Action1', to: '#', highlighted: true },
-          { content: 'Action2', to: '#', highlighted: true },
-          { content: 'Action3', to: '#', selected: false },
-        ]}
-      />
+      <ActionList>
+        <ActionList.Action to="#" highlighted={true}>
+          Action1
+        </ActionList.Action>
+        <ActionList.Action to="#" highlighted={true}>
+          Action2
+        </ActionList.Action>
+        <ActionList.Action to="#" highlighted={false}>
+          Action3
+        </ActionList.Action>
+      </ActionList>
     </Panel>
   </Box>
 ));
@@ -115,13 +146,17 @@ export const HighlightedActions = withInfo({ propTables: [ActionList] })(() => (
 export const WithHelpText = withInfo({ propTables: [ActionList] })(() => (
   <Box maxWidth="20rem">
     <Panel>
-      <ActionList
-        actions={[
-          { content: 'mail.example.com', to: '#', helpText: 'Sending Domain' },
-          { content: 'bobs pizza shop', to: '#', helpText: 'Subaccount' },
-          { content: 'welcome-email-ab-test-12', to: '#', helpText: 'Template' },
-        ]}
-      />
+      <ActionList>
+        <ActionList.Action to="#" helpText="Sending Domain">
+          Action1
+        </ActionList.Action>
+        <ActionList.Action to="#" helpText="Subaccount">
+          Action2
+        </ActionList.Action>
+        <ActionList.Action to="#" helpText="Template">
+          Action3
+        </ActionList.Action>
+      </ActionList>
     </Panel>
   </Box>
 ));
@@ -129,14 +164,26 @@ export const WithHelpText = withInfo({ propTables: [ActionList] })(() => (
 export const AsButtonsAndCheckboxes = withInfo({ propTables: [ActionList] })(() => (
   <Box maxWidth="20rem">
     <Panel>
-      <ActionList
-        actions={[
+      <ActionList>
+        {/* actions={[
           { content: 'Checkbox', selected: true, is: 'checkbox' },
           { content: 'Checkbox', is: 'checkbox' },
           { content: 'Button', selected: false, is: 'button' },
           { content: 'Link', is: 'link', to: '#', external: true },
-        ]}
-      />
+        ]} */}
+        <ActionList.Action to="#" selected={true} is="checkbox">
+          Checkbox
+        </ActionList.Action>
+        <ActionList.Action to="#" selected={false} is="checkbox">
+          Checkbox
+        </ActionList.Action>
+        <ActionList.Action to="#" is="button">
+          Button
+        </ActionList.Action>
+        <ActionList.Action to="#" is="link" external>
+          External Link
+        </ActionList.Action>
+      </ActionList>
     </Panel>
   </Box>
 ));
@@ -144,14 +191,10 @@ export const AsButtonsAndCheckboxes = withInfo({ propTables: [ActionList] })(() 
 export const SystemProps = withInfo({ propTables: [ActionList] })(() => (
   <Box maxWidth="20rem">
     <Panel>
-      <ActionList
-        m="400"
-        width={1 / 2}
-        actions={[
-          { content: 'Action1', to: '#' },
-          { content: 'Action2', to: '#' },
-        ]}
-      />
+      <ActionList m="400" width={1 / 2}>
+        <ActionList.Action to="#">Action1</ActionList.Action>
+        <ActionList.Action to="#">Action2</ActionList.Action>
+      </ActionList>
     </Panel>
   </Box>
 ));

--- a/stories/action/ActionList.stories.js
+++ b/stories/action/ActionList.stories.js
@@ -10,7 +10,9 @@ export const WithinPopovers = withInfo()(() => (
   <Inline space="15rem">
     <Popover open trigger={<Button>Actions</Button>} style={{ width: '200px' }}>
       <ActionList>
-        <ActionList.Action to="#">Action1</ActionList.Action>
+        <ActionList.Action to="#" helpText="help text">
+          Action1
+        </ActionList.Action>
         <ActionList.Action to="#">Action2</ActionList.Action>
       </ActionList>
     </Popover>


### PR DESCRIPTION
### What Changed
- Adds `ActionList.Action` and `ActionList.Section` components
- Updates components that use `ActionList`
<!--
What changes does this PR propose?
Provide screenshots or [screen recordings](https://getkap.co/) for any visual changes.
-->

### How To Test or Verify

- Verify old usage still works here: http://localhost:9001/?path=/story/action-actionlist--deprecated-usage
- Verify new usage works: http://localhost:9001/?path=/story/action-actionlist--within-popovers

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
