### PR TITLE
UX-407 - Force tab layout shift when tabs are dynamically updated

### DIFF
--- a/packages/matchbox/src/components/Tabs/Tabs.js
+++ b/packages/matchbox/src/components/Tabs/Tabs.js
@@ -74,7 +74,7 @@ const Tabs = React.forwardRef(function Tabs(props, userRef) {
         setIsOverflowing(false);
       }
     }
-  }, [wrapperRef, overflowRef, contentRect]);
+  }, [wrapperRef, overflowRef, contentRect, tabs]);
 
   // Constructs the tabs, their props and handles tab keyboard navigation
   const { tabMarkup, tabActions, focusContainerProps } = useTabConstructor({

--- a/stories/navigation/Tabs.stories.js
+++ b/stories/navigation/Tabs.stories.js
@@ -23,6 +23,26 @@ const tabs = [
   },
 ];
 
+const dynamicTabs = [
+  {
+    content: 'Details Dynamic',
+    onClick: action('Details Dynamic Clicked'),
+  },
+  {
+    content: 'More Details Dynamic ',
+    onClick: action('More Details Clicked'),
+  },
+  {
+    content: 'Example with long text Dynamic',
+    onClick: action('Example with long text clicked'),
+  },
+  {
+    content: 'Example with a component wrapper Dynamic',
+    onClick: action('Example with component clicked'),
+    Component: React.forwardRef((props, ref) => <a ref={ref} {...props} href="#" />),
+  },
+];
+
 export default {
   title: 'Navigation|Tabs',
 };
@@ -69,6 +89,28 @@ export const SystemProps = withInfo()(() => {
     <>
       <Tabs borderBottom="none" {...getTabsProps()} my={['400', null, '800', '100px']} />
       <Tabs fitted {...getTabsProps()} mx={['400', null, '800', '200px']} />
+    </>
+  );
+});
+
+export const DynamicTabs = withInfo()(() => {
+  const { getTabsProps } = useTabs({ tabs });
+  const [tabsProps, setTabsProps] = React.useState(getTabsProps);
+
+  React.useEffect(() => {
+    const timer = setTimeout(() => {
+      setTabsProps({
+        ...tabsProps,
+        tabs: dynamicTabs,
+      });
+      console.log(tabsProps);
+    }, 3000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <>
+      <Tabs mb="800" {...tabsProps} keyboardActivation="manual" />
     </>
   );
 });

--- a/stories/navigation/Tabs.stories.js
+++ b/stories/navigation/Tabs.stories.js
@@ -103,7 +103,6 @@ export const DynamicTabs = withInfo()(() => {
         ...tabsProps,
         tabs: dynamicTabs,
       });
-      console.log(tabsProps);
     }, 3000);
     return () => clearTimeout(timer);
   }, []);


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed

- Listen for dynamic tab content changes and shift layout if they overflow 

### How To Test or Verify

- `npm run start:storybook`
- Verify the dynamic tabs story [here](http://localhost:9001/?path=/story/navigation-tabs--dynamic-tabs)

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
