### PR TITLE
UX-334 Support grid orientation & Allow non RadioCard children

### DIFF
--- a/cypress/integration/RadioCard.spec.js
+++ b/cypress/integration/RadioCard.spec.js
@@ -3,7 +3,7 @@
 describe('The RadioCard component', () => {
   describe('Basic', () => {
     beforeEach(() => {
-      cy.visit('/iframe.html?path=/story/form-radiocard--light-vertical-group');
+      cy.visit('/iframe.html?path=/story/form-radiocard--vertical-group');
     });
 
     it('selects on click', () => {

--- a/packages/matchbox/src/components/RadioCard/Group.js
+++ b/packages/matchbox/src/components/RadioCard/Group.js
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { margin } from 'styled-system';
 import { createPropTypes } from '@styled-system/prop-types';
 import { getChild } from '../../helpers/children';
+import { Box } from '../Box';
 import { Columns } from '../Columns';
 import { Column } from '../Column';
 import { Label } from '../Label';
@@ -57,6 +58,14 @@ const Group = React.forwardRef(function Group(props, userRef) {
           ))}
         </Stack>
       )}
+
+      {orientation === 'grid' && (
+        <Box display="grid" gridTemplateColumns={['1fr', null, '1fr 1fr']} gridGap="300">
+          {items.map((item, i) => (
+            <div key={i}>{item}</div>
+          ))}
+        </Box>
+      )}
     </Fieldset>
   );
 });
@@ -69,7 +78,7 @@ Group.propTypes = {
   label: PropTypes.string.isRequired,
   labelHidden: PropTypes.bool,
   optional: PropTypes.bool,
-  orientation: PropTypes.oneOf(['horizontal', 'vertical']),
+  orientation: PropTypes.oneOf(['horizontal', 'vertical', 'grid']),
   weight: PropTypes.oneOf(['light', 'heavy']),
   ...createPropTypes(margin.propNames),
 };

--- a/packages/matchbox/src/components/RadioCard/Group.js
+++ b/packages/matchbox/src/components/RadioCard/Group.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { margin } from 'styled-system';
 import { createPropTypes } from '@styled-system/prop-types';
-import { getChild } from '../../helpers/children';
 import { Box } from '../Box';
 import { Columns } from '../Columns';
 import { Column } from '../Column';
