### PR TITLE
UX-381 Make Modal.Content height restriction optional

### DIFF
--- a/packages/matchbox/src/components/Modal/Content.js
+++ b/packages/matchbox/src/components/Modal/Content.js
@@ -7,7 +7,7 @@ import { pick } from '../../helpers/props';
 import { Box } from '../Box';
 
 const Content = React.forwardRef(function Content(props, ref) {
-  const { children, ...rest } = props;
+  const { children, restrictHeight, ...rest } = props;
   const systemProps = pick(rest, padding.propNames);
 
   return (
@@ -15,8 +15,8 @@ const Content = React.forwardRef(function Content(props, ref) {
       data-id="modal-content"
       p="500"
       {...systemProps}
-      maxHeight="60vh"
-      overflowY="auto"
+      maxHeight={restrictHeight ? '60vh' : null}
+      overflowY={restrictHeight ? 'auto' : null}
       ref={ref}
     >
       {children}
@@ -25,8 +25,12 @@ const Content = React.forwardRef(function Content(props, ref) {
 });
 
 Content.displayName = 'Modal.Content';
+Content.defaultProps = {
+  restrictHeight: true,
+};
 Content.propTypes = {
   children: PropTypes.node,
+  restrictHeight: PropTypes.bool,
   ...createPropTypes(padding.propNames),
 };
 

--- a/packages/matchbox/src/components/Modal/Modal.js
+++ b/packages/matchbox/src/components/Modal/Modal.js
@@ -101,13 +101,7 @@ const Modal = React.forwardRef(function Modal(props, userRef) {
             role="dialog"
             aria-modal="true"
           >
-            <Box
-              p={['400', null, '700']}
-              pt={['5rem', null]}
-              size="100%"
-              ref={overlayRef}
-              data-id="modal-overlay"
-            >
+            <Box size="100%" ref={overlayRef} data-id="modal-overlay">
               <StyledWrapper>
                 <StyledFocusLock disabled={!open || isInIframe()}>
                   <Transition
@@ -128,6 +122,7 @@ const Modal = React.forwardRef(function Modal(props, userRef) {
                         display="flex"
                         justifyContent="center"
                         data-id="modal-content-wrapper"
+                        p={['400', null, '700']}
                       >
                         <Box
                           ref={contentRef}

--- a/packages/matchbox/src/components/Modal/tests/Modal.test.js
+++ b/packages/matchbox/src/components/Modal/tests/Modal.test.js
@@ -3,11 +3,11 @@ import Modal from '../Modal';
 import { Button } from '../../Button';
 import { onKey } from '../../../helpers/keyEvents';
 
-const subject = props =>
+const subject = (props = {}, contentProps = {}) =>
   global.mountStyled(
     <Modal {...props}>
       <Modal.Header showCloseButton={props.showCloseButton}>Modal Header</Modal.Header>
-      <Modal.Content>Modal Content</Modal.Content>
+      <Modal.Content {...contentProps}>Modal Content</Modal.Content>
       <Modal.Footer>
         <Button>Primary Button</Button>
         <Button>Secondary Button</Button>
@@ -32,6 +32,18 @@ describe('Modal', () => {
     const wrapper = subject({ open: true });
 
     expect(wrapper.find('[data-id="modal-content-wrapper"]')).toExist();
+  });
+
+  it('renders restricted modal height by default', () => {
+    const wrapper = subject({ open: true });
+
+    expect(wrapper.find('[data-id="modal-content"]').at(0)).toHaveStyleRule('max-height', '60vh');
+  });
+
+  it('renders unrestricted modal height when "restrictHeight" is set to false', () => {
+    const wrapper = subject({ open: true }, { restrictHeight: false });
+
+    expect(wrapper.find('[data-id="modal-content"]').at(0)).not.toHaveStyleRule('max-height');
   });
 
   it('renders with relevant ARIA attributes', () => {

--- a/stories/overlays/Modal.stories.js
+++ b/stories/overlays/Modal.stories.js
@@ -38,7 +38,7 @@ export const ConfigurableButtons = withInfo()(() => (
   </Modal>
 ));
 
-export const TallModal = withInfo()(() => (
+export const TallModal = () => (
   <Modal p={800} showCloseButton open portalId={PORTAL_ID}>
     <Modal.Header showCloseButton>Modal Title</Modal.Header>
     <Modal.Content>
@@ -52,7 +52,23 @@ export const TallModal = withInfo()(() => (
       <Button>Tertiary Button</Button>
     </Modal.Footer>
   </Modal>
-));
+);
+
+export const TallModalWithoutHeightRestriction = () => (
+  <Modal p={800} showCloseButton open portalId={PORTAL_ID}>
+    <Modal.Header showCloseButton>Modal Title</Modal.Header>
+    <Modal.Content restrictHeight={false}>
+      <Box p="300" height="2000px" bg="blue.300">
+        Tall Modal Content
+      </Box>
+    </Modal.Content>
+    <Modal.Footer>
+      <Button>Primary Button</Button>
+      <Button>Secondary Button</Button>
+      <Button>Tertiary Button</Button>
+    </Modal.Footer>
+  </Modal>
+);
 
 export const ToggleExample = () => {
   const modal = useModal();


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed
- Adds a new prop on `Modal.Content` `restrictHeight`
- This new prop defaults to true, setting it to false allows Modals to expand to its contents height

### How To Test or Verify
- Run storybook
- Visit http://localhost:9001/?path=/story/overlays-modal--tall-modal-without-height-restriction
- Visit http://localhost:9001/?path=/story/overlays-modal--tall-modal
- Verify behavior works as expected

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
