### PR TITLE
UX-362 Update responsive Empty States

### DIFF
--- a/config/helpers.js
+++ b/config/helpers.js
@@ -53,3 +53,8 @@ global.renderStyled = node => {
 global.mountStyled = node => {
   return mount(<ThemeProvider skipGlobalStyles>{node}</ThemeProvider>);
 };
+
+global.matchMedia = () => ({
+  addListener: jest.fn(),
+  removeListener: jest.fn(),
+});

--- a/cypress/integration/Layout.spec.js
+++ b/cypress/integration/Layout.spec.js
@@ -4,14 +4,14 @@ describe('Layout', () => {
   it('should render non-mobile layout', () => {
     cy.viewport(1500, 500);
     cy.visit('/iframe.html?path=/story/layout-layout--annotated-example');
-    cy.get('[data-id="annotated-section"]').should('have.css', 'width', '345px');
-    cy.get('[data-id="detail-section"]').should('have.css', 'width', '1035px');
+    cy.get('[data-id="annotated-section"]').should('have.attr', 'width', '0.3333333333333333');
+    cy.get('[data-id="detail-section"]').should('have.attr', 'width', '1');
   });
 
   it('should render mobile layout', () => {
     cy.viewport(500, 500);
     cy.visit('/iframe.html?path=/story/layout-layout--annotated-example');
-    cy.get('[data-id="annotated-section"]').should('have.css', 'width', '404px');
-    cy.get('[data-id="detail-section"]').should('have.css', 'width', '404px');
+    cy.get('[data-id="annotated-section"]').should('have.attr', 'width', '100%');
+    cy.get('[data-id="detail-section"]').should('have.attr', 'width', '100%');
   });
 });

--- a/cypress/integration/Layout.spec.js
+++ b/cypress/integration/Layout.spec.js
@@ -1,0 +1,17 @@
+/// <reference types="Cypress" />
+
+describe('Layout', () => {
+  it('should render non-mobile layout', () => {
+    cy.viewport(1500, 500);
+    cy.visit('/iframe.html?path=/story/layout-layout--annotated-example');
+    cy.get('[data-id="annotated-section"]').should('have.css', 'width', '345px');
+    cy.get('[data-id="detail-section"]').should('have.css', 'width', '1035px');
+  });
+
+  it('should render mobile layout', () => {
+    cy.viewport(500, 500);
+    cy.visit('/iframe.html?path=/story/layout-layout--annotated-example');
+    cy.get('[data-id="annotated-section"]').should('have.css', 'width', '404px');
+    cy.get('[data-id="detail-section"]').should('have.css', 'width', '404px');
+  });
+});

--- a/packages/matchbox/src/components/Columns/Columns.js
+++ b/packages/matchbox/src/components/Columns/Columns.js
@@ -5,13 +5,12 @@ import styled from 'styled-components';
 import { pick } from '../../helpers/systemProps';
 import { createPropTypes } from '@styled-system/prop-types';
 import { margin } from 'styled-system';
-import { tokens } from '@sparkpost/design-tokens';
 import { ColumnsContext } from './context';
 import { verticalAlignment, horizontalAlignment, reverseColumns, negativeMargin } from './styles';
-import { useWindowSize } from '../../helpers/geometry';
+import useBreakpoint from '../../hooks/useBreakpoint';
 import { Box } from '../Box';
 
-const breakpoints = ['xs', 'sm', 'md', 'lg', 'xl'];
+const breakpoints = ['default', 'xs', 'sm', 'md', 'lg', 'xl'];
 
 const StyledColumns = styled(Box)`
   ${verticalAlignment}
@@ -22,21 +21,13 @@ const StyledColumns = styled(Box)`
 
 const Columns = React.forwardRef(function Columns(props, ref) {
   const { children, reverse, space, alignY, align, collapseBelow, ...rest } = props;
-  const [collapsed, setCollapsed] = React.useState(false);
-
   const systemProps = pick(rest, margin.propNames);
+  const breakpoint = useBreakpoint();
 
-  const windowSize = useWindowSize();
-
-  React.useLayoutEffect(() => {
-    if (collapseBelow) {
-      if (windowSize.width <= parseInt(tokens[`mediaQuery_${collapseBelow}`], 10)) {
-        setCollapsed(true);
-      } else {
-        setCollapsed(false);
-      }
-    }
-  }, [windowSize, collapseBelow]);
+  const collapsed = React.useMemo(() => {
+    const arr = breakpoints.slice(breakpoints.findIndex(bp => bp === breakpoint));
+    return arr.includes(collapseBelow);
+  }, [breakpoint, collapseBelow]);
 
   return (
     <Box {...systemProps} data-id={props['data-id']}>

--- a/packages/matchbox/src/components/Columns/tests/Columns.test.js
+++ b/packages/matchbox/src/components/Columns/tests/Columns.test.js
@@ -14,12 +14,6 @@ describe('Columns', () => {
       </Columns>,
     );
 
-  const resizeWindow = (x, y) => {
-    window.innerWidth = x;
-    window.innerHeight = y;
-    window.dispatchEvent(new Event('resize'));
-  };
-
   it('should render data-id', () => {
     const wrapper = subject();
     expect(wrapper.find('[data-id="test-id"]')).toExist();
@@ -55,12 +49,7 @@ describe('Columns', () => {
 
   it('collapses columns with collapseBelow', () => {
     const fullWidthWrapper = subject({ collapseBelow: 'sm' });
-    expect(fullWidthWrapper.find('div').at(2)).toHaveStyleRule('width', '50%');
-    expect(fullWidthWrapper.find('div').at(3)).toHaveStyleRule('width', '50%');
-
-    resizeWindow(500, 500);
-    const resizedWrapper = subject({ collapseBelow: 'sm' });
-    expect(resizedWrapper.find('div').at(2)).toHaveStyleRule('width', '100%');
-    expect(resizedWrapper.find('div').at(3)).toHaveStyleRule('width', '100%');
+    expect(fullWidthWrapper.find('div').at(2)).toHaveStyleRule('width', '100%');
+    expect(fullWidthWrapper.find('div').at(3)).toHaveStyleRule('width', '100%');
   });
 });

--- a/packages/matchbox/src/components/EmptyState/EmptyState.js
+++ b/packages/matchbox/src/components/EmptyState/EmptyState.js
@@ -1,5 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { margin } from 'styled-system';
+import { createPropTypes } from '@styled-system/prop-types';
+import { Box } from '../Box';
+import { Columns } from '../Columns';
+import { Column } from '../Column';
+import { Inline } from '../Inline';
 import Action from './Action';
 import Header from './Header';
 import Content from './Content';
@@ -7,22 +13,19 @@ import List from './List';
 import Image from './Image';
 import Legacy from './Legacy';
 import { getChild } from '../../helpers/children';
-import { margin } from 'styled-system';
 import { pick } from '../../helpers/systemProps';
-import { createPropTypes } from '@styled-system/prop-types';
-
-import { Box } from '../Box';
-import { Columns } from '../Columns';
-import { Column } from '../Column';
-import { Inline } from '../Inline';
+import useBreakpoint from '../../hooks/useBreakpoint';
 
 const EmptyState = React.forwardRef(function EmptyState(props, userRef) {
   const { children, ...rest } = props;
+  const breakpoint = useBreakpoint();
+  const isMobile = ['default', 'xs', 'sm'].includes(breakpoint);
 
   const systemProps = pick(rest, margin.propNames);
 
   return (
     <Columns collapseBelow="sm" space="500" alignY="center" {...systemProps} ref={userRef}>
+      {isMobile ? <Column width={1 / 2}>{getChild('EmptyState.Image', children)}</Column> : null}
       <Column width={1 / 2}>
         {getChild('EmptyState.Header', children)}
         {getChild('EmptyState.Content', children)}
@@ -30,7 +33,7 @@ const EmptyState = React.forwardRef(function EmptyState(props, userRef) {
           <Inline space="500">{getChild('EmptyState.Action', children)}</Inline>
         </Box>
       </Column>
-      <Column width={1 / 2}>{getChild('EmptyState.Image', children)}</Column>
+      {!isMobile ? <Column width={1 / 2}>{getChild('EmptyState.Image', children)}</Column> : null}
     </Columns>
   );
 });

--- a/packages/matchbox/src/components/EmptyState/Image.js
+++ b/packages/matchbox/src/components/EmptyState/Image.js
@@ -8,7 +8,7 @@ const Image = React.forwardRef(function Image(props, userRef) {
   const { src, className, children } = props;
 
   return (
-    <StyledImage display={['none', null, 'block']} width="100%" height="auto" ref={userRef}>
+    <StyledImage display="block" width="100%" height="auto" ref={userRef}>
       <Picture className={className}>
         {children}
         <Picture.Image src={src} />

--- a/packages/matchbox/src/components/Layout/tests/Section.test.js
+++ b/packages/matchbox/src/components/Layout/tests/Section.test.js
@@ -31,6 +31,6 @@ describe('Layout', () => {
       </Layout>,
     );
 
-    expect(wrapper.find('div').at(2)).toHaveStyleRule('width', `${100 * (1 / 3)}%`);
+    expect(wrapper.find('div').at(2)).toHaveStyleRule('width', `100%`);
   });
 });

--- a/stories/layout/Layout.stories.js
+++ b/stories/layout/Layout.stories.js
@@ -57,13 +57,13 @@ export const CollapseBelowExample = withInfo()(() => (
 export const AnnotatedExample = withInfo()(() => (
   <Page title="Domain Details" breadcrumbAction={breadcrumbAction}>
     <Layout>
-      <Layout.Section annotated>
+      <Layout.Section annotated data-id="annotated-section">
         <Layout.SectionTitle>Domain Status</Layout.SectionTitle>
         <Text fontSize="200" color="gray.700">
           Domain status text
         </Text>
       </Layout.Section>
-      <Layout.Section>
+      <Layout.Section data-id="detail-section">
         <Panel>
           <Panel.Section>
             <Columns collapseBelow="md">


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed
- Updates EmptyState so images appear above the text on smaller screen sizes
- Refactors Columns to use `useBreakpoint` instead of listening to window size

### How To Test or Verify
- Run storybook
- Visit http://localhost:9001/?path=/story/layout-empty-state--basic-empty-state
- Verify responsiveness

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
