### PR TITLE
UX-419 Reduce Empty State Image Size

### DIFF
--- a/packages/design-tokens/tokens/sizing.yml
+++ b/packages/design-tokens/tokens/sizing.yml
@@ -18,6 +18,9 @@ props:
   - name: sizing-1200
     value: 45rem
     comment: 720px
+  - name: sizing-1150
+    value: 35rem
+    comment: 560px
   - name: sizing-1100
     value: 28rem
     comment: 448px

--- a/packages/matchbox/src/components/EmptyState/Image.js
+++ b/packages/matchbox/src/components/EmptyState/Image.js
@@ -13,7 +13,7 @@ const Image = React.forwardRef(function Image(props, userRef) {
       mx="auto"
       mb="400"
       width={['100%', '80%', '60%', '100%']}
-      maxWidth="35rem"
+      maxWidth="1150"
       height="auto"
       ref={userRef}
     >

--- a/packages/matchbox/src/components/EmptyState/Image.js
+++ b/packages/matchbox/src/components/EmptyState/Image.js
@@ -13,6 +13,7 @@ const Image = React.forwardRef(function Image(props, userRef) {
       mx="auto"
       mb="400"
       width={['100%', '80%', '60%', '100%']}
+      maxWidth="35rem"
       height="auto"
       ref={userRef}
     >

--- a/packages/matchbox/src/components/ThemeProvider/theme.js
+++ b/packages/matchbox/src/components/ThemeProvider/theme.js
@@ -146,6 +146,7 @@ const theme = {
     900: tokens.sizing_900,
     1000: tokens.sizing_1000,
     1100: tokens.sizing_1100,
+    1150: tokens.sizing_1150,
     1200: tokens.sizing_1200,
     1300: tokens.sizing_1300,
     1350: tokens.sizing_1350,


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed
- Adds a new sizing token `1150` or 35rems
- Adds a max width to the Empty State image component

### How To Test or Verify
- Run storybook, and run the token build
- Visit: https://matchbox-storybook.netlify.app/iframe.html?id=layout-empty-state--basic-empty-state
- And Visit: http://localhost:9001/iframe.html?id=layout-empty-state--basic-empty-state
- Verify the size difference across different viewport sizes

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
