### PR TITLE
UX-329 match Select text styles to Button

### DIFF
--- a/packages/matchbox/src/components/Select/styles.js
+++ b/packages/matchbox/src/components/Select/styles.js
@@ -2,6 +2,8 @@ import { tokens } from '@sparkpost/design-tokens';
 
 export const select = props => `
   appearance: none;
+  font-weight: ${tokens.fontWeight_medium};
+  font-size: ${tokens.fontSize_200};
   &:hover {
     cursor: ${props.disabled ? 'not-allowed;' : 'pointer;'}
   }


### PR DESCRIPTION
### What Changed

- Updates Select text styles to match Button

### How To Test or Verify

- `npm run start:storybook`
- Verify Select stories

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
