### PR TITLE
UX-336 Add Padding system prop to Modal.Content

### DIFF
--- a/packages/matchbox/src/components/Modal/Content.js
+++ b/packages/matchbox/src/components/Modal/Content.js
@@ -1,13 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { padding } from 'styled-system';
+import { createPropTypes } from '@styled-system/prop-types';
+import { pick } from '../../helpers/systemProps';
 
 import { Box } from '../Box';
 
 const Content = React.forwardRef(function Content(props, ref) {
-  const { children } = props;
+  const { children, ...rest } = props;
+  const systemProps = pick(rest, padding.propNames);
 
   return (
-    <Box data-id="modal-content" p="500" maxHeight="60vh" overflowY="auto" ref={ref}>
+    <Box data-id="modal-content" {...systemProps} maxHeight="60vh" overflowY="auto" ref={ref}>
       {children}
     </Box>
   );
@@ -16,6 +20,11 @@ const Content = React.forwardRef(function Content(props, ref) {
 Content.displayName = 'Modal.Content';
 Content.propTypes = {
   children: PropTypes.node,
+  ...createPropTypes(padding.propNames),
+};
+
+Content.defaultProps = {
+  p: '500',
 };
 
 export default Content;

--- a/site/src/pages/components/modal.mdx
+++ b/site/src/pages/components/modal.mdx
@@ -91,7 +91,7 @@ None
 
 ### Modal.Content System Props
 
-None
+<SystemPropsTags propsList={['padding']} />
 
 ### Modal.Content API
 

--- a/stories/overlays/Modal.stories.js
+++ b/stories/overlays/Modal.stories.js
@@ -93,3 +93,19 @@ export const LEGACY = withInfo()(() => (
     </Panel.LEGACY>
   </Modal.LEGACY>
 ));
+
+export const SystemProps = withInfo()(() => (
+  <Modal p={800} showCloseButton open portalId={PORTAL_ID}>
+    <Modal.Header showCloseButton>Modal Title</Modal.Header>
+    <Modal.Content p="800">
+      <Box bg="blue.300" p="300">
+        Modal Content
+      </Box>
+    </Modal.Content>
+    <Modal.Footer>
+      <Button>Primary Button</Button>
+      <Button>Secondary Button</Button>
+      <Button>Tertiary Button</Button>
+    </Modal.Footer>
+  </Modal>
+));


### PR DESCRIPTION
### What Changed

- Adds `padding` system prop to `Modal.Content`

### How To Test or Verify

- `npm run start:storybook`
- Verify `Modal` stories - added new system props story

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
