### PR TITLE
Issue 630 - Forward refs to Radio, Checkbox, Textfield and Select

### DIFF
--- a/packages/matchbox/src/components/Checkbox/Checkbox.js
+++ b/packages/matchbox/src/components/Checkbox/Checkbox.js
@@ -20,7 +20,7 @@ import {
   Wrapper,
 } from './styles';
 
-function Checkbox(props) {
+const Checkbox = React.forwardRef(function Checkbox(props, userRef) {
   const {
     id,
     checked,
@@ -66,6 +66,7 @@ function Checkbox(props) {
           type="checkbox"
           required={required}
           error={error}
+          ref={userRef}
           {...indeterminateAttributes}
           {...describedBy}
           {...componentProps}
@@ -123,7 +124,7 @@ function Checkbox(props) {
       )}
     </Wrapper>
   );
-}
+});
 
 Checkbox.displayName = 'Checkbox';
 Checkbox.Group = Group;

--- a/packages/matchbox/src/components/Checkbox/tests/Checkbox.test.js
+++ b/packages/matchbox/src/components/Checkbox/tests/Checkbox.test.js
@@ -80,4 +80,20 @@ describe('Checkbox', () => {
     expect(events.onBlur).toHaveBeenCalled();
     expect(events.onFocus).toHaveBeenCalled();
   });
+
+  it('renders with with a ref', () => {
+    function Test() {
+      const ref = React.useRef();
+      React.useEffect(() => {
+        ref.current.focus();
+      }, []);
+      return (
+        <>
+          <Checkbox ref={ref} id="test-checkbox"></Checkbox>
+        </>
+      );
+    }
+    global.mountStyled(<Test />);
+    expect(document.activeElement.id).toEqual('test-checkbox');
+  });
 });

--- a/packages/matchbox/src/components/Radio/Radio.js
+++ b/packages/matchbox/src/components/Radio/Radio.js
@@ -13,7 +13,7 @@ import { margin } from 'styled-system';
 import Group from './Group';
 import { Wrapper, StyledLabel, StyledInput, StyledChecked, StyledUnchecked } from './styles';
 
-function Radio(props) {
+const Radio = React.forwardRef(function Radio(props, userRef) {
   const {
     id,
     name,
@@ -53,6 +53,7 @@ function Radio(props) {
           onBlur={onBlur}
           type="radio"
           error={error}
+          ref={userRef}
           {...describedBy}
           {...componentProps}
         />
@@ -85,7 +86,7 @@ function Radio(props) {
       )}
     </Wrapper>
   );
-}
+});
 
 Radio.displayName = 'Radio';
 

--- a/packages/matchbox/src/components/Radio/tests/Radio.test.js
+++ b/packages/matchbox/src/components/Radio/tests/Radio.test.js
@@ -87,4 +87,20 @@ describe('Radio', () => {
     expect(events.onBlur).toHaveBeenCalled();
     expect(events.onFocus).toHaveBeenCalled();
   });
+
+  it('renders with with a ref', () => {
+    function Test() {
+      const ref = React.useRef();
+      React.useEffect(() => {
+        ref.current.focus();
+      }, []);
+      return (
+        <>
+          <Radio ref={ref} id="test-radio"></Radio>
+        </>
+      );
+    }
+    global.mountStyled(<Test />);
+    expect(document.activeElement.id).toEqual('test-radio');
+  });
 });

--- a/packages/matchbox/src/components/Select/Select.js
+++ b/packages/matchbox/src/components/Select/Select.js
@@ -57,7 +57,7 @@ const StyledInput = styled(Box)`
   outline: none;
 `;
 
