### PR TITLE
UX-356 Focus modal panel when opening

### DIFF
--- a/cypress/integration/Modal.spec.js
+++ b/cypress/integration/Modal.spec.js
@@ -33,6 +33,8 @@ describe('The Modal component', () => {
     // Wait for transition animation
     cy.wait(300);
 
+    cy.focused().should('have.attr', 'data-id', 'modal-content-panel');
+
     // This is equivalent to tabbing when entering the window, so should handle the tab trap appropriately
     cy.get('body').tab();
     cy.focused().should('have.attr', 'data-id', 'modal-close');

--- a/packages/matchbox/src/components/Modal/Modal.js
+++ b/packages/matchbox/src/components/Modal/Modal.js
@@ -38,7 +38,7 @@ const StyledContent = styled(Box)`
   ${contentAnimation}
 `;
 
-const Modal = React.forwardRef(function Modal(props, ref) {
+const Modal = React.forwardRef(function Modal(props, userRef) {
   const {
     children,
     className,
@@ -81,6 +81,13 @@ const Modal = React.forwardRef(function Modal(props, ref) {
   useWindowEvent('keydown', handleEscape);
   useWindowEvent('click', handleOutsideClick);
 
+  // Focuses container when opening
+  React.useLayoutEffect(() => {
+    if (open) {
+      contentRef.current.focus();
+    }
+  }, [open]);
+
   return (
     <>
       <ScrollLock isActive={open} />
@@ -117,14 +124,21 @@ const Modal = React.forwardRef(function Modal(props, ref) {
                       <StyledContent
                         state={state}
                         tabIndex="-1"
-                        ref={ref}
+                        ref={userRef}
                         display="flex"
                         justifyContent="center"
                         data-id="modal-content-wrapper"
                       >
-                        <Box ref={contentRef} width="100%" maxWidth={maxWidth} bg="white">
+                        <Box
+                          ref={contentRef}
+                          width="100%"
+                          maxWidth={maxWidth}
+                          bg="white"
+                          tabIndex="-1"
+                          data-id="modal-content-panel"
+                        >
                           {getChild('Modal.Header', children, { onClose })}
-                          {getChild('Modal.Content', children, { ref, open })}
+                          {getChild('Modal.Content', children, { open })}
                           {getChild('Modal.Footer', children)}
                         </Box>
                       </StyledContent>


### PR DESCRIPTION

### What Changed
- Focuses on a modal content container when opening

### How To Test or Verify
- Run storybook
- Visit http://localhost:9001/?path=/story/overlays-modal--toggle-example
- Verify focus is on the container when opening

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
