### PR TITLE
UX-345 Support additional ListBox keyboard interactions

### DIFF
--- a/cypress/integration/ListBox.spec.js
+++ b/cypress/integration/ListBox.spec.js
@@ -66,4 +66,20 @@ describe('The ListBox component', () => {
 
     cy.focused().should('have.text', 'Charlie');
   });
+
+  it('tabs through properly without opening', () => {
+    cy.wait(100);
+    cy.get('body').tab();
+    cy.focused().should('have.attr', 'id', 'listbox-1');
+    cy.focused().tab();
+    cy.focused().should('have.text', 'Copy'); // The storybook info button
+  });
+
+  it('tabs through properly while open', () => {
+    cy.get('label').click();
+    cy.get('body').tab();
+    cy.focused().should('have.text', 'Bravo');
+    cy.focused().tab();
+    cy.focused().should('have.text', 'Copy');
+  });
 });

--- a/cypress/integration/ListBox.spec.js
+++ b/cypress/integration/ListBox.spec.js
@@ -72,7 +72,7 @@ describe('The ListBox component', () => {
     cy.get('body').tab();
     cy.focused().should('have.attr', 'id', 'listbox-1');
     cy.focused().tab();
-    cy.focused().should('have.text', 'Copy'); // The storybook info button
+    cy.focused().should('have.text', 'Copy'); // The storybook info button after the listbox
   });
 
   it('tabs through properly while open', () => {
@@ -80,14 +80,26 @@ describe('The ListBox component', () => {
     cy.get('body').tab();
     cy.focused().should('have.text', 'Bravo');
     cy.focused().tab();
-    cy.focused().should('have.text', 'Copy');
+    cy.focused().should('have.text', 'Copy'); // The storybook info button after the listbox
   });
 
   it('opens the menu when focused and closed with keyboard arrows', () => {
-    cy.get('label').click();
+    cy.wait(100);
     cy.get('body').tab();
-    cy.focused().should('have.text', 'Bravo');
-    cy.focused().tab();
-    cy.focused().should('have.text', 'Copy');
+    cy.focused().trigger('keydown', {
+      key: 'ArrowDown',
+      keycode: 40,
+      shiftKey: false,
+    });
+    cy.contains('Alpha').should('be.visible');
+  });
+
+  it('selects item on click and returns focus to button', () => {
+    cy.get('label').click();
+    cy.get('button')
+      .eq(3)
+      .click();
+    cy.wait(100);
+    cy.focused().should('have.text', 'Charlie');
   });
 });

--- a/cypress/integration/ListBox.spec.js
+++ b/cypress/integration/ListBox.spec.js
@@ -82,4 +82,12 @@ describe('The ListBox component', () => {
     cy.focused().tab();
     cy.focused().should('have.text', 'Copy');
   });
+
+  it('opens the menu when focused and closed with keyboard arrows', () => {
+    cy.get('label').click();
+    cy.get('body').tab();
+    cy.focused().should('have.text', 'Bravo');
+    cy.focused().tab();
+    cy.focused().should('have.text', 'Copy');
+  });
 });