-const SelectBox = props => {
+const SelectBox = React.forwardRef(function SelectBox(props, userRef) {
   return (
     <StyledInputWrapper>
       <StyledInput
@@ -73,10 +73,11 @@ const SelectBox = props => {
         height="2.5rem"
         color="gray.900"
         {...props}
+        ref={userRef}
       />
     </StyledInputWrapper>
   );
-};
+});
 
 const system = compose(margin, maxWidth);
 
@@ -92,7 +93,7 @@ const StyledWrapper = styled('div')`
   ${system}
 `;
 
-function Select(props) {
+const Select = React.forwardRef(function Select(props, userRef) {
   const {
     id,
     options,
@@ -149,6 +150,7 @@ function Select(props) {
           hasError={!!error}
           {...componentProps}
           {...describedBy}
+          ref={userRef}
         >
           <Options
             options={options}
@@ -162,7 +164,7 @@ function Select(props) {
       {helpMarkup}
     </StyledWrapper>
   );
-}
+});
 
 Select.displayName = 'Select';
 Select.propTypes = {

--- a/packages/matchbox/src/components/Select/tests/Select.test.js
+++ b/packages/matchbox/src/components/Select/tests/Select.test.js
@@ -122,4 +122,20 @@ describe('Select', () => {
     expect(events.onBlur).toHaveBeenCalled();
     expect(events.onFocus).toHaveBeenCalled();
   });
+
+  it('renders with with a ref', () => {
+    function Test() {
+      const ref = React.useRef();
+      React.useEffect(() => {
+        ref.current.focus();
+      }, []);
+      return (
+        <>
+          <Select ref={ref} id="test-select" options={[]}></Select>
+        </>
+      );
+    }
+    global.mountStyled(<Test />);
+    expect(document.activeElement.id).toEqual('test-select');
+  });
 });

--- a/packages/matchbox/src/components/TextField/TextField.js
+++ b/packages/matchbox/src/components/TextField/TextField.js
@@ -29,7 +29,7 @@ const StyledInput = styled(Box)`
   outline: none;
 `;
 
-const FieldBox = props => {
+const FieldBox = React.forwardRef(function FieldBox(props, userRef) {
   return (
     <StyledInputWrapper>
       <StyledInput
@@ -46,10 +46,11 @@ const FieldBox = props => {
         lineHeight={props.lineHeight}
         py={props.py}
         required={props.required}
+        ref={userRef}
       />
     </StyledInputWrapper>
   );
-};
+});
 
 function PrefixOrSuffix({ content, className, forwardedRef, ...rest }) {
   if (!content) {
@@ -73,7 +74,7 @@ function PrefixOrSuffix({ content, className, forwardedRef, ...rest }) {
   );
 }
 
-function TextField(props) {
+const TextField = React.forwardRef(function TextField(props, userRef) {
   const {
     align,
     autoFocus,
@@ -175,7 +176,7 @@ function TextField(props) {
             forwardedRef={prefixRef}
             left="300"
           />
-          <FieldBox {...inputProps} />
+          <FieldBox ref={userRef} {...inputProps} />
           <PrefixOrSuffix
             content={suffix}
             className={suffixClassname}
@@ -188,7 +189,7 @@ function TextField(props) {
       {helpText && <HelpText id={helpTextId}>{helpText}</HelpText>}
     </StyledWrapper>
   );
-}
+});
 
 TextField.displayName = 'TextField';
 TextField.propTypes = {

--- a/packages/matchbox/src/components/TextField/tests/TextField.test.js
+++ b/packages/matchbox/src/components/TextField/tests/TextField.test.js
@@ -143,4 +143,20 @@ describe('TextField', () => {
     expect(events.onBlur).toHaveBeenCalledTimes(1);
     expect(events.onFocus).toHaveBeenCalledTimes(1);
   });
+
+  it('renders with with a ref', () => {
+    function Test() {
+      const ref = React.useRef();
+      React.useEffect(() => {
+        ref.current.focus();
+      }, []);
+      return (
+        <>
+          <TextField ref={ref} id="test-field"></TextField>
+        </>
+      );
+    }
+    global.mountStyled(<Test />);
+    expect(document.activeElement.id).toEqual('test-field');
+  });
 });


### PR DESCRIPTION
Resolves #630 

### What Changed
- Adds `React.forwardRef` to `Radio` `Checkbox` `Textfield` and `Select` to allow refs to pass through.

### How To Test or Verify
- Run storybook, and verify refs can be passed through

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
