### PR TITLE
UX-342 Support  prop on Modal.Content

### DIFF
--- a/packages/matchbox/src/components/Modal/Content.js
+++ b/packages/matchbox/src/components/Modal/Content.js
@@ -11,7 +11,14 @@ const Content = React.forwardRef(function Content(props, ref) {
   const systemProps = pick(rest, padding.propNames);
 
   return (
-    <Box data-id="modal-content" {...systemProps} maxHeight="60vh" overflowY="auto" ref={ref}>
+    <Box
+      data-id="modal-content"
+      p="500"
+      {...systemProps}
+      maxHeight="60vh"
+      overflowY="auto"
+      ref={ref}
+    >
       {children}
     </Box>
   );
@@ -21,10 +28,6 @@ Content.displayName = 'Modal.Content';
 Content.propTypes = {
   children: PropTypes.node,
   ...createPropTypes(padding.propNames),
-};
-
-Content.defaultProps = {
-  p: '500',
 };
 
 export default Content;

--- a/stories/overlays/Modal.stories.js
+++ b/stories/overlays/Modal.stories.js
@@ -97,7 +97,7 @@ export const LEGACY = withInfo()(() => (
 export const SystemProps = withInfo()(() => (
   <Modal p={800} showCloseButton open portalId={PORTAL_ID}>
     <Modal.Header showCloseButton>Modal Title</Modal.Header>
-    <Modal.Content p="800">
+    <Modal.Content padding="800">
       <Box bg="blue.300" p="300">
         Modal Content
       </Box>


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed
- Removes modal content default prop `p`
- Hardcodes the default instead so `padding` works when passed to the component

### How To Test or Verify
- Visit the modal story: http://localhost:9001/?path=/story/overlays-modal--system-props
- Verify `p` works as well as `padding`
<!--
Describe any steps that may help reviewers verify changes.
Anything beyond basic unit testing, such as assistive tech usage, or special interactions.
-->

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
