### PR TITLE
UX-404 Upgrades react-transition-group to resolve deprecated use of findDomNode

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -20,8 +20,10 @@ setDefaults({
 });
 
 storybook.addDecorator(storyFn => (
-  <ThemeProvider>
-    <Box p="700">{storyFn()}</Box>
-  </ThemeProvider>
+  <React.StrictMode>
+    <ThemeProvider>
+      <Box p="700">{storyFn()}</Box>
+    </ThemeProvider>
+  </React.StrictMode>
 ));
 storybook.configure(require.context('../stories', true, /\.stories\.js$/), module);

--- a/packages/matchbox/package-lock.json
+++ b/packages/matchbox/package-lock.json
@@ -1347,7 +1347,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "autoprefixer": {
       "version": "7.2.6",
@@ -1902,18 +1903,6 @@
             "json-parse-better-errors": "^1.0.1"
           }
         }
-      }
-    },
-    "css": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
-      "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.3",
-        "source-map": "^0.6.1",
-        "source-map-resolve": "^0.5.2",
-        "urix": "^0.1.0"
       }
     },
     "css-color-keywords": {
@@ -2681,6 +2670,11 @@
       "integrity": "sha512-WcKx5OY+KoSIAxBW6UBBRay1U6vkYheCdjyVNDm85zt5K9mHoGOfsOsqIszfAqrQQFIIKgjh2+FDgIj/zsl21Q==",
       "dev": true
     },
+    "csstype": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
+      "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ=="
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -2695,7 +2689,8 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "define-properties": {
       "version": "1.1.3",
@@ -2764,11 +2759,27 @@
       "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
     },
     "dom-helpers": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
-      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.0.tgz",
+      "integrity": "sha512-Ru5o9+V8CpunKnz5LGgWXkmrH/20cGKwcHwS4m73zIvs54CN9epEmT/HLqFJW3kXpakAFkEdzgy1hzlJe3E4OQ==",
       "requires": {
-        "@babel/runtime": "^7.1.2"
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+        }
       }
     },
     "dom-serializer": {
@@ -4288,15 +4299,6 @@
       "dev": true,
       "optional": true
     },
-    "jest-styled-components": {
-      "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/jest-styled-components/-/jest-styled-components-6.3.3.tgz",
-      "integrity": "sha512-RBMPZSJJSgPDTTJsuYzx5fsij/CULaqQNZOWkn8J/L++rX6P830o2vB9CXGzfQf/bVq9qGr1ZBNoivi+v6JPYg==",
-      "dev": true,
-      "requires": {
-        "css": "^2.2.4"
-      }
-    },
     "jest-worker": {
       "version": "26.1.0",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.1.0.tgz",
@@ -5345,11 +5347,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
       "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
     },
-    "react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-    },
     "react-scrolllock": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-scrolllock/-/react-scrolllock-5.0.1.tgz",
@@ -5372,14 +5369,14 @@
       }
     },
     "react-transition-group": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