--- a/packages/matchbox/src/components/ListBox/ListBox.js
+++ b/packages/matchbox/src/components/ListBox/ListBox.js
@@ -86,6 +86,7 @@ const ListBox = React.forwardRef(function ListBox(props, userRef) {
   const [currentValue, setCurrentValue] = React.useState(
     value ? value : defaultValue != null ? defaultValue : placeholder,
   );
+  const buttonRef = React.useRef();
 
   const { describedBy, errorId, helpTextId } = useInputDescribedBy({
     id,
@@ -120,6 +121,9 @@ const ListBox = React.forwardRef(function ListBox(props, userRef) {
 
     setOpen(false);
     setCurrentValue(value);
+
+    // Returns focus to the button when closing the popover
+    buttonRef.current.focus();
   }
 
   const contentFromValue = React.useMemo(() => {
@@ -165,6 +169,13 @@ const ListBox = React.forwardRef(function ListBox(props, userRef) {
     }
   }
 
+  function assignRefs(node) {
+    buttonRef.current = node;
+    if (userRef) {
+      userRef.current = node;
+    }
+  }
+
   return (
     <StyledWrapper tabIndex="-1" {...systemProps} {...focusContainerProps}>
       {labelMarkup}
@@ -192,7 +203,7 @@ const ListBox = React.forwardRef(function ListBox(props, userRef) {
               disabled={disabled}
               {...componentProps}
               {...describedBy}
-              ref={userRef}
+              ref={assignRefs}
             >
               {contentFromValue}
             </ListBoxButton>

--- a/packages/matchbox/src/components/ListBox/ListBox.js
+++ b/packages/matchbox/src/components/ListBox/ListBox.js
@@ -14,6 +14,7 @@ import { compose, margin, maxWidth, maxHeight } from 'styled-system';
 import { createPropTypes } from '@styled-system/prop-types';
 import { omit } from '@styled-system/props';
 import { pick } from '../../helpers/systemProps';
+import { onKeys } from '../../helpers/keyEvents';
 import useOptionConstructor from './useOptionConstructor';
 
 import { Button } from '../Button';
@@ -154,6 +155,16 @@ const ListBox = React.forwardRef(function ListBox(props, userRef) {
     placeholder,
   });
 
+  // Opens the popover when hitting up or down when focused and closed
+  function activatorKeyDown(e) {
+    if (!open) {
+      onKeys(['arrowDown', 'arrowUp'], () => {
+        e.preventDefault();
+        togglePopover(e);
+      })(e);
+    }
+  }
+
   return (
     <StyledWrapper tabIndex="-1" {...systemProps} {...focusContainerProps}>
       {labelMarkup}
@@ -177,6 +188,7 @@ const ListBox = React.forwardRef(function ListBox(props, userRef) {
               aria-expanded={open}
               aria-labelledby={id}
               onClick={togglePopover}
+              onKeyDown={activatorKeyDown}
               disabled={disabled}
               {...componentProps}
               {...describedBy}

--- a/packages/matchbox/src/components/ListBox/ListBox.js
+++ b/packages/matchbox/src/components/ListBox/ListBox.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { KeyboardArrowDown } from '@sparkpost/matchbox-icons';
@@ -81,7 +81,7 @@ const ListBox = React.forwardRef(function ListBox(props, userRef) {
   const maxHeightProps = pick(rest, maxHeight.propNames);
   const componentProps = omit(rest);
 
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = React.useState(false);
   const [currentValue, setCurrentValue] = React.useState(
     value ? value : defaultValue != null ? defaultValue : placeholder,
   );
@@ -109,6 +109,7 @@ const ListBox = React.forwardRef(function ListBox(props, userRef) {
 
   function onSelect(value) {
     if (onChange) {
+      // This is a fake event, because buttons do not inherently have a change event
       onChange({
         currentTarget: {
           value,

--- a/packages/matchbox/src/components/ListBox/Option.js
+++ b/packages/matchbox/src/components/ListBox/Option.js
@@ -21,15 +21,9 @@ const Option = React.forwardRef(function Option(props, ref) {
       aria-posinset={index}
       aria-selected={isActive}
       disabled={disabled}
+      onClick={() => onSelect(value)}
     >
-      <StyledLink
-        active={isActive}
-        as="button"
-        disabled={disabled}
-        onClick={() => onSelect(value)}
-        tabIndex={0}
-        ref={ref}
-      >
+      <StyledLink active={isActive} as="button" disabled={disabled} tabIndex="-1" ref={ref}>
         {children}
       </StyledLink>
     </Box>

--- a/packages/matchbox/src/components/ListBox/useOptionConstructor.js
+++ b/packages/matchbox/src/components/ListBox/useOptionConstructor.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { onKey, onKeys } from '../../helpers/keyEvents';
+import { onKey } from '../../helpers/keyEvents';
 
 import Option from './Option';
 
@@ -14,31 +14,32 @@ function useOptionConstructor({ options, value, onSelect, open, placeholder }) {
   const optionRefs = React.useRef({ current: new Array(options.length) });
 
   function onFocusContainerKeyDown(e) {
-    e.preventDefault();
-    e.stopPropagation();
+    if (open) {
+      onKey('arrowDown', () => {
+        e.preventDefault();
+        if (focused === options.length - 1) {
+          setFocused(0);
+        } else {
+          setFocused(focused + 1);
+        }
+      })(e);
 
-    onKeys(['arrowDown', 'tab'], () => {
-      if (focused === options.length - 1) {
-        setFocused(0);
-      } else {
-        setFocused(focused + 1);
-      }
-    })(e);
+      onKey('arrowUp', () => {
+        e.preventDefault();
+        if (focused === 0) {
+          setFocused(options.length - 1);
+        } else {
+          setFocused(focused - 1);
+        }
+      })(e);
 
-    onKey('arrowUp', () => {
-      if (focused === 0) {
-        setFocused(options.length - 1);
-      } else {
-        setFocused(focused - 1);
-      }
-    })(e);
+      onKey('enter', () => {
+        onSelect(options[focused].props.value);
+      })(e);
 
-    onKey('enter', () => {
-      onSelect(options[focused].props.value);
-    })(e);
-
-    setKeysSoFar(keysSoFar + e.key.toLowerCase());
-    clearKeysSoFarAfterDelay();
+      setKeysSoFar(keysSoFar + e.key.toLowerCase());
+      clearKeysSoFarAfterDelay();
+    }
   }
 
   function clearKeysSoFarAfterDelay() {

--- a/packages/matchbox/src/components/ListBox/useOptionConstructor.js
+++ b/packages/matchbox/src/components/ListBox/useOptionConstructor.js
@@ -32,10 +32,6 @@ function useOptionConstructor({ options, value, onSelect, open, placeholder }) {
         }
       })(e);
 
-      onKey('enter', () => {
-        onSelect(options[focused].props.value);
-      })(e);
-
       setKeysSoFar(keysSoFar + e.key.toLowerCase());
       clearKeysSoFarAfterDelay();
     }
@@ -62,12 +58,6 @@ function useOptionConstructor({ options, value, onSelect, open, placeholder }) {
       optionRefs.current = [];
     };
   }, [options]);
-
-  React.useEffect(() => {
-    if (!open && value) {
-      setFocused(options.findIndex(option => option.props.value === value));
-    }
-  }, [open, value]);
 
   // Focuses on option when focused index changes
   React.useLayoutEffect(() => {

--- a/packages/matchbox/src/components/ListBox/useOptionConstructor.js
+++ b/packages/matchbox/src/components/ListBox/useOptionConstructor.js
@@ -10,7 +10,6 @@ function useOptionConstructor({ options, value, onSelect, open, placeholder }) {
   const [keysSoFar, setKeysSoFar] = React.useState('');
   const [keyClear, setKeyClear] = React.useState();
 
-  const focusContainerRef = React.useRef({});
   const optionRefs = React.useRef({ current: new Array(options.length) });
 
   function onFocusContainerKeyDown(e) {
@@ -111,7 +110,6 @@ function useOptionConstructor({ options, value, onSelect, open, placeholder }) {
   return {
     optionsMarkup,
     focusContainerProps: {
-      ref: focusContainerRef,
       onKeyDown: onFocusContainerKeyDown,
     },
   };

--- a/stories/form/ListBox.stories.js
+++ b/stories/form/ListBox.stories.js
@@ -100,3 +100,29 @@ export const Disabled = withInfo()(() => (
     <ListBox.Option value="option-4">Option 4</ListBox.Option>
   </ListBox>
 ));
+
+export const WithARef = withInfo()(() => {
+  function Example() {
+    const ref = React.useRef();
+
+    React.useEffect(() => {
+      ref.current.focus();
+    }, []);
+
+    return (
+      <ListBox
+        id="listbox-1"
+        defaultValue="option-2"
+        label="Select an option"
+        onChange={e => console.log(e.currentTarget.value)}
+        ref={ref}
+      >
+        <ListBox.Option value="option-1">Option 1</ListBox.Option>
+        <ListBox.Option value="option-2">Option 2</ListBox.Option>
+        <ListBox.Option value="option-3">Option 3</ListBox.Option>
+        <ListBox.Option value="option-4">Option 4</ListBox.Option>
+      </ListBox>
+    );
+  }
+  return <Example />;
+});

--- a/stories/form/ListBox.stories.js
+++ b/stories/form/ListBox.stories.js
@@ -7,7 +7,12 @@ export default {
 };
 
 export const BasicListbox = withInfo()(() => (
-  <ListBox id="listbox-1" defaultValue="option-1" label="Select an option">
+  <ListBox
+    id="listbox-1"
+    defaultValue="option-1"
+    label="Select an option"
+    onChange={e => console.log(e)}
+  >
     <ListBox.Option value="option-1">Option 1</ListBox.Option>
     <ListBox.Option value="option-2">Option 2</ListBox.Option>
     <ListBox.Option value="option-3">Option 3</ListBox.Option>


### PR DESCRIPTION
### What Changed
- Properly tabs through the ListBox - bypassing options
- Opens the Listbox when focused and pressing arrow up or down
- Returns focus to the Button when closed

### How To Test or Verify
- Visit http://localhost:9001/?path=/story/form-listbox--with-a-ref
- Verify keyboard interactions

### PR Checklist

- [x] Add the correct `type` label
- [x] Pull request approval from #uxfe or #design-guild
