### PR TITLE
UX-335 Add ComboBoxTextField delimiter prop

### DIFF
--- a/packages/matchbox/src/components/ComboBox/ComboBoxTextField.js
+++ b/packages/matchbox/src/components/ComboBox/ComboBoxTextField.js
@@ -139,7 +139,7 @@ ComboBoxTextField.propTypes = {
   autoFocus: PropTypes.bool,
   children: PropTypes.node,
   disabled: PropTypes.bool,
-  delimiter: PropTypes.node,
+  delimiter: PropTypes.string,
   error: PropTypes.string,
   errorInLabel: PropTypes.bool,
   helpText: PropTypes.node,

--- a/packages/matchbox/src/components/ComboBox/ComboBoxTextField.js
+++ b/packages/matchbox/src/components/ComboBox/ComboBoxTextField.js
@@ -24,6 +24,7 @@ function ComboBoxTextField(props) {
   const {
     autoFocus,
     disabled,
+    delimiter,
     children,
     error,
     errorInLabel,
@@ -85,11 +86,25 @@ function ComboBoxTextField(props) {
         {selectedItems.length > 0 && (
           <Box display="flex" pl="200" pt="0.375rem">
             <Inline space="100">
-              {selectedItems.map((item, i) => (
-                <Tag key={i} onRemove={!disabled ? () => removeItem(item) : null}>
-                  {itemToString(item)}
-                </Tag>
-              ))}
+              {selectedItems.map((item, i) => {
+                return (
+                  <span key={i}>
+                    <Tag onRemove={!disabled ? () => removeItem(item) : null}>
+                      {itemToString(item)}
+                    </Tag>
+                    {delimiter && i < selectedItems.length - 1 ? (
+                      <Box
+                        as="span"
+                        ml="100"
+                        fontWeight="medium"
+                        style={{ textTransform: 'uppercase', fontStyle: 'italic' }}
+                      >
+                        {delimiter}
+                      </Box>
+                    ) : null}
+                  </span>
+                );
+              })}
             </Inline>
           </Box>
         )}
@@ -122,8 +137,9 @@ function ComboBoxTextField(props) {
 
 ComboBoxTextField.propTypes = {
   autoFocus: PropTypes.bool,
-  disabled: PropTypes.bool,
   children: PropTypes.node,
+  disabled: PropTypes.bool,
+  delimiter: PropTypes.node,
   error: PropTypes.string,
   errorInLabel: PropTypes.bool,
   helpText: PropTypes.node,

--- a/packages/matchbox/src/components/ComboBox/ComboBoxTextField.js
+++ b/packages/matchbox/src/components/ComboBox/ComboBoxTextField.js
@@ -97,7 +97,8 @@ function ComboBoxTextField(props) {
                         as="span"
                         ml="100"
                         fontWeight="medium"
-                        style={{ textTransform: 'uppercase', fontStyle: 'italic' }}
+                        fontStyle="italic"
+                        style={{ textTransform: 'uppercase' }}
                       >
                         {delimiter}
                       </Box>

--- a/packages/matchbox/src/components/ComboBox/tests/ComboBoxTextField.test.js
+++ b/packages/matchbox/src/components/ComboBox/tests/ComboBoxTextField.test.js
@@ -116,6 +116,11 @@ describe('ComboBoxTextField', () => {
       expect(tags(wrapper).text()).toEqual('fooRemovebarRemove');
     });
 
+    it('should render selected items with a delimiter correctly', () => {
+      const wrapper = subject({ delimiter: 'or' });
+      expect(tags(wrapper).text()).toEqual('fooRemoveorbarRemove');
+    });
+
     it('should handle remove on a tag correctly', () => {
       const removeItem = jest.fn();
       const wrapper = subject({ removeItem });

--- a/site/src/pages/components/combobox.mdx
+++ b/site/src/pages/components/combobox.mdx
@@ -107,6 +107,10 @@ import { LiveCode } from '../../components/LiveCode';
   Whether the input is disabled or not. Disables tag removal
 </Prop>
 
+<Prop name="delimiter" type="string">
+  Adds a delimiter in between each tag
+</Prop>
+
 <Prop name="error" type="string">
   Renders an error message below the input
 </Prop>

--- a/stories/form/ComboBox.stories.js
+++ b/stories/form/ComboBox.stories.js
@@ -13,7 +13,7 @@ function getItems() {
 }
 
 function TypeaheadExample(props) {
-  const { error } = props;
+  const { error, delimiter } = props;
   const [selected, setSelected] = React.useState([]);
 
   function stateReducer(state, changes) {
@@ -87,6 +87,7 @@ function TypeaheadExample(props) {
       error: error && !isOpen ? 'test' : null,
       placeholder: 'Type to search',
       helpText: 'Help text',
+      delimiter,
     });
 
     const menuProps = getMenuProps({
@@ -168,3 +169,7 @@ export const TextFieldWhileDisabled = withInfo({
     disabled
   />
 ));
+
+export const WithDelimiter = withInfo({
+  propTables: [ComboBox, ComboBoxMenu, ComboBoxTextField],
+})(() => <TypeaheadExample delimiter="or" />);


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed
- Adds `delimiter` string prop to the combobox textfield
<!--
What changes does this PR propose?
Provide screenshots or [screen recordings](https://getkap.co/) for any visual changes.
-->

### How To Test or Verify
- Visit http://localhost:9001/?path=/story/form-combobox--with-delimiter
- Verify delimiter works
<!--
Describe any steps that may help reviewers verify changes.
Anything beyond basic unit testing, such as assistive tech usage, or special interactions.
-->

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
