### PR TITLE
UX-402 Fix Listbox padding as inline element

### DIFF
--- a/packages/matchbox/src/components/ListBox/ListBox.js
+++ b/packages/matchbox/src/components/ListBox/ListBox.js
@@ -38,6 +38,7 @@ const StyledButton = styled(Button)`
   font-size: ${props => props.theme.fontSizes['200']};
   font-weight: ${props => props.theme.fontWeights['medium']};
   background: ${props => (props.disabled ? props.theme.colors.gray['200'] : '')};
+  padding-right: ${props => props.theme.space[650]};
   &:hover {
     background: ${props => (props.disabled ? props.theme.colors.gray['200'] : 'transparent')};
   }

--- a/packages/matchbox/src/components/ListBox/styles.js
+++ b/packages/matchbox/src/components/ListBox/styles.js
@@ -7,7 +7,7 @@ import { UnstyledLink } from '../UnstyledLink';
 export const chevron = props => `
   position: absolute;
   z-index: ${props.theme.zIndex_default};
-  top: 8%;
+  top: 3%;
   right: ${props.theme.space['300']};
   height: 100%;
   fill: ${props.theme.colors.blue['700']};

--- a/stories/form/ListBox.stories.js
+++ b/stories/form/ListBox.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { withInfo } from '@storybook/addon-info';
-import { ListBox } from '@sparkpost/matchbox';
+import { ListBox, Inline } from '@sparkpost/matchbox';
 
 export default {
   title: 'Form|ListBox',
@@ -130,3 +130,14 @@ export const WithARef = withInfo()(() => {
   }
   return <Example />;
 });
+
+export const AsAnInlineElement = () => (
+  <Inline>
+    <ListBox id="listbox-4" label="Select an option" placeholder="Select One">
+      <ListBox.Option value="option-1">Option 1</ListBox.Option>
+      <ListBox.Option value="option-2">Option 2</ListBox.Option>
+      <ListBox.Option value="option-3">Option 3</ListBox.Option>
+      <ListBox.Option value="option-4">Option 4</ListBox.Option>
+    </ListBox>
+  </Inline>
+);


### PR DESCRIPTION
### What Changed
- Adds additional padding-right to the ListBox component

### How To Test or Verify
- Run storybook, visit the new ListBox story: http://localhost:9001/?path=/story/form-listbox--as-an-inline-element

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
