### PR TITLE
UX-400 - Handle disabled Actionlist Actions

### DIFF
--- a/packages/matchbox/src/components/ActionList/Action.js
+++ b/packages/matchbox/src/components/ActionList/Action.js
@@ -7,7 +7,7 @@ import { HelpText } from '../HelpText';
 import { StyledLink } from './styles';
 
 const Action = React.forwardRef(function Action(props, userRef) {
-  const { content, children, helpText, is = 'link', selected, ...action } = props;
+  const { content, children, disabled, helpText, is = 'link', selected, ...action } = props;
 
   const linkContent = React.useMemo(() => {
     return (
@@ -32,6 +32,7 @@ const Action = React.forwardRef(function Action(props, userRef) {
     <StyledLink
       as={is === 'button' ? 'button' : null}
       type={is === 'button' ? 'button' : null}
+      disabled={disabled}
       isType={is}
       ref={userRef}
       {...isAttributes}
@@ -46,6 +47,7 @@ Action.displayName = 'ActionList.Action';
 Action.propTypes = {
   content: PropTypes.node,
   children: PropTypes.node,
+  disabled: PropTypes.bool,
   /**
    * Same as hover styles.
    * Can be used for wrappers that manage focus within the menu, eg downshift

--- a/packages/matchbox/src/components/ActionList/styles.js
+++ b/packages/matchbox/src/components/ActionList/styles.js
@@ -44,4 +44,10 @@ export const StyledLink = styled(UnstyledLink)`
     color: ${tokens.color_blue_700};
     background: ${tokens.color_blue_100};
   }
+
+  ${'' /* This only applies to buttons, not links */}
+  &:disabled {
+    opacity: 0.6;
+    pointer-events: none;
+  }
 `;

--- a/packages/matchbox/src/components/ActionList/tests/ActionList.test.js
+++ b/packages/matchbox/src/components/ActionList/tests/ActionList.test.js
@@ -21,6 +21,25 @@ describe('ActionList', () => {
     ).toEqual('Action');
   });
 
+  it('renders disabled actions correctly', () => {
+    const onClick = jest.fn();
+    const wrapper = subject({
+      children: (
+        <>
+          <ActionList.Action disabled is="link" onClick={onClick}>
+            Action
+          </ActionList.Action>
+          <ActionList.Action disabled is="button">
+            Action 2
+          </ActionList.Action>
+        </>
+      ),
+    });
+    expect(wrapper.find('button')).toBeDisabled();
+    wrapper.find('a').simulate('click');
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
   it('renders help text correctly', () => {
     const wrapper = subject({
       children: (

--- a/site/src/pages/components/actionlist.mdx
+++ b/site/src/pages/components/actionlist.mdx
@@ -118,6 +118,10 @@ None
   Content of the ActionList Action
 </Prop>
 
+<Prop name="disabled" type="bool">
+  Disables the Action
+</Prop>
+
 <Prop name="helpText" type="string">
   Renders a string of secondary text
 </Prop>

--- a/site/src/pages/components/unstyledlink.mdx
+++ b/site/src/pages/components/unstyledlink.mdx
@@ -41,6 +41,9 @@ None
 <Prop name="children" type="React node">
   Contents of the link
 </Prop>
+<Prop name="disabled" type="bool">
+  Disables the link
+</Prop>
 <Prop name="component" type="elementType">
   Optional component wrapper for the link
 </Prop>

--- a/stories/action/ActionList.stories.js
+++ b/stories/action/ActionList.stories.js
@@ -179,6 +179,12 @@ export const AsButtonsAndCheckboxes = withInfo({ propTables: [ActionList] })(() 
         <ActionList.Action to="#" is="link" external>
           External Link
         </ActionList.Action>
+        <ActionList.Action to="#" is="button" disabled>
+          Disabled Button
+        </ActionList.Action>
+        <ActionList.Action to="#" is="link" external disabled>
+          Disabled External Link
+        </ActionList.Action>
       </ActionList>
     </Panel>
   </Box>


### PR DESCRIPTION
### What Changed
- Adds new `disabled` prop to Actionlist.Action
- Documents the new prop
- Also documents the new prop in UnstyledLink

### How To Test or Verify

- Run storybook and visit: http://localhost:9001/?path=/story/action-actionlist--as-buttons-and-checkboxes
- Verify the disabled button and link are not focusable or clickable

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
