### PR TITLE
Issue 661 Add data-id props to all layout components

### DIFF
--- a/packages/matchbox/src/components/Column/Column.js
+++ b/packages/matchbox/src/components/Column/Column.js
@@ -33,6 +33,7 @@ const Column = React.forwardRef(function Column(props, ref) {
   return (
     <StyledColumn
       display={display}
+      data-id={props['data-id']}
       className={className}
       width={columnWidth}
       flex={!width && !collapsed ? '1' : ''}
@@ -50,6 +51,7 @@ Column.displayName = 'Column';
 
 Column.propTypes = {
   children: PropTypes.node,
+  'data-id': PropTypes.string,
   width: PropTypes.oneOfType([PropTypes.oneOf(['content']), PropTypes.number]),
   className: PropTypes.string,
   ...createPropTypes(display.propNames),

--- a/packages/matchbox/src/components/Columns/Columns.js
+++ b/packages/matchbox/src/components/Columns/Columns.js
@@ -39,7 +39,7 @@ const Columns = React.forwardRef(function Columns(props, ref) {
   }, [windowSize, collapseBelow]);
 
   return (
-    <Box {...systemProps}>
+    <Box {...systemProps} data-id={props['data-id']}>
       <StyledColumns
         display="flex"
         alignY={alignY}
@@ -60,6 +60,7 @@ Columns.displayName = 'Columns';
 
 Columns.propTypes = {
   children: PropTypes.node,
+  'data-id': PropTypes.string,
   reverse: PropTypes.bool,
   space: propTypes.space.padding,
   alignY: PropTypes.oneOf(['top', 'center', 'bottom']),

--- a/packages/matchbox/src/components/Columns/tests/Columns.test.js
+++ b/packages/matchbox/src/components/Columns/tests/Columns.test.js
@@ -8,7 +8,7 @@ import { tokens } from '@sparkpost/design-tokens';
 describe('Columns', () => {
   const subject = props =>
     global.mountStyled(
-      <Columns {...props}>
+      <Columns {...props} data-id="test-id">
         <Column width={1 / 2}>Column 1</Column>
         <Column width={1 / 2}>Column 2</Column>
       </Columns>,
@@ -19,6 +19,11 @@ describe('Columns', () => {
     window.innerHeight = y;
     window.dispatchEvent(new Event('resize'));
   };
+
+  it('should render data-id', () => {
+    const wrapper = subject();
+    expect(wrapper.find('[data-id="test-id"]')).toExist();
+  });
 
   it('renders with default props', () => {
     const wrapper = subject();

--- a/packages/matchbox/src/components/Grid/tests/Column.test.js
+++ b/packages/matchbox/src/components/Grid/tests/Column.test.js
@@ -6,11 +6,16 @@ describe('Column', () => {
   const subject = props =>
     global
       .mountStyled(
-        <Column {...props}>
+        <Column {...props} data-id="test-id">
           <p>Grid</p>
         </Column>,
       )
       .find('div');
+
+  it('should render data-id', () => {
+    const wrapper = subject();
+    expect(wrapper.find('[data-id="test-id"]')).toExist();
+  });
 
   it('renders with default props', () => {
     const wrapper = subject();

--- a/packages/matchbox/src/components/Inline/Inline.js
+++ b/packages/matchbox/src/components/Inline/Inline.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Box } from '../Box';
 import styled from 'styled-components';
 import propTypes from '@styled-system/prop-types';
@@ -29,7 +30,7 @@ function Inline(props) {
   const items = React.Children.toArray(children);
 
   return (
-    <OuterWrapper gutter={space}>
+    <OuterWrapper gutter={space} data-id={props['data-id']}>
       <InnerWrapper gutter={space} align={align}>
         {items.map((child, i) => (
           <Box key={i} pt={space} pl={space}>
@@ -42,6 +43,7 @@ function Inline(props) {
 }
 
 Inline.propTypes = {
+  'data-id': PropTypes.string,
   /**
    * Sets the gutter space between children.
    * Styled-system responsive arrays work here.

--- a/packages/matchbox/src/components/Inline/tests/Inline.test.js
+++ b/packages/matchbox/src/components/Inline/tests/Inline.test.js
@@ -5,7 +5,7 @@ import 'jest-styled-components';
 describe('Inline', () => {
   const subject = props =>
     global.mountStyled(
-      <Inline {...props}>
+      <Inline {...props} data-id="test-id">
         <div>1</div>
         <div>2</div>
       </Inline>,
@@ -25,6 +25,11 @@ describe('Inline', () => {
         .at(1)
         .text(),
     ).toBe('2');
+  });
+
+  it('should render data-id', () => {
+    const wrapper = subject();
+    expect(wrapper.find('[data-id="test-id"]')).toExist();
   });
 
   it('should render spacing default and base styles correctly', () => {

--- a/packages/matchbox/src/components/Layout/Layout.js
+++ b/packages/matchbox/src/components/Layout/Layout.js
@@ -11,7 +11,13 @@ const Layout = React.forwardRef(function Layout(props, ref) {
   const { children, collapseBelow } = props;
 
   return (
-    <Columns collapseBelow={collapseBelow} space={['400', null, '500']} mb="600" ref={ref}>
+    <Columns
+      collapseBelow={collapseBelow}
+      space={['400', null, '500']}
+      mb="600"
+      ref={ref}
+      data-id={props['data-id']}
+    >
       {children}
     </Columns>
   );
@@ -24,6 +30,7 @@ Layout.propTypes = {
    * Layout Children
    */
   children: PropTypes.node,
+  'data-id': PropTypes.string,
   /**
    * When to collapse the columns. 'xs', 'sm', 'md', 'lg', or 'xl'
    */

--- a/packages/matchbox/src/components/Layout/Section.js
+++ b/packages/matchbox/src/components/Layout/Section.js
@@ -5,7 +5,11 @@ import { Column } from '../Column';
 function Section(props) {
   const { annotated, children } = props;
 
-  return <Column width={annotated ? 1 / 3 : 1}>{children}</Column>;
+  return (
+    <Column width={annotated ? 1 / 3 : 1} data-id={props['data-id']}>
+      {children}
+    </Column>
+  );
 }
 
 Section.displayName = 'Layout.Section';
@@ -15,6 +19,7 @@ Section.propTypes = {
    * Section Children
    */
   children: PropTypes.node,
+  'data-id': PropTypes.string,
   /**
    * Use for annotated sections, sets width to 1/3
    */

--- a/packages/matchbox/src/components/Layout/SectionTitle.js
+++ b/packages/matchbox/src/components/Layout/SectionTitle.js
@@ -7,7 +7,13 @@ function SectionTitle(props) {
   const { children, as } = props;
 
   return (
-    <Text as={as} fontSize={['300', null, '400']} lineHeight={['300', null, '400']} pb="300">
+    <Text
+      as={as}
+      fontSize={['300', null, '400']}
+      lineHeight={['300', null, '400']}
+      pb="300"
+      data-id={props['data-id']}
+    >
       {children}
     </Text>
   );
@@ -15,6 +21,7 @@ function SectionTitle(props) {
 
 SectionTitle.propTypes = {
   as: PropTypes.elementType,
+  'data-id': PropTypes.string,
 };
 
 SectionTitle.defaultProps = {

--- a/packages/matchbox/src/components/Layout/tests/Layout.test.js
+++ b/packages/matchbox/src/components/Layout/tests/Layout.test.js
@@ -12,10 +12,15 @@ const resizeWindow = (x, y) => {
 describe('Layout', () => {
   const subject = props =>
     global.mountStyled(
-      <Layout {...props}>
+      <Layout {...props} data-id="test-id">
         <Layout.Section>Layout Section Content</Layout.Section>
       </Layout>,
     );
+
+  it('should render data-id', () => {
+    const wrapper = subject();
+    expect(wrapper.find('[data-id="test-id"]')).toExist();
+  });
 
   it('renders layout with content', () => {
     const wrapper = subject();

--- a/packages/matchbox/src/components/Layout/tests/Section.test.js
+++ b/packages/matchbox/src/components/Layout/tests/Section.test.js
@@ -7,10 +7,15 @@ describe('Layout', () => {
   const subject = () =>
     global.mountStyled(
       <Layout>
-        <Layout.Section>Two Column Layout</Layout.Section>
+        <Layout.Section data-id="test-id">Two Column Layout</Layout.Section>
         <Layout.Section>Two Column Layout</Layout.Section>
       </Layout>,
     );
+
+  it('should render data-id', () => {
+    const wrapper = subject();
+    expect(wrapper.find('[data-id="test-id"]')).toExist();
+  });
 
   it('renders columns', () => {
     const wrapper = subject();

--- a/packages/matchbox/src/components/Layout/tests/SectionTitle.test.js
+++ b/packages/matchbox/src/components/Layout/tests/SectionTitle.test.js
@@ -4,11 +4,17 @@ import 'jest-styled-components';
 import SectionTitle from '../SectionTitle';
 
 describe('Layout', () => {
-  const subject = () => global.mountStyled(<SectionTitle>The Title</SectionTitle>);
+  const subject = () =>
+    global.mountStyled(<SectionTitle data-id="test-id">The Title</SectionTitle>);
 
   it('renders section title', () => {
     const wrapper = subject();
 
     expect(wrapper.text()).toEqual('The Title');
+  });
+
+  it('should render data-id', () => {
+    const wrapper = subject();
+    expect(wrapper.find('[data-id="test-id"]')).toExist();
   });
 });

--- a/packages/matchbox/src/components/Stack/Stack.js
+++ b/packages/matchbox/src/components/Stack/Stack.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { system } from 'styled-system';
 import { Box } from '../Box';
 import styled from 'styled-components';
@@ -36,7 +37,7 @@ function Stack(props) {
   }
 
   return (
-    <div>
+    <div data-id={props['data-id']}>
       {items.map((child, i) => (
         <StyledBox key={i} alignment={align} gutter={i < items.length - 1 ? space : null}>
           {child}
@@ -47,6 +48,7 @@ function Stack(props) {
 }
 
 Stack.propTypes = {
+  'data-id': PropTypes.string,
   /**
    * Sets the gutter space between children.
    * Styled-system responsive arrays work here.

--- a/packages/matchbox/src/components/Stack/tests/Stack.test.js
+++ b/packages/matchbox/src/components/Stack/tests/Stack.test.js
@@ -5,12 +5,17 @@ import 'jest-styled-components';
 describe('Stack', () => {
   const subject = props =>
     global.mountStyled(
-      <Stack {...props}>
+      <Stack {...props} data-id="test-id">
         {false && <span id="child-0">0</span>}
         <span id="child-1">1</span>
         <span id="child-2">2</span>
       </Stack>,
     );
+
+  it('should render data-id', () => {
+    const wrapper = subject();
+    expect(wrapper.find('[data-id="test-id"]')).toExist();
+  });
 
   it('should render children correctly', () => {
     const wrapper = subject();

--- a/packages/matchbox/src/components/Text/Text.js
+++ b/packages/matchbox/src/components/Text/Text.js
@@ -24,6 +24,7 @@ const Text = React.forwardRef(function Text(props, ref) {
 
 Text.propTypes = {
   as: PropTypes.elementType.isRequired,
+  'data-id': PropTypes.string,
   children: PropTypes.node.isRequired,
   looksLike: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p']),
 };

--- a/packages/matchbox/src/components/Text/tests/Text.test.js
+++ b/packages/matchbox/src/components/Text/tests/Text.test.js
@@ -14,6 +14,11 @@ describe('Text', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('should render data-id', () => {
+    const wrapper = global.mountStyled(<Text data-id="test-id">Text</Text>);
+    expect(wrapper.find('[data-id="test-id"]')).toExist();
+  });
+
   describe('lookslike renders correctly', () => {
     it('it should render visually as the lookslike prop while html should match the as prop ', () => {
       const wrapper = global.mountStyled(


### PR DESCRIPTION
Resolves #661 

<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed
- Adds `data-id` to `Stack` `Inline` `Columns` `Column` `Layout`
<!--
What changes does this PR propose?
Provide screenshots or [screen recordings](https://getkap.co/) for any visual changes.
-->

### How To Test or Verify
- Run storybook, and add `data-id` as a prop to the components
<!--
Describe any steps that may help reviewers verify changes.
Anything beyond basic unit testing, such as assistive tech usage, or special interactions.
-->

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
