### PR TITLE
UX-409 Lower padding on Panel, Table, borderless Expandable

### DIFF
--- a/packages/matchbox/src/components/Expandable/styles.js
+++ b/packages/matchbox/src/components/Expandable/styles.js
@@ -83,6 +83,7 @@ export const arrow = props => {
 
 export const title = () => `
   font-size: ${tokens.fontSize_400};
+  line-height: ${tokens.lineHeight_400};
   font-weight: ${tokens.fontWeight_semibold};
 `;
 

--- a/packages/matchbox/src/components/Expandable/styles.js
+++ b/packages/matchbox/src/components/Expandable/styles.js
@@ -9,7 +9,7 @@ export const StyledHeader = styled('button')`
   outline: none;
   ${({ variant }) =>
     css({
-      padding: variant === 'borderless' ? ['400', null, '500'] : '300',
+      padding: variant === 'borderless' ? '400' : '300',
     })}
 
   display: flex;
@@ -39,8 +39,8 @@ export const StyledContentWrapper = styled('div')`
       display: ${display};
     `;
   }}
-  ${({ variant }) => css({ px: variant === 'borderless' ? ['400', null, '500'] : '300' })}
-  ${({ variant }) => css({ pb: variant === 'borderless' ? ['400', null, '500'] : '300' })}
+  ${({ variant }) => css({ px: variant === 'borderless' ? '400' : '300' })}
+  ${({ variant }) => css({ pb: variant === 'borderless' ? '400' : '300' })}
 `;
 
 export const expandable = props => {

--- a/packages/matchbox/src/components/Panel/Header.js
+++ b/packages/matchbox/src/components/Panel/Header.js
@@ -19,9 +19,7 @@ const Header = React.forwardRef(function Header(props, userRef) {
       borderBottom={borderBottom ? '300' : 'none'}
       className={className}
       {...paddingContext}
-      // The array is a hack to override responsive padding context
-      // First null to inherit padding context
-      pb={borderBottom ? null : [0, null, 0]}
+      pb={borderBottom ? null : '0'}
       ref={userRef}
       tabIndex="-1"
     >

--- a/packages/matchbox/src/components/Panel/Panel.js
+++ b/packages/matchbox/src/components/Panel/Panel.js
@@ -38,7 +38,7 @@ const Panel = React.forwardRef(function Panel(props, userRef) {
       >
         {accent && <Accent accentColor={accent} />}
         <PanelPaddingContext.Provider
-          value={{ p: contextP || contextPadding || [400, null, 500], ...context }}
+          value={{ p: contextP || contextPadding || '400', ...context }}
         >
           {children}
         </PanelPaddingContext.Provider>

--- a/packages/matchbox/src/components/Panel/SubHeader.js
+++ b/packages/matchbox/src/components/Panel/SubHeader.js
@@ -13,7 +13,7 @@ const SubHeader = React.forwardRef(function SubHeader(props, userRef) {
       as={as}
       {...paddingContext}
       className={className}
-      pb={[0, null, 0]}
+      pb="0"
       fontSize="200"
       fontWeight="normal"
       lineHeight="200"

--- a/packages/matchbox/src/components/Table/Table.js
+++ b/packages/matchbox/src/components/Table/Table.js
@@ -42,7 +42,7 @@ function Table(props) {
     children
   );
 
-  const { px = '500', py = '400', ...paddingProps } = pick(rest, padding.propNames);
+  const { px = '400', py = '400', ...paddingProps } = pick(rest, padding.propNames);
   const marginProps = pick(rest, margin.propNames);
 
   return (

--- a/packages/matchbox/src/components/Table/TableElements.js
+++ b/packages/matchbox/src/components/Table/TableElements.js
@@ -51,7 +51,7 @@ Cell.displayName = 'Table.Cell';
 
 const HeaderCell = ({ value, children, className, ...rest }) => {
   return (
-    <StyledHeaderCell p="500" className={className} {...rest}>
+    <StyledHeaderCell p="400" className={className} {...rest}>
       {value || children}
     </StyledHeaderCell>
   );

--- a/stories/layout/Table.stories.js
+++ b/stories/layout/Table.stories.js
@@ -24,7 +24,7 @@ const data = [
 
 export const TableComponents = withInfo({ propTablesExclude: [Panel] })(() => (
   <Panel>
-    <Table p={500} title="My Table">
+    <Table title="My Table">
       <thead>
         <Table.Row header>
           <Table.HeaderCell>Heading 1</Table.HeaderCell>


### PR DESCRIPTION
### What Changed
- Lowers Panel padding from `400, null, 500` to `400`
- Lowers borderless Expandable padding from `400, null, 500` to `400`
- Lowers table padding-x from `500` to `400`

### How To Test or Verify
- Run storybook and verify
- http://localhost:9001/?path=/story/layout-table--system-props
- http://localhost:9001/?path=/story/layout-panel--with-a-header & other Panel stories
- http://localhost:9001/?path=/story/layout-expandable--borderless

<!--
Describe any steps that may help reviewers verify changes.
Anything beyond basic unit testing, such as assistive tech usage, or special interactions.
-->

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
