### PR TITLE
UX-401 Disable UnstyledLinks interaction when disabled

### DIFF
--- a/packages/matchbox/src/components/UnstyledLink/UnstyledLink.js
+++ b/packages/matchbox/src/components/UnstyledLink/UnstyledLink.js
@@ -9,11 +9,10 @@ const StyledText = styled(Text)`
   ${props => {
     if (props.disabled) {
       return `
-        opacity: 0.6;
-        color: ${props.theme.colors.gray['900']};
-        &:hover {
+        &, &:visited {
+          opacity: 0.6;
           color: ${props.theme.colors.gray['900']};
-          cursor: not-allowed;
+          pointer-events: none;
         }
     `;
     }
@@ -31,13 +30,20 @@ const UnstyledLink = React.forwardRef(function UnstyledLink(props, ref) {
     onClick,
     role,
     disabled,
+    tabIndex,
     ...rest
   } = props;
-  console.log(disabled);
 
   const WrapperComponent = component || Component;
   const linkTitle = external && !title ? 'Opens in a new tab' : title;
   const linkRole = role ? role : !!onClick ? 'button' : null;
+
+  const disabledAttributes = {
+    'aria-disabled': disabled,
+    disabled,
+    tabIndex: disabled ? '-1' : tabIndex,
+    onClick: disabled ? () => false : onClick,
+  };
 
   if (to && !WrapperComponent) {
     return (
@@ -49,9 +55,9 @@ const UnstyledLink = React.forwardRef(function UnstyledLink(props, ref) {
         title={linkTitle}
         onClick={onClick}
         role={role}
-        disabled={disabled}
         ref={ref}
         {...rest}
+        {...disabledAttributes}
       >
         {children}
       </StyledText>
@@ -65,10 +71,10 @@ const UnstyledLink = React.forwardRef(function UnstyledLink(props, ref) {
         onClick={onClick}
         ref={ref}
         role={role}
-        disabled={disabled}
         title={linkTitle}
         to={to}
         {...rest}
+        {...disabledAttributes}
       >
         {children}
       </StyledText>
@@ -82,8 +88,8 @@ const UnstyledLink = React.forwardRef(function UnstyledLink(props, ref) {
       role={linkRole}
       onClick={onClick}
       ref={ref}
-      disabled={disabled}
       {...rest}
+      {...disabledAttributes}
     >
       {children}
     </StyledText>
@@ -102,6 +108,7 @@ UnstyledLink.propTypes = {
   children: PropTypes.node,
   onClick: PropTypes.func,
   role: PropTypes.string,
+  tabIndex: PropTypes.string,
 };
 
 export default UnstyledLink;

--- a/packages/matchbox/src/components/UnstyledLink/tests/UnstyledLink.test.js
+++ b/packages/matchbox/src/components/UnstyledLink/tests/UnstyledLink.test.js
@@ -49,4 +49,32 @@ describe('UnstyledLink', () => {
     expect(wrapper.find('a').text()).toEqual('Hola!');
     expect(wrapper.find('a').prop('role')).toEqual('test-role');
   });
+
+  it('invokes an onClick handler', () => {
+    const onClick = jest.fn();
+    let wrapper = subject({ onClick });
+    wrapper.find('a').simulate('click');
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('sets tabIndex correctly', () => {
+    let wrapper = subject({ tabIndex: '3' });
+    expect(wrapper).toHaveAttributeValue('tabindex', '3');
+  });
+
+  describe('disabled', () => {
+    it('renders a disabled link correctly', () => {
+      let wrapper = subject({ disabled: true, tabIndex: '3' });
+      expect(wrapper).toHaveAttributeValue('aria-disabled', 'true');
+      expect(wrapper).toHaveAttributeValue('tabindex', '-1');
+      expect(wrapper.find('a').prop('disabled')).toEqual(true);
+    });
+
+    it('does not invoke an onClick handler', () => {
+      const onClick = jest.fn();
+      let wrapper = subject({ onClick, disabled: true });
+      wrapper.find('a').simulate('click');
+      expect(onClick).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/stories/navigation/UnstyledLink.stories.js
+++ b/stories/navigation/UnstyledLink.stories.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { withInfo } from '@storybook/addon-info';
-import { action } from '@storybook/addon-actions';
-import { UnstyledLink } from '@sparkpost/matchbox';
+import { UnstyledLink, Stack } from '@sparkpost/matchbox';
 
 export default {
   title: 'Navigation|UnstyledLink',
@@ -11,9 +10,9 @@ function DemoWrapper(props) {
   return <a>{props.children}</a>;
 }
 
-export const WithAnOnClickAction = withInfo()(() => (
-  <UnstyledLink onClick={action('Handle Click')}>A link</UnstyledLink>
-));
+export const WithAnOnClickAction = () => (
+  <UnstyledLink onClick={() => console.log('click')}>A link</UnstyledLink>
+);
 
 export const WithAnExternalLink = withInfo()(() => (
   <UnstyledLink to="https://google.com" external>
@@ -28,7 +27,20 @@ export const WithWrapperComponents = withInfo()(() => (
   </>
 ));
 
-export const Disabled = withInfo()(() => <UnstyledLink disabled>Disabled Link</UnstyledLink>);
+export const Disabled = () => (
+  <Stack>
+    <UnstyledLink disabled>Disabled Link without href</UnstyledLink>
+    <UnstyledLink disabled to="#">
+      Disabled Link with href
+    </UnstyledLink>
+    <UnstyledLink disabled onClick={() => console.log('i should not be clickable')}>
+      Disabled Link with onClick
+    </UnstyledLink>
+    <UnstyledLink disabled to="#" onClick={() => console.log('i should not be clickable')}>
+      Disabled Link with onClick and href
+    </UnstyledLink>
+  </Stack>
+);
 
 export const WithTextProps = withInfo()(() => (
   <>


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed
- Adds `aria-disabled` `tabindex` and an `onClick` handler when `UnstyledLink`s are `disabled`
<!--
What changes does this PR propose?
Provide screenshots or [screen recordings](https://getkap.co/) for any visual changes.
-->

### How To Test or Verify
- Run storybook
- Visit http://localhost:9001/?path=/story/navigation-unstyledlink--disabled
- Verify links are not clickable or focusable
<!--
Describe any steps that may help reviewers verify changes.
Anything beyond basic unit testing, such as assistive tech usage, or special interactions.
-->

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
