### PR TITLE
UX-318 Remove RadioCard.Group disabled prop

### DIFF
--- a/packages/matchbox/src/components/RadioCard/Group.js
+++ b/packages/matchbox/src/components/RadioCard/Group.js
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 import { margin } from 'styled-system';
 import { createPropTypes } from '@styled-system/prop-types';
 import { getChild } from '../../helpers/children';
-import { Box } from '../Box';
 import { Columns } from '../Columns';
 import { Column } from '../Column';
 import { Label } from '../Label';
@@ -25,7 +24,6 @@ const Group = React.forwardRef(function Group(props, userRef) {
   const {
     children,
     collapseBelow,
-    disabled,
     id,
     label,
     labelHidden,
@@ -35,7 +33,7 @@ const Group = React.forwardRef(function Group(props, userRef) {
     ...rest
   } = props;
 
-  const items = getChild('RadioCard', children, { disabled, weight });
+  const items = getChild('RadioCard', children, { weight });
   const systemProps = pick(rest, margin.propNames);
 
   return (
@@ -68,7 +66,6 @@ Group.displayName = 'RadioCard.Group';
 Group.propTypes = {
   collapseBelow: PropTypes.oneOf(breakpoints),
   'data-id': PropTypes.string,
-  disabled: PropTypes.bool,
   label: PropTypes.string.isRequired,
   labelHidden: PropTypes.bool,
   optional: PropTypes.bool,

--- a/packages/matchbox/src/components/RadioCard/tests/RadioCard.test.js
+++ b/packages/matchbox/src/components/RadioCard/tests/RadioCard.test.js
@@ -73,4 +73,35 @@ describe('RadioCard', () => {
     global.mountStyled(<Test />);
     expect(document.activeElement.id).toEqual('test-card');
   });
+
+  describe('Group', () => {
+    it('renders disabled in a group', () => {
+      const wrapper = global.mountStyled(
+        <RadioCard.Group label="label">
+          <RadioCard id="test-id1" disabled />
+          <RadioCard id="test-id2" />
+        </RadioCard.Group>,
+      );
+      expect(wrapper.find('input').at(0)).toBeDisabled();
+      expect(wrapper.find('input').at(1)).not.toBeDisabled();
+    });
+
+    it('renders an optional and label', () => {
+      const wrapper = global.mountStyled(
+        <RadioCard.Group label="label" optional>
+          <RadioCard id="test-id" />
+        </RadioCard.Group>,
+      );
+      expect(wrapper.text()).toEqual('labelOptional');
+    });
+
+    it('renders an horizontal orientation', () => {
+      const wrapper = global.mountStyled(
+        <RadioCard.Group label="label" orientation="horizontal">
+          <RadioCard id="test-id" />
+        </RadioCard.Group>,
+      );
+      expect(wrapper.find('#test-id')).toExist();
+    });
+  });
 });

--- a/stories/form/RadioCard.stories.js
+++ b/stories/form/RadioCard.stories.js
@@ -10,12 +10,15 @@ export const HeavyWeight = withInfo()(() => <RadioCard id="id1" label="Check Me"
 export const LightWeight = withInfo()(() => <RadioCard id="id1" label="Check Me" weight="light" />);
 
 export const DisabledRadio = withInfo()(() => (
-  <RadioCard.Group label="Radio Card Group" disabled>
+  <RadioCard.Group label="Radio Card Group">
     <RadioCard id="id1" label="Check Me 1" disabled>
-      I am help text
+      This one is disabled
     </RadioCard>
-    <RadioCard id="id1" label="Check Me 2" disabled defaultChecked>
-      I am help text
+    <RadioCard id="id2" label="Check Me 2" disabled defaultChecked>
+      This one is disabled
+    </RadioCard>
+    <RadioCard id="id3" label="Check Me 3">
+      This one is not disabled
     </RadioCard>
   </RadioCard.Group>
 ));


### PR DESCRIPTION
### What Changed
- Removes the `RadioCard.Group` disabled prop - It didn't match the `Radio` components `disabled` behavior
- Fixes a bug where the `Group`s `disabled` prop was overwriting the children's

### How To Test or Verify
- Run storybook with `npm run start:storybook`
- Visit: http://localhost:9001/?path=/story/form-radiocard--disabled-radio
- Verify the first two radio cards are disabled

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
