### PR TITLE
UX-420 Ensure Banner button is always on top of contents

### DIFF
--- a/packages/matchbox/src/components/Banner/Banner.js
+++ b/packages/matchbox/src/components/Banner/Banner.js
@@ -101,7 +101,7 @@ const Banner = React.forwardRef(function Banner(props, ref) {
   }, [action, actions]);
 
   const dismissMarkup = onDismiss ? (
-    <Box flex={['1', null, '0']} textAlign="right">
+    <Box flex={['1', null, '0']} textAlign="right" position="relative">
       <StyledDismiss
         as="button"
         onClick={onDismiss}
@@ -144,6 +144,7 @@ const Banner = React.forwardRef(function Banner(props, ref) {
       {...rest}
       ref={ref}
       tabIndex="-1"
+      overflow="hidden"
     >
       {status !== 'muted' && <IconSection status={status} size={size} />}
       <Box flex="1" order={['1', null, '0']} flexBasis={['100%', null, 'auto']}>

--- a/packages/matchbox/src/components/Banner/Media.js
+++ b/packages/matchbox/src/components/Banner/Media.js
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { Box } from '../Box';
 
 const StyledMedia = styled(Box)`
+  pointer-events: none;
   figure,
   img,
   video {


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed

- Fixes a bug that prevented the Banner dismiss button from being clicked on certain screen sizes

### How To Test or Verify
- Run storybook
- Visit http://localhost:9001/?path=/story/feedback-banner--empty-banner-with-video
- Resize screen until video overlaps with the dismiss button

<!--
Describe any steps that may help reviewers verify changes.
Anything beyond basic unit testing, such as assistive tech usage, or special interactions.
-->

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
