### PR TITLE
UX-365 Make LabelValue composable

### DIFF
--- a/packages/matchbox/src/components/LabelValue/LabelValue.js
+++ b/packages/matchbox/src/components/LabelValue/LabelValue.js
@@ -5,11 +5,24 @@ import styled from 'styled-components';
 import { tokens } from '@sparkpost/design-tokens';
 import { margin } from 'styled-system';
 import { pick } from '../../helpers/systemProps';
+import { getChild } from '../../helpers/children';
 import { Box } from '../Box';
 
 const StyledWrapper = styled.div`
   ${margin}
 `;
+
+const Label = ({ children, orientation }) => (
+  <Box fontSize="200" fontWeight="semibold" mb={orientation === 'vertical' ? '100' : ''}>
+    {children}
+  </Box>
+);
+
+Label.displayName = 'LabelValue.Label';
+
+const Value = ({ children }) => <Box>{children}</Box>;
+
+Value.displayName = 'LabelValue.Value';
 
 const LabelValue = React.forwardRef(function LabelValue(props, userRef) {
   const { label, children, className, orientation, ...rest } = props;
@@ -23,10 +36,8 @@ const LabelValue = React.forwardRef(function LabelValue(props, userRef) {
         gridGap={orientation === 'horizontal' ? '300' : ''}
         gridTemplateColumns={orientation === 'horizontal' ? `${tokens.spacing_900} 1fr` : ''}
       >
-        <Box fontSize="200" fontWeight="semibold" mb={orientation === 'vertical' ? '100' : ''}>
-          {label}
-        </Box>
-        <Box>{children}</Box>
+        {getChild('LabelValue.Label', children, { orientation })}
+        {getChild('LabelValue.Value', children)}
       </Box>
     </StyledWrapper>
   );
@@ -44,5 +55,8 @@ LabelValue.propTypes = {
 LabelValue.defaultProps = {
   orientation: 'vertical',
 };
+
+LabelValue.Label = Label;
+LabelValue.Value = Value;
 
 export default LabelValue;

--- a/packages/matchbox/src/components/LabelValue/tests/LabelValue.test.js
+++ b/packages/matchbox/src/components/LabelValue/tests/LabelValue.test.js
@@ -5,8 +5,9 @@ import 'jest-styled-components';
 describe('LabelValue', () => {
   it('renders correctly', () => {
     const wrapper = global.mountStyled(
-      <LabelValue label="Label text" className="test-class">
-        children
+      <LabelValue className="test-class">
+        <LabelValue.Label>Label text</LabelValue.Label>
+        <LabelValue.Value>children</LabelValue.Value>
       </LabelValue>,
     );
     expect(wrapper.text()).toEqual('Label textchildren');
@@ -20,8 +21,9 @@ describe('LabelValue', () => {
 
   it('renders horizontal orientation correctly', () => {
     const wrapper = global.mountStyled(
-      <LabelValue label="Label text" orientation="horizontal">
-        children
+      <LabelValue orientation="horizontal">
+        <LabelValue.Label>Label text</LabelValue.Label>
+        <LabelValue.Value>children</LabelValue.Value>
       </LabelValue>,
     );
     expect(wrapper.find('div').at(1)).toHaveStyleRule('display', 'grid');

--- a/stories/layout/LabelValue.stories.js
+++ b/stories/layout/LabelValue.stories.js
@@ -7,23 +7,33 @@ export default {
 };
 
 export const VerticalOrientation = withInfo()(() => (
-  <LabelValue label="Label">Just a LabelValue</LabelValue>
+  <LabelValue>
+    <LabelValue.Label>Label</LabelValue.Label>
+    <LabelValue.Value>Just a LabelValue</LabelValue.Value>
+  </LabelValue>
 ));
 export const HorizontalOrientation = withInfo()(() => (
-  <LabelValue orientation="horizontal" label="Label">
-    Just a LabelValue
+  <LabelValue orientation="horizontal">
+    <LabelValue.Label>Label</LabelValue.Label>
+    <LabelValue.Value>Just a LabelValue</LabelValue.Value>
   </LabelValue>
 ));
 
 export const HorizontalWithWrapping = withInfo()(() => (
-  <LabelValue orientation="horizontal" label="Label with wrapping behavior">
-    <div>Just a LabelValue</div>
-    <div>Just a LabelValue</div>
+  <LabelValue orientation="horizontal">
+    <LabelValue.Label>Label with wrapping behavior</LabelValue.Label>
+    <LabelValue.Value>
+      <div>Just a LabelValue</div>
+      <div>Just a LabelValue</div>
+    </LabelValue.Value>
   </LabelValue>
 ));
 
 export const SystemProps = withInfo()(() => (
-  <LabelValue label="Label" mx="600" my="800">
-    <div>Just a LabelValue</div>
+  <LabelValue mx="600" my="800">
+    <LabelValue.Label>Label</LabelValue.Label>
+    <LabelValue.Value>
+      <div>Just a LabelValue</div>
+    </LabelValue.Value>
   </LabelValue>
 ));


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed

- Updates `LabelValue` component to be composable
- Adds `LabelValue.Label` and `LabelValue.Value` components

### How To Test or Verify

- `npm run start:storybook`
- verify `LabelValue` stories

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
