### PR TITLE
UX-422 add new EmptyState.Media to allow Video or Picture elements

### DIFF
--- a/packages/matchbox/src/components/EmptyState/EmptyState.js
+++ b/packages/matchbox/src/components/EmptyState/EmptyState.js
@@ -11,6 +11,7 @@ import Header from './Header';
 import Content from './Content';
 import List from './List';
 import Image from './Image';
+import Media from './Media';
 import Legacy from './Legacy';
 import { getChild } from '../../helpers/children';
 import { pick } from '../../helpers/props';
@@ -23,9 +24,16 @@ const EmptyState = React.forwardRef(function EmptyState(props, userRef) {
 
   const systemProps = pick(rest, margin.propNames);
 
+  // Allow fallback use of `EmptyState.Image` for now
+  // We should remove in the future in favor of `EmptyState.Media`
+  const Media = getChild('EmptyState.Media', children);
+  const Image = getChild('EmptyState.Image', children);
+
   return (
     <Columns collapseBelow="sm" space="500" alignY="center" {...systemProps} ref={userRef}>
-      {isMobile ? <Column width={1 / 2}>{getChild('EmptyState.Image', children)}</Column> : null}
+      {isMobile ? (
+        <Column width={1 / 2}>{Image && Image.length >= 1 ? Image : Media}</Column>
+      ) : null}
       <Column width={1 / 2}>
         {getChild('EmptyState.Header', children)}
         {getChild('EmptyState.Content', children)}
@@ -33,7 +41,9 @@ const EmptyState = React.forwardRef(function EmptyState(props, userRef) {
           <Inline space="500">{getChild('EmptyState.Action', children)}</Inline>
         </Box>
       </Column>
-      {!isMobile ? <Column width={1 / 2}>{getChild('EmptyState.Image', children)}</Column> : null}
+      {!isMobile ? (
+        <Column width={1 / 2}>{Image && Image.length >= 1 ? Image : Media}</Column>
+      ) : null}
     </Columns>
   );
 });
@@ -49,6 +59,7 @@ EmptyState.Action = Action;
 EmptyState.Header = Header;
 EmptyState.Content = Content;
 EmptyState.Image = Image;
+EmptyState.Media = Media;
 EmptyState.List = List;
 EmptyState.LEGACY = Legacy;
 

--- a/packages/matchbox/src/components/EmptyState/Media.js
+++ b/packages/matchbox/src/components/EmptyState/Media.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { createPropTypes } from '@styled-system/prop-types';
+import { maxWidth } from 'styled-system';
+import { Box } from '../Box';
+
+const StyledMedia = styled(Box)`
+  pointer-events: none;
+`;
+
+const Media = React.forwardRef(function Media(props, userRef) {
+  const { children, className, maxWidth = '1100' } = props;
+
+  return (
+    <StyledMedia
+      display="block"
+      mx="auto"
+      mb="400"
+      width={['100%', '80%', '60%', '100%']}
+      maxWidth={maxWidth}
+      height="auto"
+      className={className}
+      ref={userRef}
+    >
+      {children}
+    </StyledMedia>
+  );
+});
+
+Media.displayName = 'EmptyState.Media';
+Media.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  ...createPropTypes(maxWidth.propNames),
+};
+
+export default Media;

--- a/packages/matchbox/src/components/EmptyState/tests/EmptyState.test.js
+++ b/packages/matchbox/src/components/EmptyState/tests/EmptyState.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import EmptyState from '../EmptyState';
+import { Picture } from '../../Picture';
 
 describe('EmptyState Components', () => {
   const subject = props => global.mountStyled(<EmptyState {...props} />);
@@ -25,6 +26,19 @@ describe('EmptyState Components', () => {
   it('renders with an image', () => {
     let wrapper = subject({ children: <EmptyState.Image src="/test.jpg" /> });
     expect(wrapper.find('img').props().src).toEqual('/test.jpg');
+  });
+
+  it('renders media correctly', () => {
+    let wrapper = subject({
+      children: (
+        <EmptyState.Media>
+          <Picture seeThrough>
+            <Picture.Image src="/mediatest.jpg" />
+          </Picture>
+        </EmptyState.Media>
+      ),
+    });
+    expect(wrapper.find('img').props().src).toEqual('/mediatest.jpg');
   });
 
   it('renders with actions', () => {

--- a/stories/layout/EmptyState.stories.js
+++ b/stories/layout/EmptyState.stories.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import { withInfo } from '@storybook/addon-info';
 import { action } from '@storybook/addon-actions';
-import { EmptyState } from '@sparkpost/matchbox';
+import { EmptyState, Picture, Video } from '@sparkpost/matchbox';
 import TemplatesImage from '../storyHelpers/TemplatesImage';
 import AccountsImage from '@sparkpost/matchbox-media/images/Accounts.jpg';
 import AnalyticsImage from '@sparkpost/matchbox-media/images/Analytics.jpg';
+import RVVideo from '@sparkpost/matchbox-media/videos/Recipient-Validation-Crop.webm';
+import RVVideo2 from '@sparkpost/matchbox-media/videos/Recipient-Validation-Crop.mp4';
 
 export default {
   title: 'Layout|Empty State',
@@ -26,7 +28,11 @@ export const BasicEmptyState = () => (
         <li>Three</li>
       </EmptyState.List>
     </EmptyState.Content>
-    <EmptyState.Image src={AccountsImage} />
+    <EmptyState.Media>
+      <Picture seeThrough>
+        <Picture.Image src={AccountsImage} />
+      </Picture>
+    </EmptyState.Media>
     <EmptyState.Action>Create Template</EmptyState.Action>
     <EmptyState.Action variant="outline">Learn More</EmptyState.Action>
   </EmptyState>
@@ -38,7 +44,28 @@ export const AnotherEmptyState = () => (
     <EmptyState.Content>
       <p>Build, test, preview and send your transmissions.</p>
     </EmptyState.Content>
-    <EmptyState.Image src={AnalyticsImage} />
+    <EmptyState.Media>
+      <Picture seeThrough>
+        <Picture.Image src={AnalyticsImage} />
+      </Picture>
+    </EmptyState.Media>
+    <EmptyState.Action>Create Template</EmptyState.Action>
+    <EmptyState.Action variant="outline">Learn More</EmptyState.Action>
+  </EmptyState>
+);
+
+export const EmptyStateWithMedia = () => (
+  <EmptyState>
+    <EmptyState.Header> Manage your email templates</EmptyState.Header>
+    <EmptyState.Content>
+      <p>Build, test, preview and send your transmissions.</p>
+    </EmptyState.Content>
+    <EmptyState.Media>
+      <Video loop>
+        <Video.Source src={RVVideo} type="video/webm" />
+        <Video.Source src={RVVideo2} type="video/mp4" />
+      </Video>
+    </EmptyState.Media>
     <EmptyState.Action>Create Template</EmptyState.Action>
     <EmptyState.Action variant="outline">Learn More</EmptyState.Action>
   </EmptyState>


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed

- New `EmptyState.Media` Component
- Allows both `Picture` and `Video` 
- configurable `maxWidth` prop

### How To Test or Verify

- `npm run start:storybook`
- Verify EmptyState stories at http://localhost:9001/?path=/story/layout-empty-state--empty-state-with-media

### Follow-Up Ticket
- https://sparkpost.atlassian.net/browse/UX-426


### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
