### PR TITLE
UX-412 Add support for EmptyState.Header 'as' and 'looksLike'

### DIFF
--- a/packages/matchbox/src/components/EmptyState/Header.js
+++ b/packages/matchbox/src/components/EmptyState/Header.js
@@ -1,26 +1,35 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Box } from '../Box';
+import { Text } from '../Text';
 
 const Header = React.forwardRef(function Header(props, userRef) {
+  const { as, looksLike } = props;
+
   return (
-    <Box
-      as="h1"
-      fontSize={['600', null, null, '700']}
+    <Text
+      as={as}
+      looksLike={looksLike}
+      fontSize={!looksLike ? ['600', null, null, '700'] : null}
+      lineHeight={!looksLike ? ['600', null, null, '700'] : null}
       mb={300}
       ref={userRef}
-      lineHeight={['600', null, null, '700']}
     >
       {props.children}
-    </Box>
+    </Text>
   );
 });
 
 Header.displayName = 'EmptyState.Header';
 
+Header.defaultProps = {
+  as: 'h1',
+};
+
 Header.propTypes = {
   children: PropTypes.node,
+  as: PropTypes.string,
+  looksLike: PropTypes.string,
 };
 
 export default Header;

--- a/packages/matchbox/src/components/EmptyState/tests/EmptyState.test.js
+++ b/packages/matchbox/src/components/EmptyState/tests/EmptyState.test.js
@@ -7,6 +7,14 @@ describe('EmptyState Components', () => {
   it('renders header correctly', () => {
     const wrapper = subject({ children: <EmptyState.Header>The Header</EmptyState.Header> });
     expect(wrapper.text()).toEqual('The Header');
+    expect(wrapper.find('h1')).toExist();
+  });
+
+  it('renders header with and as prop correctly', () => {
+    const wrapper = subject({
+      children: <EmptyState.Header as="h3">The Header</EmptyState.Header>,
+    });
+    expect(wrapper.find('h3')).toExist();
   });
 
   it('renders content correctly', () => {

--- a/stories/layout/EmptyState.stories.js
+++ b/stories/layout/EmptyState.stories.js
@@ -11,7 +11,9 @@ export default {
 
 export const BasicEmptyState = withInfo({ propTables: [EmptyState] })(() => (
   <EmptyState>
-    <EmptyState.Header> Manage your email templates</EmptyState.Header>
+    <EmptyState.Header as="h2" looksLike="h2">
+      Manage your email templates
+    </EmptyState.Header>
     <EmptyState.Content>
       <p>Build, test, preview and send your transmissions.</p>
       <EmptyState.List>


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed
- EmptyState.Header now supports `as` and `looksLike`

### How To Test or Verify
- Run Storybook
- Verify the props work at: http://localhost:9001/?path=/story/layout-empty-state--basic-empty-state

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
