### PR TITLE
UX-403 & Issue-710 Fix empty Modal.Footer & dynamic children

### DIFF
--- a/packages/matchbox/src/components/Modal/Footer.js
+++ b/packages/matchbox/src/components/Modal/Footer.js
@@ -1,22 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { getChild } from '../../helpers/children';
 import { Panel } from '../Panel';
 import { Box } from '../Box';
+import { Inline } from '../Inline';
 
 const buttonProps = {
   0: {
     color: 'blue',
-    mr: '400',
+    key: 'modal-primary',
   },
   1: {
     color: 'blue',
-    outlineBorder: true,
-    mr: '400',
+    variant: 'outline',
+    key: 'modal-secondary',
   },
   2: {
     color: 'blue',
-    flat: true,
+    variant: 'text',
+    key: 'modal-tertiary',
   },
 };
 
@@ -28,20 +29,24 @@ function getButtonProps(index, element) {
 }
 
 const Footer = React.forwardRef(function Footer({ children }, ref) {
-  let buttons = getChild('Button', children);
+  const buttons = React.Children.toArray(children);
 
   return (
     <Panel borderLeft="none" borderRight="none" borderBottom="none" ref={ref}>
       <Panel.Section>
-        <Box display="flex" justifyContent="space-between">
-          <Box>
-            {buttons[0] && React.cloneElement(buttons[0], getButtonProps(0, buttons[0]))}
-            {buttons[1] && React.cloneElement(buttons[1], getButtonProps(1, buttons[1]))}
+        {buttons && (
+          <Box display="flex" justifyContent="space-between">
+            <Inline space="300">
+              {buttons[0] && React.cloneElement(buttons[1], getButtonProps(0, buttons[0]))}
+              {buttons[1] && React.cloneElement(buttons[1], getButtonProps(1, buttons[1]))}
+            </Inline>
+            {buttons[2] && (
+              <Box>
+                {buttons[2] && React.cloneElement(buttons[2], getButtonProps(2, buttons[2]))}
+              </Box>
+            )}
           </Box>
-          {buttons[2] && (
-            <Box>{buttons[2] && React.cloneElement(buttons[2], getButtonProps(2, buttons[2]))}</Box>
-          )}
-        </Box>
+        )}
       </Panel.Section>
     </Panel>
   );

--- a/stories/overlays/Modal.stories.js
+++ b/stories/overlays/Modal.stories.js
@@ -20,6 +20,26 @@ export const Open = withInfo()(() => (
   </Modal>
 ));
 
+export const NonButtons = () => (
+  <Modal p={800} showCloseButton open portalId={PORTAL_ID}>
+    <Modal.Header showCloseButton>Modal Title</Modal.Header>
+    <Modal.Content>Modal Content</Modal.Content>
+    <Modal.Footer>
+      <Button>Primary Button</Button>
+      <Box as={Button}>Not a button</Box>
+      <Box as={Button}>Not a button</Box>
+    </Modal.Footer>
+  </Modal>
+);
+
+export const EmptyFooter = () => (
+  <Modal p={800} showCloseButton open portalId={PORTAL_ID}>
+    <Modal.Header showCloseButton>Modal Title</Modal.Header>
+    <Modal.Content>Modal Content</Modal.Content>
+    <Modal.Footer></Modal.Footer>
+  </Modal>
+);
+
 export const ConfigurableButtons = withInfo()(() => (
   <Modal p={800} showCloseButton open portalId={PORTAL_ID}>
     <Modal.Header showCloseButton>Modal Title</Modal.Header>


### PR DESCRIPTION
Closes #710 

<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed

- Modal.Footer buttons now use `variant` props instead of deprecated props
- Modal.Footer does not crash without children
- Modal.Footer now accepts non-Buttons as children, and renders them

### How To Test or Verify
- Run storybook and visit the new Modal stories:
- http://localhost:9001/?path=/story/overlays-modal--non-buttons
- http://localhost:9001/?path=/story/overlays-modal--empty-footer

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
