### PR TITLE
UX-383 Add disabled prop and styles to UnstyledLink

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24102,7 +24102,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -24583,7 +24583,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -26609,7 +26609,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },

--- a/packages/matchbox/src/components/UnstyledLink/UnstyledLink.js
+++ b/packages/matchbox/src/components/UnstyledLink/UnstyledLink.js
@@ -1,11 +1,39 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 import { deprecate } from '../../helpers/propTypes';
 
 import { Text } from '../Text';
 
+const StyledText = styled(Text)`
+  ${props => {
+    if (props.disabled) {
+      return `
+        opacity: 0.6;
+        color: ${props.theme.colors.gray['900']};
+        &:hover {
+          color: ${props.theme.colors.gray['900']};
+          cursor: not-allowed;
+        }
+    `;
+    }
+  }}
+`;
+
 const UnstyledLink = React.forwardRef(function UnstyledLink(props, ref) {
-  const { children, to, title, Component, component, external, onClick, role, ...rest } = props;
+  const {
+    children,
+    to,
+    title,
+    Component,
+    component,
+    external,
+    onClick,
+    role,
+    disabled,
+    ...rest
+  } = props;
+  console.log(disabled);
 
   const WrapperComponent = component || Component;
   const linkTitle = external && !title ? 'Opens in a new tab' : title;
@@ -13,7 +41,7 @@ const UnstyledLink = React.forwardRef(function UnstyledLink(props, ref) {
 
   if (to && !WrapperComponent) {
     return (
-      <Text
+      <StyledText
         as="a"
         href={to}
         target={external ? '_blank' : ''}
@@ -21,34 +49,44 @@ const UnstyledLink = React.forwardRef(function UnstyledLink(props, ref) {
         title={linkTitle}
         onClick={onClick}
         role={role}
+        disabled={disabled}
         ref={ref}
         {...rest}
       >
         {children}
-      </Text>
+      </StyledText>
     );
   }
 
   if (WrapperComponent) {
     return (
-      <Text
+      <StyledText
         as={WrapperComponent}
         onClick={onClick}
         ref={ref}
         role={role}
+        disabled={disabled}
         title={linkTitle}
         to={to}
         {...rest}
       >
         {children}
-      </Text>
+      </StyledText>
     );
   }
 
   return (
-    <Text as="a" title={linkTitle} role={linkRole} onClick={onClick} ref={ref} {...rest}>
+    <StyledText
+      as="a"
+      title={linkTitle}
+      role={linkRole}
+      onClick={onClick}
+      ref={ref}
+      disabled={disabled}
+      {...rest}
+    >
       {children}
-    </Text>
+    </StyledText>
   );
 });
 
@@ -56,6 +94,7 @@ UnstyledLink.displayName = 'UnstyledLink';
 
 UnstyledLink.propTypes = {
   to: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  disabled: PropTypes.bool,
   title: PropTypes.string,
   external: PropTypes.bool,
   component: PropTypes.elementType,

--- a/stories/navigation/UnstyledLink.stories.js
+++ b/stories/navigation/UnstyledLink.stories.js
@@ -28,6 +28,8 @@ export const WithWrapperComponents = withInfo()(() => (
   </>
 ));
 
+export const Disabled = withInfo()(() => <UnstyledLink disabled>Disabled Link</UnstyledLink>);
+
 export const WithTextProps = withInfo()(() => (
   <>
     <UnstyledLink mr={400} color="purple.600" to="https://google.com" external>


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed

- Adds `disabled` prop of type `bool` to `UnstyledLink`
- Adds CSS to signify that the `UnstyledLink` is disabled
- Fixes #700 

### How To Test or Verify

- `npm run start:storybook`
- Verify [UnstyledLink story](http://localhost:9001/?path=/story/navigation-unstyledlink--disabled)

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
