### PR TITLE
UX-260 Create usePrefersColorScheme hook

### DIFF
--- a/cypress/integration/usePrefersColorScheme.spec.js
+++ b/cypress/integration/usePrefersColorScheme.spec.js
@@ -1,30 +1,31 @@
 /// <reference types="Cypress" />
 
 describe('usePrefersColorScheme hook', () => {
-  beforeEach(() => {
+  const visit = dark => {
     cy.visit('/iframe.html?path=/story/utility-usepreferscolorscheme--example-usage', {
-      onBeforeLoad(win) {
-        cy.stub(win, 'matchMedia')
+      onBeforeLoad(window) {
+        cy.stub(window, 'matchMedia')
           .withArgs('(prefers-color-scheme: dark)')
           .returns({
-            matches: true,
+            matches: dark,
           });
       },
     });
+  };
+  beforeEach(() => {
     // Setting viewport dimensions to avoid side effects
     cy.viewport(500, 500);
   });
 
-  it('should set dark or light', () => {
-    const DARK = '(prefers-reduced-motion: dark)';
-    const LIGHT = '(prefers-reduced-motion: light)';
+  it('should return dark if dark preference set', () => {
+    visit(true);
 
-    if (window.matchMedia(DARK).matches) {
-      cy.contains('reduce').should('exist');
-    }
+    cy.contains('dark').should('exist');
+  });
 
-    if (window.matchMedia(LIGHT).matches) {
-      cy.contains('no-preference').should('exist');
-    }
+  it('should return light if dark preference not set', () => {
+    visit(false);
+
+    cy.contains('light').should('exist');
   });
 });

--- a/cypress/integration/usePrefersColorScheme.spec.js
+++ b/cypress/integration/usePrefersColorScheme.spec.js
@@ -2,7 +2,15 @@
 
 describe('usePrefersColorScheme hook', () => {
   beforeEach(() => {
-    cy.visit('/iframe.html?path=/story/utility-useprefersrcolorscheme--example-usage');
+    cy.visit('/iframe.html?path=/story/utility-usepreferscolorscheme--example-usage', {
+      onBeforeLoad(win) {
+        cy.stub(win, 'matchMedia')
+          .withArgs('(prefers-color-scheme: dark)')
+          .returns({
+            matches: true,
+          });
+      },
+    });
     // Setting viewport dimensions to avoid side effects
     cy.viewport(500, 500);
   });

--- a/cypress/integration/usePrefersColorScheme.spec.js
+++ b/cypress/integration/usePrefersColorScheme.spec.js
@@ -1,0 +1,22 @@
+/// <reference types="Cypress" />
+
+describe('usePrefersColorScheme hook', () => {
+  beforeEach(() => {
+    cy.visit('/iframe.html?path=/story/utility-useprefersrcolorscheme--example-usage');
+    // Setting viewport dimensions to avoid side effects
+    cy.viewport(500, 500);
+  });
+
+  it('should set dark or light', () => {
+    const DARK = '(prefers-reduced-motion: dark)';
+    const LIGHT = '(prefers-reduced-motion: light)';
+
+    if (window.matchMedia(DARK).matches) {
+      cy.contains('reduce').should('exist');
+    }
+
+    if (window.matchMedia(LIGHT).matches) {
+      cy.contains('no-preference').should('exist');
+    }
+  });
+});

--- a/packages/matchbox/src/hooks/index.js
+++ b/packages/matchbox/src/hooks/index.js
@@ -7,3 +7,4 @@ export { default as useTabs } from './useTabs';
 export { default as useWindowEvent } from './useWindowEvent';
 export { default as useInView } from './useInView';
 export { default as usePrefersReducedMotion } from './usePrefersReducedMotion';
+export { default as usePrefersColorScheme } from './usePrefersColorScheme';

--- a/packages/matchbox/src/hooks/usePrefersColorScheme.js
+++ b/packages/matchbox/src/hooks/usePrefersColorScheme.js
@@ -12,7 +12,7 @@ import { getWindow } from '../helpers/window';
  * return <div>{prefersColorScheme}</div>
  */
 
-const QUERY = '(prefers-reduced-motion: dark)';
+const QUERY = '(prefers-color-scheme: dark)';
 
 function usePrefersColorScheme() {
   const environment = getWindow();

--- a/packages/matchbox/src/hooks/usePrefersColorScheme.js
+++ b/packages/matchbox/src/hooks/usePrefersColorScheme.js
@@ -28,10 +28,14 @@ function usePrefersColorScheme() {
       setPrefersColorScheme(event.matches);
     };
 
-    mql.addListener(listener);
+    if (mql.addListener) {
+      mql.addListener(listener);
+    }
 
     return () => {
-      mql.removeListener(listener);
+      if (mql.removeListener) {
+        mql.removeListener(listener);
+      }
     };
   });
 

--- a/packages/matchbox/src/hooks/usePrefersColorScheme.js
+++ b/packages/matchbox/src/hooks/usePrefersColorScheme.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { getWindow } from '../helpers/window';
+
+/**
+ * SSR friendly hook that returns prefers-color-scheme status
+ *
+ * @returns
+ * 'dark' OR 'light'
+ *
+ * @example
+ * const prefersColorScheme = usePrefersColorScheme();
+ * return <div>{prefersColorScheme}</div>
+ */
+
+const QUERY = '(prefers-reduced-motion: dark)';
+
+function usePrefersColorScheme() {
+  const environment = getWindow();
+
+  const [prefersColorScheme, setPrefersColorScheme] = React.useState(
+    environment.matchMedia(QUERY).matches,
+  );
+
+  React.useEffect(() => {
+    const mql = environment.matchMedia(QUERY);
+
+    const listener = event => {
+      setPrefersColorScheme(event.matches);
+    };
+
+    mql.addListener(listener);
+
+    return () => {
+      mql.removeListener(listener);
+    };
+  });
+
+  return prefersColorScheme ? 'dark' : 'light';
+}
+
+export default usePrefersColorScheme;

--- a/stories/utility/usePrefersColorScheme.stories.js
+++ b/stories/utility/usePrefersColorScheme.stories.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Box, usePrefersColorScheme } from '@sparkpost/matchbox';
+
+export default {
+  title: 'Utility|usePrefersColorScheme',
+};
+
+export const ExampleUsage = () => {
+  const prefersColorScheme = usePrefersColorScheme();
+
+  return (
+    <>
+      <Box>(prefers-color-scheme: {prefersColorScheme})</Box>
+    </>
+  );
+};


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed

- new `usePrefersColorScheme` hook
- returns either `light` or `dark`

### How To Test or Verify

- `npm run start:storybook`
- Verify story http://localhost:9001/?path=/story/utility-usepreferscolorscheme--example-usage
- Testing with Chrome:
    - System Preferences -> General -> Appearance:Dark (toggle between these two and the story will update)

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