@@ -24,7 +23,7 @@ const breakpoints = ['xs', 'sm', 'md', 'lg', 'xl'];
 const Group = React.forwardRef(function Group(props, userRef) {
   const { children, collapseBelow, id, label, labelHidden, orientation, optional, ...rest } = props;
 
-  const items = getChild('RadioCard', children);
+  const items = React.Children.toArray(children);
   const systemProps = pick(rest, margin.propNames);
 
   return (

--- a/packages/matchbox/src/components/RadioCard/Group.js
+++ b/packages/matchbox/src/components/RadioCard/Group.js
@@ -22,19 +22,9 @@ const Fieldset = styled.fieldset`
 const breakpoints = ['xs', 'sm', 'md', 'lg', 'xl'];
 
 const Group = React.forwardRef(function Group(props, userRef) {
-  const {
-    children,
-    collapseBelow,
-    id,
-    label,
-    labelHidden,
-    orientation,
-    optional,
-    weight,
-    ...rest
-  } = props;
+  const { children, collapseBelow, id, label, labelHidden, orientation, optional, ...rest } = props;
 
-  const items = getChild('RadioCard', children, { weight });
+  const items = getChild('RadioCard', children);
   const systemProps = pick(rest, margin.propNames);
 
   return (
@@ -79,13 +69,11 @@ Group.propTypes = {
   labelHidden: PropTypes.bool,
   optional: PropTypes.bool,
   orientation: PropTypes.oneOf(['horizontal', 'vertical', 'grid']),
-  weight: PropTypes.oneOf(['light', 'heavy']),
   ...createPropTypes(margin.propNames),
 };
 
 Group.defaultProps = {
   orientation: 'vertical',
-  weight: 'light',
 };
 
 export default Group;

--- a/packages/matchbox/src/components/RadioCard/RadioCard.js
+++ b/packages/matchbox/src/components/RadioCard/RadioCard.js
@@ -18,7 +18,7 @@ const RadioCard = React.forwardRef(function RadioCard(props, userRef) {
     onFocus,
     onBlur,
     value,
-    weight,
+    weight = 'light',
     ...rest
   } = props;
 

--- a/packages/matchbox/src/components/RadioCard/tests/RadioCard.test.js
+++ b/packages/matchbox/src/components/RadioCard/tests/RadioCard.test.js
@@ -103,5 +103,14 @@ describe('RadioCard', () => {
       );
       expect(wrapper.find('#test-id')).toExist();
     });
+
+    it('renders a grid orientation', () => {
+      const wrapper = global.mountStyled(
+        <RadioCard.Group label="label" orientation="grid">
+          <RadioCard id="test-id" />
+        </RadioCard.Group>,
+      );
+      expect(wrapper.find('#test-id')).toExist();
+    });
   });
 });

--- a/site/src/pages/components/radiocard.mdx
+++ b/site/src/pages/components/radiocard.mdx
@@ -51,12 +51,32 @@ Use this component to group options that are mutually exclusive.
         collapseBelow="md"
         label="Radio Card Group"
         orientation="horizontal"
-        weight="light"
       >
         <RadioCard id="id1" label="Check Me 1" name="group" defaultChecked>
           I am help text
         </RadioCard>
         <RadioCard id="id2" label="Check Me 2" name="group">
+          I am help text
+        </RadioCard>
+      </RadioCard.Group>`}
+  />
+  <LiveCode.Content
+    title="Grid Group"
+    code={`
+      <RadioCard.Group
+        label="Radio Card Group"
+        orientation="grid"
+      >
+        <RadioCard id="id1" label="Check Me 1" name="group" defaultChecked>
+          I am help text
+        </RadioCard>
+        <RadioCard id="id2" label="Check Me 2" name="group">
+          I am help text
+        </RadioCard>
+        <RadioCard id="id3" label="Check Me 3" name="group">
+          I am help text
+        </RadioCard>
+        <RadioCard id="id4" label="Check Me 4" name="group">
           I am help text
         </RadioCard>
       </RadioCard.Group>`}

--- a/site/src/pages/components/radiocard.mdx
+++ b/site/src/pages/components/radiocard.mdx
@@ -113,18 +113,10 @@ Use this component to group options that are mutually exclusive.
 <Prop
   name="orientation"
   type="string"
-  values={['"vertical"', '"horizontal"']}
+  values={['"vertical"', '"horizontal"', '"grid"']}
   defaultValue='"vertical"'
 >
   Orientation of the child cards
-</Prop>
-<Prop
-  name="weight"
-  type="string"
-  values={['"light"', '"heavy"']}
-  defaultValue='"light"'
->
-  Visual weight of the child cards
 </Prop>
 
 ---
@@ -173,4 +165,12 @@ None
 
 <Prop name="value" type="string">
   Value for the form input
+</Prop>
+<Prop
+  name="weight"
+  type="string"
+  values={['"light"', '"heavy"']}
+  defaultValue='"light"'
+>
+  Visual weight of the child cards
 </Prop>

--- a/stories/form/RadioCard.stories.js
+++ b/stories/form/RadioCard.stories.js
@@ -38,7 +38,7 @@ export const VerticalGroup = withInfo()(() => (
 ));
 
 export const GridOrientationGroup = withInfo()(() => (
-  <RadioCard.Group collapseBelow="sm" label="Radio Card Group" orientation="grid">
+  <RadioCard.Group label="Radio Card Group" orientation="grid">
     <RadioCard id="id1" label="Check Me 1" name="group" defaultChecked>
       I am help text
     </RadioCard>

--- a/stories/form/RadioCard.stories.js
+++ b/stories/form/RadioCard.stories.js
@@ -23,8 +23,8 @@ export const DisabledRadio = withInfo()(() => (
   </RadioCard.Group>
 ));
 
-export const LightVerticalGroup = withInfo()(() => (
-  <RadioCard.Group label="Radio Card Group" weight="light">
+export const VerticalGroup = withInfo()(() => (
+  <RadioCard.Group label="Radio Card Group">
     <RadioCard id="id1" label="Check Me 1" name="group" defaultChecked>
       I am help text
     </RadioCard>
@@ -38,7 +38,7 @@ export const LightVerticalGroup = withInfo()(() => (
 ));
 
 export const GridOrientationGroup = withInfo()(() => (
-  <RadioCard.Group collapseBelow="sm" label="Radio Card Group" orientation="grid" weight="heavy">
+  <RadioCard.Group collapseBelow="sm" label="Radio Card Group" orientation="grid">
     <RadioCard id="id1" label="Check Me 1" name="group" defaultChecked>
       I am help text
     </RadioCard>
@@ -54,13 +54,8 @@ export const GridOrientationGroup = withInfo()(() => (
   </RadioCard.Group>
 ));
 
-export const HeavyCollapsingHorizontalGroup = withInfo()(() => (
-  <RadioCard.Group
-    collapseBelow="sm"
-    label="Radio Card Group"
-    orientation="horizontal"
-    weight="heavy"
-  >
+export const CollapsingHorizontalGroup = withInfo()(() => (
+  <RadioCard.Group collapseBelow="sm" label="Radio Card Group" orientation="horizontal">
     <RadioCard id="id1" label="Check Me 1" name="group" defaultChecked>
       I am help text
     </RadioCard>
@@ -71,7 +66,7 @@ export const HeavyCollapsingHorizontalGroup = withInfo()(() => (
 ));
 
 export const GroupWithHiddenLabel = withInfo()(() => (
-  <RadioCard.Group label="Radio Card Group" weight="light" labelHidden>
+  <RadioCard.Group label="Radio Card Group" labelHidden>
     <RadioCard id="id1" label="Check Me 1" name="group" defaultChecked>
       I am help text
     </RadioCard>
@@ -85,7 +80,7 @@ export const GroupWithHiddenLabel = withInfo()(() => (
 ));
 
 export const GroupWithOptionalLabel = withInfo()(() => (
-  <RadioCard.Group label="Radio Card Group" weight="light" optional>
+  <RadioCard.Group label="Radio Card Group" optional>
     <RadioCard id="id1" label="Check Me 1" name="group" defaultChecked>
       I am help text
     </RadioCard>
@@ -99,7 +94,7 @@ export const GroupWithOptionalLabel = withInfo()(() => (
 ));
 
 export const GroupWithSystemProps = withInfo()(() => (
-  <RadioCard.Group label="Radio Card Group" weight="light" my="500" mx="700">
+  <RadioCard.Group label="Radio Card Group" my="500" mx="700">
     <RadioCard id="id1" label="Check Me 1" name="group" defaultChecked>
       I am help text
     </RadioCard>

--- a/stories/form/RadioCard.stories.js
+++ b/stories/form/RadioCard.stories.js
@@ -37,6 +37,23 @@ export const LightVerticalGroup = withInfo()(() => (
   </RadioCard.Group>
 ));
 
+export const GridOrientationGroup = withInfo()(() => (
+  <RadioCard.Group collapseBelow="sm" label="Radio Card Group" orientation="grid" weight="heavy">
+    <RadioCard id="id1" label="Check Me 1" name="group" defaultChecked>
+      I am help text
+    </RadioCard>
+    <RadioCard id="id2" label="Check Me 2" name="group">
+      I am help text
+    </RadioCard>
+    <RadioCard id="id3" label="Check Me 3" name="group" defaultChecked>
+      I am help text
+    </RadioCard>
+    <RadioCard id="id4" label="Check Me 4" name="group">
+      I am help text
+    </RadioCard>
+  </RadioCard.Group>
+));
+
 export const HeavyCollapsingHorizontalGroup = withInfo()(() => (
   <RadioCard.Group
     collapseBelow="sm"


### PR DESCRIPTION
Closes #629 

### What Changed
- Adds new `grid` orientation option
- Removes restriction on React children inside radio card groups

### How To Test or Verify

<!--
Describe any steps that may help reviewers verify changes.
Anything beyond basic unit testing, such as assistive tech usage, or special interactions.
-->

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
