### PR TITLE
UX-234 Tabs should measure overflow on component resize

### DIFF
--- a/packages/matchbox/src/components/Tabs/Tabs.js
+++ b/packages/matchbox/src/components/Tabs/Tabs.js
@@ -14,6 +14,7 @@ import { deprecate } from '../../helpers/propTypes';
 import useTabConstructor from './useTabConstructor';
 import Tab from './Tab';
 import { containerStyles, overflowTabs } from './styles';
+import { useResizeObserver } from '../../hooks';
 
 import { getPositionFor, useWindowSize } from '../../helpers/geometry';
 
@@ -43,6 +44,9 @@ const Tabs = React.forwardRef(function Tabs(props, userRef) {
   const wrapperRef = React.useRef();
   const overflowRef = React.useRef();
   const windowSize = useWindowSize();
+
+  const [resizeRef, entry] = useResizeObserver();
+  console.log(entry);
 
   function handleClick(event, index) {
     const { onClick } = tabs[index];
@@ -88,6 +92,9 @@ const Tabs = React.forwardRef(function Tabs(props, userRef) {
   const assignWrapperRefs = node => {
     if (wrapperRef) {
       wrapperRef.current = node;
+    }
+    if (resizeRef) {
+      resizeRef.current = node;
     }
     if (userRef) {
       userRef.current = node;

--- a/packages/matchbox/src/components/Tabs/Tabs.js
+++ b/packages/matchbox/src/components/Tabs/Tabs.js
@@ -16,7 +16,7 @@ import Tab from './Tab';
 import { containerStyles, overflowTabs } from './styles';
 import { useResizeObserver } from '../../hooks';
 
-import { getPositionFor, useWindowSize } from '../../helpers/geometry';
+import { getPositionFor } from '../../helpers/geometry';
 
 const OverflowTabContainer = styled('div')`
   ${overflowTabs}
@@ -43,10 +43,8 @@ const Tabs = React.forwardRef(function Tabs(props, userRef) {
 
   const wrapperRef = React.useRef();
   const overflowRef = React.useRef();
-  const windowSize = useWindowSize();
 
-  const [resizeRef, entry] = useResizeObserver();
-  console.log(entry);
+  const [resizeRef, { contentRect }] = useResizeObserver();
 
   function handleClick(event, index) {
     const { onClick } = tabs[index];
@@ -76,7 +74,7 @@ const Tabs = React.forwardRef(function Tabs(props, userRef) {
         setIsOverflowing(false);
       }
     }
-  }, [wrapperRef, overflowRef, windowSize]);
+  }, [wrapperRef, overflowRef, contentRect]);
 
   // Constructs the tabs, their props and handles tab keyboard navigation
   const { tabMarkup, tabActions, focusContainerProps } = useTabConstructor({
@@ -93,11 +91,11 @@ const Tabs = React.forwardRef(function Tabs(props, userRef) {
     if (wrapperRef) {
       wrapperRef.current = node;
     }
-    if (resizeRef) {
-      resizeRef.current = node;
-    }
     if (userRef) {
       userRef.current = node;
+    }
+    if (resizeRef) {
+      resizeRef(node);
     }
   };
 


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed

- Listen for resize on Tabs component and not window
 
### How To Test or Verify

- `npm run start:storybook`
- Verify resize events are working on Tabs stories

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
