### PR TITLE
UX-421 Make EmptyState.Image maxWidth configurable

### DIFF
--- a/packages/matchbox/src/components/EmptyState/Image.js
+++ b/packages/matchbox/src/components/EmptyState/Image.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { createPropTypes } from '@styled-system/prop-types';
+import { maxWidth } from 'styled-system';
 import { StyledImage } from './styles';
 
 import { Picture } from '../Picture';
 
 const Image = React.forwardRef(function Image(props, userRef) {
-  const { src, className, children } = props;
+  const { src, className, children, maxWidth = '1100' } = props;
 
   return (
     <StyledImage
@@ -13,7 +15,7 @@ const Image = React.forwardRef(function Image(props, userRef) {
       mx="auto"
       mb="400"
       width={['100%', '80%', '60%', '100%']}
-      maxWidth="1150"
+      maxWidth={maxWidth}
       height="auto"
       ref={userRef}
     >
@@ -31,6 +33,7 @@ Image.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
   src: PropTypes.string.isRequired,
+  ...createPropTypes(maxWidth.propNames),
 };
 
 export default Image;

--- a/site/src/pages/components/emptystate.mdx
+++ b/site/src/pages/components/emptystate.mdx
@@ -64,7 +64,7 @@ None
 
 ### EmptyState.Image System Props
 
-None
+<SystemPropsTags propsList={['maxWidth']} />
 
 ### EmptyState.Image API
 
@@ -80,13 +80,14 @@ None
   The source url of the Image
 </Prop>
 
---- 
+---
 
 ### EmptyState.Content System Props
 
 None
 
 ### EmptyState.Content API
+
 <Prop name="children" type="node">
   The content of the EmptyState
 </Prop>

--- a/stories/layout/EmptyState.stories.js
+++ b/stories/layout/EmptyState.stories.js
@@ -4,12 +4,13 @@ import { action } from '@storybook/addon-actions';
 import { EmptyState } from '@sparkpost/matchbox';
 import TemplatesImage from '../storyHelpers/TemplatesImage';
 import AccountsImage from '@sparkpost/matchbox-media/images/Accounts.jpg';
+import AnalyticsImage from '@sparkpost/matchbox-media/images/Analytics.jpg';
 
 export default {
   title: 'Layout|Empty State',
 };
 
-export const BasicEmptyState = withInfo({ propTables: [EmptyState] })(() => (
+export const BasicEmptyState = () => (
   <EmptyState>
     <EmptyState.Header> Manage your email templates</EmptyState.Header>
     <EmptyState.Content>
@@ -27,7 +28,19 @@ export const BasicEmptyState = withInfo({ propTables: [EmptyState] })(() => (
     <EmptyState.Action>Create Template</EmptyState.Action>
     <EmptyState.Action variant="outline">Learn More</EmptyState.Action>
   </EmptyState>
-));
+);
+
+export const AnotherEmptyState = () => (
+  <EmptyState>
+    <EmptyState.Header> Manage your email templates</EmptyState.Header>
+    <EmptyState.Content>
+      <p>Build, test, preview and send your transmissions.</p>
+    </EmptyState.Content>
+    <EmptyState.Image src={AnalyticsImage} />
+    <EmptyState.Action>Create Template</EmptyState.Action>
+    <EmptyState.Action variant="outline">Learn More</EmptyState.Action>
+  </EmptyState>
+);
 
 export const LEGACY = withInfo()(() => (
   <EmptyState.LEGACY


### PR DESCRIPTION


### What Changed
- Makes EmptyState.Image maxWidth configurable as a system prop

### How To Test or Verify
- Run storybook
- Visit the empty state stories, verify that the prop is configurable

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
