### PR TITLE
UX-324 Page and Actionlist actions render with null actions

### DIFF
--- a/packages/matchbox/src/components/ActionList/ActionList.js
+++ b/packages/matchbox/src/components/ActionList/ActionList.js
@@ -24,8 +24,8 @@ const ActionList = React.forwardRef(function ActionList(props, userRef) {
     ...rest
   } = props;
 
-  let list = actions.length ? groupByValues(actions, groupByKey) : [];
-  if (sections.length) {
+  let list = actions && actions.length ? groupByValues(actions, groupByKey) : [];
+  if (sections && sections.length) {
     list = list.concat(sections);
   }
 

--- a/packages/matchbox/src/helpers/array.js
+++ b/packages/matchbox/src/helpers/array.js
@@ -15,10 +15,11 @@
  *   2: [ { name: 'b', section: 2 } ]
  * }
  */
-export const groupBy = (list, groupingKey) => list.reduce((acc, item) => {
-  const index = item[groupingKey];
-  return { ...acc, [index]: [ ...(acc[index] || []), item ]};
-}, {});
+export const groupBy = (list, groupingKey) =>
+  list.reduce((acc, item) => {
+    const index = item[groupingKey];
+    return { ...acc, [index]: [...(acc[index] || []), item] };
+  }, {});
 
 export const groupByValues = (list, groupingKey) => Object.values(groupBy(list, groupingKey));
 
@@ -32,9 +33,15 @@ export const groupByValues = (list, groupingKey) => Object.values(groupBy(list, 
  * // returns
  * [{ name: 'a' }, { name: 'c' }]
  */
-export const filterByVisible = (actions) => actions.reduce((acc, { visible = true, ...action }) => {
-  if (visible) {
-    acc.push(action);
+export const filterByVisible = actions => {
+  if (!actions) {
+    return [];
   }
-  return acc;
-}, []);
+
+  return actions.reduce((acc, { visible = true, ...action }) => {
+    if (visible) {
+      acc.push(action);
+    }
+    return acc;
+  }, []);
+};

--- a/packages/matchbox/src/helpers/tests/array.test.js
+++ b/packages/matchbox/src/helpers/tests/array.test.js
@@ -1,32 +1,30 @@
 import { groupBy, groupByValues, filterByVisible } from '../array';
 
 describe('Helper: Array helpers', () => {
-
   let list;
 
   beforeEach(() => {
     list = [
       {
         name: 'a',
-        section: 1
+        section: 1,
       },
       {
         name: 'b',
-        section: 4
+        section: 4,
       },
       {
         name: 'c',
-        section: 1
+        section: 1,
       },
       {
         name: 'd',
-        section: 'mixed whoa'
-      }
+        section: 'mixed whoa',
+      },
     ];
   });
 
   describe('groupBy', () => {
-
     it('should group a list by a given key', () => {
       expect(groupBy(list, 'section')).toMatchSnapshot();
     });
@@ -44,25 +42,29 @@ describe('Helper: Array helpers', () => {
       expect(Object.keys(grouped)).toHaveLength(1);
       expect(grouped).toMatchSnapshot();
     });
-
   });
 
   describe('groupByValues', () => {
-
     it('should return a grouped array', () => {
       expect(groupByValues(list, 'section')).toMatchSnapshot();
     });
-
   });
 
   describe('filterByVisible', () => {
     it('should return only visible actions', () => {
-      expect(filterByVisible([
-        { content: '1' },
-        { content: '2', visible: true },
-        { content: '3', visible: false }
-      ])).toMatchSnapshot();
+      expect(
+        filterByVisible([
+          { content: '1' },
+          { content: '2', visible: true },
+          { content: '3', visible: false },
+        ]),
+      ).toMatchSnapshot();
+    });
+
+    it('should fail gracefully', () => {
+      expect(filterByVisible(null)).toEqual([]);
+      expect(filterByVisible(undefined)).toEqual([]);
+      expect(filterByVisible()).toEqual([]);
     });
   });
-
 });


### PR DESCRIPTION
### What Changed
- Allows the `filterByVisible` function to fail gracefully by returning an empty array

### How To Test or Verify
- Run storybook
- Visit page stories: http://localhost:9001/?path=/story/layout-page--basic-example
- Try to add `null` or `undefined` into `secondaryActions`
- Do the same with actions here: http://localhost:9001/?path=/story/action-actionlist--deprecated-usage

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
