### PR TITLE
Issue-608 Add motion to theme

### DIFF
--- a/packages/matchbox/src/components/ThemeProvider/theme.js
+++ b/packages/matchbox/src/components/ThemeProvider/theme.js
@@ -238,6 +238,19 @@ const theme = {
     default: tokens.zIndex_default,
     overlay: tokens.zIndex_overlay,
   },
+
+  motion: {
+    duration: {
+      fast: tokens.motionDuration_fast,
+      medium: tokens.motionDuration_medium,
+      slow: tokens.motionDuration_slow,
+    },
+    ease: {
+      in: tokens.motionEase_in,
+      out: tokens.motionEase_out,
+      inOut: tokens.motionEase_in_out,
+    },
+  },
 };
 
 export default theme;

--- a/site/src/components/SystemProps/data.js
+++ b/site/src/components/SystemProps/data.js
@@ -156,5 +156,18 @@ export const propData = {
   borders: {
     '400': '${borderWidth_100} solid ${color_gray_400}', // eslint-disable-line no-template-curly-in-string
     '500': '${borderWidth_200} solid ${color_gray_400}' // eslint-disable-line no-template-curly-in-string
+  },
+  zIndices: {
+    below: 'zIndex_below',
+    default: 'zIndex_default',
+    overlay: 'zIndex_overlay'
+  },
+  motion: {
+    'duration.fast': 'motionDuration_fast',
+    'duration.me': 'motionDuration_medium',
+    'duration._slow': 'motionDuration_slow',
+    'ease.in': 'motionEase_in',
+    'ease.out': 'motionEase_out',
+    'ease.inOut': 'motionEase_in_out'
   }
 };

--- a/site/src/components/SystemProps/data.js
+++ b/site/src/components/SystemProps/data.js
@@ -164,8 +164,8 @@ export const propData = {
   },
   motion: {
     'duration.fast': 'motionDuration_fast',
-    'duration.me': 'motionDuration_medium',
-    'duration._slow': 'motionDuration_slow',
+    'duration.medium': 'motionDuration_medium',
+    'duration.slow': 'motionDuration_slow',
     'ease.in': 'motionEase_in',
     'ease.out': 'motionEase_out',
     'ease.inOut': 'motionEase_in_out'

--- a/site/src/pages/components/system-props.mdx
+++ b/site/src/pages/components/system-props.mdx
@@ -63,6 +63,12 @@ Theme Reference:
   <Box as="li">
     <Link to="/components/system-props#breakpoints">Breakpoints</Link>
   </Box>
+  <Box as="li">
+    <Link to="/components/system-props#z-index">Z Index</Link>
+  </Box>
+  <Box as="li">
+    <Link to="/components/system-props#motion">Motion</Link>
+  </Box>
 </Box>
 
 <Box my="800"></Box>
@@ -166,3 +172,11 @@ Theme Reference:
 ```
 
 <SystemPropsTable theme="breakpoints" />
+
+##### Z Index
+
+<SystemPropsTable theme="zIndices" />
+
+##### Motion
+
+<SystemPropsTable theme="motion" />


### PR DESCRIPTION
Closes #608 

### What Changed

- Adds `motion` tokens to the styled-system theme file
- Updates the site documentation to include both motion and zindices

### How To Test or Verify
- Run storybook
- Verify motion is included in the theme by accessing `props.theme` from any component under `ThemeProvider`

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
