### PR TITLE
Resolves #706 Add noticable focus indicator on Expandable buttons

### DIFF
--- a/packages/matchbox/src/components/Expandable/styles.js
+++ b/packages/matchbox/src/components/Expandable/styles.js
@@ -1,6 +1,6 @@
 import { tokens } from '@sparkpost/design-tokens';
 import css from '@styled-system/css';
-import { buttonReset } from '../../styles/helpers';
+import { buttonReset, focusOutline } from '../../styles/helpers';
 import styled from 'styled-components';
 
 export const StyledHeader = styled('button')`
@@ -76,7 +76,8 @@ export const arrow = props => {
 
     ${StyledHeader}:hover &, ${StyledHeader}:focus & {	
       background: ${tokens.color_blue_200};	
-      color: ${tokens.color_blue_800};	
+      color: ${tokens.color_blue_800};
+      ${focusOutline({ modifier: '&', radius: tokens.borderRadius_circle })}
     }
   `;
 };

--- a/packages/matchbox/src/styles/helpers.js
+++ b/packages/matchbox/src/styles/helpers.js
@@ -48,6 +48,7 @@ export const focusOutline = ({
   color = tokens.color_blue_700,
   modifier = '&:focus',
   offset = '3px',
+  radius = tokens.borderRadius_200,
 } = {}) => `
   position: relative;
   outline: none;
@@ -61,7 +62,7 @@ export const focusOutline = ({
     right: -${offset};
     bottom: -${offset};
     transition: box-shadow ${tokens.motionDuration_fast};
-    border-radius: ${tokens.borderRadius_200};
+    border-radius: ${radius};
     box-shadow: none;
     pointer-events: none;
   } 

--- a/site/src/pages/components/mixins.mdx
+++ b/site/src/pages/components/mixins.mdx
@@ -58,3 +58,6 @@ const Button = styled.button`
 <Prop name="offest" type="string" defaultValue="'3px'">
   Distance of the focus ring to the element
 </Prop>
+<Prop name="radius" type="string" defaultValue="tokens.borderRadius_200">
+  Border radius of the focus ring
+</Prop>


### PR DESCRIPTION
Closes #706 

### What Changed
- Adds a radius option to the focusOutline helper
- Adds a focus outline to the Expandable button

### How To Test or Verify

- Run storybook and visit: http://localhost:9001/?path=/story/layout-expandable--with-image-title-and-subtitle
- Verify the Expandable toggle button has a visual outline

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