-      "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
+      "integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
       "requires": {
-        "dom-helpers": "^3.4.0",
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2",
-        "react-lifecycles-compat": "^3.0.4"
+        "prop-types": "^15.6.2"
       }
     },
     "readable-stream": {
@@ -5583,7 +5580,8 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "ret": {
       "version": "0.1.15",
@@ -6040,6 +6038,7 @@
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "atob": "^2.1.1",
         "decode-uri-component": "^0.2.0",
@@ -6062,7 +6061,8 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "sourcemap-codec": {
       "version": "1.4.6",
@@ -6532,7 +6532,8 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "use": {
       "version": "3.1.1",

--- a/packages/matchbox/package.json
+++ b/packages/matchbox/package.json
@@ -32,7 +32,7 @@
     "prop-types": "^15.7.2",
     "react-focus-lock": "^2.4.0",
     "react-scrolllock": "^5.0.1",
-    "react-transition-group": "^2.3.0",
+    "react-transition-group": "^4.4.1",
     "resize-observer-polyfill": "^1.5.1",
     "styled-normalize": "^8.0.7",
     "styled-system": "^5.1.5"
@@ -58,7 +58,6 @@
     "cssnano": "^4.1.10",
     "fs-extra": "^3.0.1",
     "incstr": "^1.2.3",
-    "jest-styled-components": "^6.3.3",
     "postcss-modules": "^1.4.1",
     "postcss-modules-scope": "^1.0.2",
     "react": "^16.8.6",

--- a/packages/matchbox/src/components/Button/Button.js
+++ b/packages/matchbox/src/components/Button/Button.js
@@ -106,6 +106,8 @@ const Button = React.forwardRef(function Button(props, ref) {
     ...rest // TODO remove spreading of unknown props
   } = props;
 
+  const transitionRef = React.useRef();
+
   const systemProps = pick(rest, system.propNames);
   const componentProps = omit(rest);
 
@@ -123,9 +125,9 @@ const Button = React.forwardRef(function Button(props, ref) {
 
   const loadingIndicator = React.useMemo(() => {
     return (
-      <Transition mountOnEnter unmountOnExit in={loading} timeout={0}>
+      <Transition mountOnEnter unmountOnExit in={loading} timeout={0} nodeRef={transitionRef}>
         {state => (
-          <StyledLoader state={state}>
+          <StyledLoader state={state} ref={transitionRef}>
             <Spinner
               color={
                 isSolid && color === 'white'

--- a/packages/matchbox/src/components/Drawer/Drawer.js
+++ b/packages/matchbox/src/components/Drawer/Drawer.js
@@ -17,7 +17,7 @@ import { getChild } from '../../helpers/children';
 import { getWindow, isInIframe } from '../../helpers/window';
 import { Overlay, Container } from './styles';
 
-const Drawer = React.forwardRef(function Drawer(props, ref) {
+const Drawer = React.forwardRef(function Drawer(props, userRef) {
   const {
     children,
     closeOnEscape,
@@ -109,6 +109,7 @@ const Drawer = React.forwardRef(function Drawer(props, ref) {
             enter: 0,
             exit: secondsToMS(tokens.motionDuration_medium),
           }}
+          nodeRef={overlayRef}
         >
           {state => (
             <FocusLock returnFocus disabled={!open || isInIframe()} autoFocus={false}>
@@ -117,7 +118,7 @@ const Drawer = React.forwardRef(function Drawer(props, ref) {
                 height="100vh"
                 left="0"
                 position="fixed"
-                ref={ref}
+                ref={userRef}
                 style={{ pointerEvents: 'none' }}
                 tabIndex="-1"
                 top="0"

--- a/packages/matchbox/src/components/Modal/Modal.js
+++ b/packages/matchbox/src/components/Modal/Modal.js
@@ -53,6 +53,7 @@ const Modal = React.forwardRef(function Modal(props, userRef) {
 
   const overlayRef = useRef();
   const contentRef = useRef();
+  const transitionRef = useRef();
 
   // Calls onClose when clicking outside modal content
   function handleOutsideClick(e) {
@@ -112,31 +113,34 @@ const Modal = React.forwardRef(function Modal(props, userRef) {
                       enter: secondsToMS(tokens.motionDuration_medium),
                       exit: secondsToMS(tokens.motionDuration_fast),
                     }}
+                    nodeRef={transitionRef}
                   >
                     {/* Negative `tabIndex` required to programmatically focus */}
                     {state => (
-                      <StyledContent
-                        state={state}
-                        tabIndex="-1"
-                        ref={userRef}
-                        display="flex"
-                        justifyContent="center"
-                        data-id="modal-content-wrapper"
-                        p={['400', null, '700']}
-                      >
-                        <Box
-                          ref={contentRef}
-                          width="100%"
-                          maxWidth={maxWidth}
-                          bg="white"
+                      <div ref={transitionRef}>
+                        <StyledContent
+                          state={state}
                           tabIndex="-1"
-                          data-id="modal-content-panel"
+                          ref={userRef}
+                          display="flex"
+                          justifyContent="center"
+                          data-id="modal-content-wrapper"
+                          p={['400', null, '700']}
                         >
-                          {getChild('Modal.Header', children, { onClose })}
-                          {getChild('Modal.Content', children, { open })}
-                          {getChild('Modal.Footer', children)}
-                        </Box>
-                      </StyledContent>
+                          <Box
+                            ref={contentRef}
+                            width="100%"
+                            maxWidth={maxWidth}
+                            bg="white"
+                            tabIndex="-1"
+                            data-id="modal-content-panel"
+                          >
+                            {getChild('Modal.Header', children, { onClose })}
+                            {getChild('Modal.Content', children, { open })}
+                            {getChild('Modal.Footer', children)}
+                          </Box>
+                        </StyledContent>
+                      </div>
                     )}
                   </Transition>
                 </StyledFocusLock>

--- a/packages/matchbox/src/components/Popover/PopoverContent.js
+++ b/packages/matchbox/src/components/Popover/PopoverContent.js
@@ -29,7 +29,7 @@ const StyledContent = styled('div')`
   })}
 `;
 
-const Content = React.forwardRef(function Content(props, ref) {
+const Content = React.forwardRef(function Content(props, userRef) {
   const {
     children,
     open,
@@ -43,6 +43,8 @@ const Content = React.forwardRef(function Content(props, ref) {
     style,
     ...rest
   } = props;
+
+  const transitionRef = React.useRef();
 
   const systemProps = pick(rest);
 
@@ -64,13 +66,14 @@ const Content = React.forwardRef(function Content(props, ref) {
         enter: 0,
         exit: secondsToMS(tokens.motionDuration_fast),
       }}
+      nodeRef={transitionRef}
     >
       {state => (
         <Box
           data-id="popover-focus-wrapper"
           position="relative"
           height="100%"
-          ref={ref}
+          ref={userRef}
           tabIndex="-1"
         >
           <StyledContent
@@ -84,6 +87,7 @@ const Content = React.forwardRef(function Content(props, ref) {
             state={state}
             {...style}
             {...systemProps}
+            ref={transitionRef}
           >
             <div>{children}</div>
           </StyledContent>

--- a/packages/matchbox/src/components/Tooltip/Tooltip.js
+++ b/packages/matchbox/src/components/Tooltip/Tooltip.js
@@ -59,6 +59,7 @@ function Tooltip(props) {
       ...rest
     } = props;
 
+    const transitionRef = React.useRef();
     const systemProps = pick(rest);
     const positionTop = preferredDirection.top || (top && !forcePosition);
     const positionLeft = preferredDirection.left || (left && !forcePosition);
@@ -77,6 +78,7 @@ function Tooltip(props) {
           enter: secondsToMS(tokens.motionDuration_medium),
           exit: 0,
         }}
+        nodeRef={transitionRef}
       >
         {state => (
           <StyledTooltipContainer
@@ -91,6 +93,7 @@ function Tooltip(props) {
             mb={positionTop ? '100' : '0'}
             visible={!disabled && show}
             state={state}
+            ref={transitionRef}
           >
             <StyledContent
               position="relative"


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed
- Enables React.StrictMode - in order to log additional warning messages and adhere to best practices
- Upgrades react-transition-group, which was using a deprecated use `findDomNode`


### How To Test or Verify
- Run storybook and verify all transitions are still working on:
- Button loading animation
- Drawer
- Modal
- Popover
- Tooltip

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
