### PR TITLE
UX-350 Add borderless Expandable variant

### DIFF
--- a/packages/matchbox/src/components/Expandable/Expandable.js
+++ b/packages/matchbox/src/components/Expandable/Expandable.js
@@ -5,7 +5,7 @@ import { margin } from 'styled-system';
 import { createPropTypes } from '@styled-system/prop-types';
 import { KeyboardArrowLeft } from '@sparkpost/matchbox-icons';
 import { onKeys } from '../../helpers/keyEvents';
-import { StyledHeader, expandable, title, subtitle, arrow, contentWrapper } from './styles';
+import { StyledHeader, StyledContentWrapper, expandable, title, subtitle, arrow } from './styles';
 
 import Accent from './Accent';
 import { Box } from '../Box';
@@ -25,10 +25,6 @@ const StyledTitle = styled('h3')`
 
 const StyledSubtitle = styled('h6')`
   ${subtitle}
-`;
-
-const StyledContentWrapper = styled('div')`
-  ${contentWrapper}
 `;
 
 const StyledIcon = styled(Box)``;
@@ -132,6 +128,14 @@ function Expandable(props) {
     </Box>
   );
 }
+
+Expandable.Accent = Accent;
+Expandable.Icon = StyledIcon;
+Expandable.Title = StyledTitle;
+Expandable.Subtitle = StyledSubtitle;
+Expandable.ContentWrapper = StyledContentWrapper;
+Expandable.Arrow = StyledArrow;
+Expandable.Header = StyledHeader;
 
 Expandable.defaultProps = {
   defaultOpen: false,

--- a/packages/matchbox/src/components/Expandable/Expandable.js
+++ b/packages/matchbox/src/components/Expandable/Expandable.js
@@ -44,6 +44,7 @@ function Expandable(props) {
     subtitle,
     title,
     accent,
+    variant,
     ...rest
   } = props;
 
@@ -95,7 +96,7 @@ function Expandable(props) {
   return (
     <Box {...rest}>
       {accentMarkup}
-      <StyledExpandable accent={accent}>
+      <StyledExpandable accent={accent} variant={variant}>
         <StyledHeader
           aria-controls={id}
           aria-expanded={isOpen}
@@ -104,6 +105,7 @@ function Expandable(props) {
           ref={header}
           data-id="expandable-toggle"
           type="button"
+          variant={variant}
         >
           {iconMarkup}
           <Box display="inline-block" flex="1">
@@ -121,6 +123,7 @@ function Expandable(props) {
           isOpen={isOpen}
           id={id}
           data-id="expandable-content"
+          variant={variant}
         >
           {contentSpacer}
           <Box flex="1">{children}</Box>
@@ -130,16 +133,9 @@ function Expandable(props) {
   );
 }
 
-Expandable.Accent = Accent;
-Expandable.Icon = StyledIcon;
-Expandable.Title = StyledTitle;
-Expandable.Subtitle = StyledSubtitle;
-Expandable.ContentWrapper = StyledContentWrapper;
-Expandable.Arrow = StyledArrow;
-Expandable.Header = StyledHeader;
-
 Expandable.defaultProps = {
   defaultOpen: false,
+  variant: 'bordered',
 };
 
 Expandable.propTypes = {
@@ -178,6 +174,8 @@ Expandable.propTypes = {
     Proptypes.bool,
     Proptypes.oneOf(['orange', 'blue', 'red', 'yellow', 'green', 'purple', 'navy', 'gray']),
   ]),
+
+  variant: Proptypes.oneOf(['bordered', 'borderless']),
   /**
    * Margin props
    */

--- a/packages/matchbox/src/components/Expandable/styles.js
+++ b/packages/matchbox/src/components/Expandable/styles.js
@@ -21,7 +21,6 @@ export const StyledHeader = styled('button')`
 
   &:hover {
     cursor: pointer;
-    background: ${tokens.color_gray_100};
   }
 `;
 
@@ -74,6 +73,11 @@ export const arrow = props => {
     transition: ${tokens.motionDuration_fast} ${tokens.motionEase_in_out};
     transform-origin: center;
     transform: ${rotate};
+
+    ${StyledHeader}:hover &, ${StyledHeader}:focus & {	
+      background: ${tokens.color_blue_200};	
+      color: ${tokens.color_blue_800};	
+    }
   `;
 };
 

