### PR TITLE
Resolves #625 - Add support for the className prop for the Column component

### DIFF
--- a/packages/matchbox/src/components/Column/Column.js
+++ b/packages/matchbox/src/components/Column/Column.js
@@ -14,7 +14,7 @@ const StyledColumn = styled(Box)`
 `;
 
 const Column = React.forwardRef(function Column(props, ref) {
-  const { width, children } = props;
+  const { width, children, className } = props;
   const { space, collapsed } = React.useContext(ColumnsContext);
 
   let columnWidth = width;
@@ -29,6 +29,7 @@ const Column = React.forwardRef(function Column(props, ref) {
 
   return (
     <StyledColumn
+      className={className}
       width={columnWidth}
       flex={!width && !collapsed ? '1' : ''}
       pt={collapsed ? space : null}
@@ -46,6 +47,7 @@ Column.displayName = 'Column';
 Column.propTypes = {
   children: PropTypes.node,
   width: PropTypes.oneOfType([PropTypes.oneOf(['content']), PropTypes.number]),
+  className: PropTypes.string,
 };
 
 export default Column;

--- a/packages/matchbox/src/components/Column/Column.js
+++ b/packages/matchbox/src/components/Column/Column.js
@@ -1,11 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { display } from 'styled-system';
+import { createPropTypes } from '@styled-system/prop-types';
 import { ColumnsContext } from '../Columns/context';
 import styled from 'styled-components';
 import { Box } from '../Box';
 import { gutter } from './styles';
 
 const StyledColumn = styled(Box)`
+  ${display}
   ${gutter}
 
   &:first-child {
@@ -14,7 +17,7 @@ const StyledColumn = styled(Box)`
 `;
 
 const Column = React.forwardRef(function Column(props, ref) {
-  const { width, children, className } = props;
+  const { width, children, className, display } = props;
   const { space, collapsed } = React.useContext(ColumnsContext);
 
   let columnWidth = width;
@@ -29,6 +32,7 @@ const Column = React.forwardRef(function Column(props, ref) {
 
   return (
     <StyledColumn
+      display={display}
       className={className}
       width={columnWidth}
       flex={!width && !collapsed ? '1' : ''}
@@ -48,6 +52,7 @@ Column.propTypes = {
   children: PropTypes.node,
   width: PropTypes.oneOfType([PropTypes.oneOf(['content']), PropTypes.number]),
   className: PropTypes.string,
+  ...createPropTypes(display.propNames),
 };
 
 export default Column;

--- a/packages/matchbox/src/components/Column/tests/Column.test.js
+++ b/packages/matchbox/src/components/Column/tests/Column.test.js
@@ -54,4 +54,10 @@ describe('Columns', () => {
     expect(wrapper.find('div').at(3)).toHaveStyleRule('width', `${100 * (2 / 6)}%`);
     expect(wrapper.find('div').at(4)).toHaveStyleRule('width', `${100 * (3 / 6)}%`);
   });
+
+  it('accepts a passed in className', () => {
+    const wrapper = subject({ className: 'foo' });
+
+    expect(wrapper.find('.foo')).toExist();
+  });
 });

--- a/packages/matchbox/src/components/Column/tests/Column.test.js
+++ b/packages/matchbox/src/components/Column/tests/Column.test.js
@@ -60,4 +60,14 @@ describe('Columns', () => {
 
     expect(wrapper.find('.foo')).toExist();
   });
+
+  it('accepts passed the passed in `display` prop', () => {
+    const wrapper = global.mountStyled(
+      <Columns>
+        <Column display="none" />
+      </Columns>,
+    );
+
+    expect(wrapper.find('div').at(2)).toHaveStyleRule('display', 'none');
+  });
 });


### PR DESCRIPTION
Resolves #625 

### What Changed

- `className` accepted as a prop for the `<Column/>` component

### How To Test or Verify

- On the Storybook site, try:
```js
<Box as={Column} display="none">I am invisible!</Box>
```

### PR Checklist

- [ ] Incorporate feedback
