### PR TITLE
UX-411 Button should accept "as" and deprecate "component"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24102,7 +24102,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -24583,7 +24583,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -26609,7 +26609,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -24102,7 +24102,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -24583,7 +24583,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -26609,7 +26609,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },

--- a/packages/matchbox/src/components/Button/Button.js
+++ b/packages/matchbox/src/components/Button/Button.js
@@ -94,6 +94,7 @@ const Button = React.forwardRef(function Button(props, ref) {
     to,
     Component, // Deprecate in favor of component
     component,
+    as,
     external,
     title,
 
@@ -109,8 +110,8 @@ const Button = React.forwardRef(function Button(props, ref) {
   const systemProps = pick(rest, system.propNames);
   const componentProps = omit(rest);
 
-  // Polyfills deprecrated 'Component' prop
-  const WrapperComponent = component || Component;
+  // Polyfills deprecrated 'Component' prop — use as instead of component
+  const WrapperComponent = as || component || Component;
 
   // Polyfills to be deprecrated 'primary' and 'destructive' prop
   const buttonColor = primary ? 'blue' : destructive ? 'red' : color;
@@ -194,7 +195,11 @@ const Button = React.forwardRef(function Button(props, ref) {
   }
 
   return (
-    <StyledButton as="button" type={submit ? 'submit' : 'button'} {...sharedProps}>
+    <StyledButton
+      as={WrapperComponent || 'button'}
+      type={submit ? 'submit' : 'button'}
+      {...sharedProps}
+    >
       {childrenMarkup}
       {loadingIndicator}
     </StyledButton>
@@ -206,9 +211,10 @@ Button.Group = Group;
 Button.Icon = Icon;
 
 Button.propTypes = {
+  as: PropTypes.elementType,
   children: PropTypes.node,
   color: PropTypes.oneOf(['gray', 'orange', 'blue', 'navy', 'purple', 'red', 'white']),
-  component: PropTypes.elementType,
+  component: deprecate(PropTypes.elementType, 'Use `as` instead'),
   disabled: PropTypes.bool,
   external: PropTypes.bool,
   fullWidth: PropTypes.bool,

--- a/packages/matchbox/src/components/Button/Button.js
+++ b/packages/matchbox/src/components/Button/Button.js
@@ -227,7 +227,7 @@ Button.propTypes = {
   variant: PropTypes.oneOf(['filled', 'outline', 'text', 'mutedOutline']),
 
   // Deprecated props
-  Component: deprecate(PropTypes.elementType, 'Use `component` instead'),
+  Component: deprecate(PropTypes.elementType, 'Use `as` instead'),
   destructive: deprecate(PropTypes.bool, 'Use the `color` prop instead'),
   flat: deprecate(PropTypes.bool, 'Use `variant` instead'),
   primary: deprecate(PropTypes.bool, 'Use `color` prop instead'),

--- a/packages/matchbox/src/components/Button/tests/Button.test.js
+++ b/packages/matchbox/src/components/Button/tests/Button.test.js
@@ -95,8 +95,8 @@ describe('Button', () => {
       assert: [['title', 'test-title']],
     },
     {
-      name: 'to with component',
-      props: { to: '/withcomp', component: () => <div /> },
+      name: 'to with as',
+      props: { to: '/withcomp', as: () => <div /> },
       assert: ['href', null],
     },
   ];
@@ -139,7 +139,7 @@ it('renders with with a ref', () => {
 describe('wrappers', () => {
   it('should render a custom wrapper', () => {
     const wrapper = global.mountStyled(
-      <Button to="/test" component="span">
+      <Button to="/test" as="span">
         Hola!
       </Button>,
     );
@@ -151,7 +151,7 @@ describe('wrappers', () => {
 describe('Button.Icon', () => {
   it('should render correctly', () => {
     const wrapper = global.mountStyled(
-      <Button to="/test" component="span">
+      <Button to="/test" as="span">
         Hola!
         <Button.Icon as={Assessment} />
       </Button>,
@@ -162,7 +162,7 @@ describe('Button.Icon', () => {
 
   it('should renders label and size correctly', () => {
     const wrapper = global.mountStyled(
-      <Button to="/test" component="span">
+      <Button to="/test" as="span">
         Hola!
         <Button.Icon as={Assessment} label="test-label" size={24} />
       </Button>,

--- a/site/src/pages/components/button.mdx
+++ b/site/src/pages/components/button.mdx
@@ -180,7 +180,7 @@ import { LiveCode } from '../../components/LiveCode';
   Children of the button
 </Prop>
 
-<Prop name="component" type="elementType">
+<Prop name="as" type="elementType">
   Component to render the button as. (i.e. 'span')
 </Prop>
 

--- a/stories/action/Button.stories.js
+++ b/stories/action/Button.stories.js
@@ -243,7 +243,11 @@ export const TogglingLoading = () => {
     </Button>
   );
 };
-export const External = withInfo()(() => <Button to="http://google.com">Google</Button>);
+export const External = withInfo()(() => (
+  <Button to="http://google.com" external>
+    Google
+  </Button>
+));
 
 export const Group = withInfo()(() => (
   <Button.Group>
@@ -253,6 +257,15 @@ export const Group = withInfo()(() => (
       Sq Rt
     </Button>
   </Button.Group>
+));
+
+export const As = withInfo()(() => (
+  <Inline>
+    <Button color="blue" as="a" to="http://google.com">
+      As &lt;a&gt;
+    </Button>
+    <Button as="h2">As &lt;h2&gt;</Button>
+  </Inline>
 ));
 
 export const Icon = withInfo()(() => (


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed

- new `as` prop which replaces `component` and `Component`
- `component` and `Component` props are deprecated 
- updates tests to use `as`

### How To Test or Verify

- `npm run start:storybook`
- verify `As` button story

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