--- a/packages/matchbox/src/components/Expandable/styles.js
+++ b/packages/matchbox/src/components/Expandable/styles.js
@@ -16,10 +16,7 @@ export const StyledHeader = styled('button')`
 
   &:hover {
     cursor: pointer;
-  }
-
-  &:focus:not(:hover) {
-    background: ${tokens.color_gray_200};
+    background: ${tokens.color_gray_100};
   }
 `;
 
@@ -54,10 +51,6 @@ export const arrow = props => {
     transform-origin: center;
 
     transform: ${rotate};
-
-    ${StyledHeader}:hover & {
-      background: ${tokens.color_gray_200};
-    }
   `;
 };
 

--- a/packages/matchbox/src/components/Expandable/styles.js
+++ b/packages/matchbox/src/components/Expandable/styles.js
@@ -1,4 +1,5 @@
 import { tokens } from '@sparkpost/design-tokens';
+import css from '@styled-system/css';
 import { buttonReset } from '../../styles/helpers';
 import styled from 'styled-components';
 
@@ -6,7 +7,11 @@ export const StyledHeader = styled('button')`
   ${buttonReset}
   user-select: none;
   outline: none;
-  padding: ${({ variant, theme }) => (variant === 'borderless' ? '0' : theme.space[300])};
+  ${({ variant }) =>
+    css({
+      padding: variant === 'borderless' ? ['400', null, '500'] : '300',
+    })}
+
   display: flex;
   align-items: center;
   text-align: left;
@@ -18,6 +23,25 @@ export const StyledHeader = styled('button')`
     cursor: pointer;
     background: ${tokens.color_gray_100};
   }
+`;
+
+export const StyledContentWrapper = styled('div')`
+  ${props => {
+    let visibility = 'hidden';
+    let display = 'none';
+
+    if (props.isOpen) {
+      visibility = 'visible';
+      display = 'flex';
+    }
+
+    return `
+      visibility: ${visibility};
+      display: ${display};
+    `;
+  }}
+  ${({ variant }) => css({ px: variant === 'borderless' ? ['400', null, '500'] : '300' })}
+  ${({ variant }) => css({ pb: variant === 'borderless' ? ['400', null, '500'] : '300' })}
 `;
 
 export const expandable = props => {
@@ -49,26 +73,7 @@ export const arrow = props => {
     padding: ${tokens.spacing_100};
     transition: ${tokens.motionDuration_fast} ${tokens.motionEase_in_out};
     transform-origin: center;
-
     transform: ${rotate};
-  `;
-};
-
-export const contentWrapper = props => {
-  let visibility = 'hidden';
-  let display = 'none';
-
-  if (props.isOpen) {
-    visibility = 'visible';
-    display = 'flex';
-  }
-
-  return `
-    padding: ${
-      props.variant === 'borderless' ? `${props.theme.space[300]} 0 0` : props.theme.space[300]
-    };
-    visibility: ${visibility};
-    display: ${display};
   `;
 };
 

--- a/packages/matchbox/src/components/Expandable/styles.js
+++ b/packages/matchbox/src/components/Expandable/styles.js
@@ -6,7 +6,7 @@ export const StyledHeader = styled('button')`
   ${buttonReset}
   user-select: none;
   outline: none;
-  padding: ${tokens.spacing_300};
+  padding: ${({ variant, theme }) => (variant === 'borderless' ? '0' : theme.space[300])};
   display: flex;
   align-items: center;
   text-align: left;
@@ -25,6 +25,9 @@ export const StyledHeader = styled('button')`
 
 export const expandable = props => {
   let borderRadius = tokens.borderRadius_100;
+  if (props.variant === 'borderless') {
+    return ``;
+  }
 
   if (props.accent) {
     borderRadius = `0 0 ${tokens.borderRadius_100} ${tokens.borderRadius_100}`;
@@ -68,7 +71,9 @@ export const contentWrapper = props => {
   }
 
   return `
-    padding: ${tokens.spacing_300};
+    padding: ${
+      props.variant === 'borderless' ? `${props.theme.space[300]} 0 0` : props.theme.space[300]
+    };
     visibility: ${visibility};
     display: ${display};
   `;

--- a/packages/matchbox/src/components/Expandable/tests/Expandable.test.js
+++ b/packages/matchbox/src/components/Expandable/tests/Expandable.test.js
@@ -50,6 +50,16 @@ describe('Expandable component', () => {
     expect(wrapper.find(Expandable.Icon).text()).toEqual('test');
   });
 
+  it('should render borderless padding', () => {
+    const wrapper = subject({
+      variant: 'borderless',
+      defaultOpen: true,
+    });
+
+    expect(wrapper.find(Expandable.ContentWrapper)).toHaveStyleRule('padding-left', '1rem');
+    expect(wrapper.find(Expandable.Header)).toHaveStyleRule('padding', '1rem');
+  });
+
   describe('uncontrolled', () => {
     it('should use default defaultOpen on first render', () => {
       const wrapper = subject();

--- a/packages/matchbox/src/components/Panel/Section.js
+++ b/packages/matchbox/src/components/Panel/Section.js
@@ -24,14 +24,22 @@ const Section = React.forwardRef(function Section(props, userRef) {
   const paddingContext = React.useContext(PanelPaddingContext);
   const systemProps = pick(rest, padding.propNames);
 
+  // Checks if 'padding', and overwrite 'p' instead of using the 'padding' key
+  const paddingProps = React.useMemo(() => {
+    if (Object.keys(systemProps).includes('padding')) {
+      const { padding, ...rest } = systemProps;
+      return { ...paddingContext, p: padding, ...rest };
+    }
+    return { ...paddingContext, ...systemProps };
+  }, [paddingContext, systemProps]);
+
   return (
     <StyledSection
       borderBottom="300"
       className={className}
       ref={userRef}
       tabIndex="-1"
-      {...paddingContext}
-      {...systemProps}
+      {...paddingProps}
     >
       <Columns collapseBelow="xs" space="300" alignY="top" align="right">
         <Column>{content}</Column>

--- a/stories/layout/Expandable.stories.js
+++ b/stories/layout/Expandable.stories.js
@@ -68,7 +68,7 @@ export const ControlledOpenState = withInfo()(() => {
 
 export const Borderless = withInfo()(() => (
   <Panel>
-    <Panel.Section padding="0">
+    <Panel.Section p="0">
       <Expandable variant="borderless" defaultOpen={true} title="Slack" id="example">
         Content here
       </Expandable>

--- a/stories/layout/Expandable.stories.js
+++ b/stories/layout/Expandable.stories.js
@@ -66,6 +66,16 @@ export const ControlledOpenState = withInfo()(() => {
   );
 });
 
+export const Borderless = withInfo()(() => (
+  <Panel>
+    <Panel.Section padding="0">
+      <Expandable variant="borderless" defaultOpen={true} title="Slack" id="example">
+        Content here
+      </Expandable>
+    </Panel.Section>
+  </Panel>
+));
+
 export const WithAnAccent = withInfo()(() => (
   <Panel>
     <Panel.Section>


### PR DESCRIPTION


### What Changed
- Fixes `padding` bug on Panel.Sections
- Adds `variant` prop to `Expandable` and a `borderless` variant

<!--
What changes does this PR propose?
Provide screenshots or [screen recordings](https://getkap.co/) for any visual changes.
-->

### How To Test or Verify
- Visit: http://localhost:9001/?path=/story/layout-expandable--borderless
- Visit panel stories and verify both `p` and `padding` can be set on panel sections
<!--
Describe any steps that may help reviewers verify changes.
Anything beyond basic unit testing, such as assistive tech usage, or special interactions.
-->

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
