### PR TITLE
Issue 617 Set Modal.Content overflow-y to auto

### DIFF
--- a/packages/matchbox/src/components/Modal/Content.js
+++ b/packages/matchbox/src/components/Modal/Content.js
@@ -7,7 +7,7 @@ const Content = React.forwardRef(function Content(props, ref) {
   const { children } = props;
 
   return (
-    <Box data-id="modal-content" p="500" maxHeight="60vh" overflowY="scroll" ref={ref}>
+    <Box data-id="modal-content" p="500" maxHeight="60vh" overflowY="auto" ref={ref}>
       {children}
     </Box>
   );


### PR DESCRIPTION
Closes #617 

### What Changed
- Sets Modal.Content `overflowY` to `auto` instead of `scroll`
- this allows short modals to hide the scrollbar

### How To Test or Verify
- Visit: http://localhost:9001/?path=/story/overlays-modal--toggle-example
- Verify no scrollbar is visible when OS system preference are set to 'Always show scrollbars'
- Also verify the Tall modal example is still scrollable

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
