### PR TITLE
UX-431 Align chevron in Page component breadcrumbs

### DIFF
--- a/packages/matchbox/src/components/Page/Page.js
+++ b/packages/matchbox/src/components/Page/Page.js
@@ -11,6 +11,7 @@ import { Popover } from '../Popover';
 import { UnstyledLink } from '../UnstyledLink';
 import { ScreenReaderOnly } from '../ScreenReaderOnly';
 import { filterByVisible } from '../../helpers/array';
+import { tokens } from '@sparkpost/design-tokens';
 
 const StyledLink = styled(UnstyledLink)`
   text-decoration: none;
@@ -18,9 +19,9 @@ const StyledLink = styled(UnstyledLink)`
 
 function Breadcrumb({ content, ...rest }) {
   return (
-    <StyledLink {...rest} fontSize="200" lineHeight="200" fontWeight="medium">
-      <Box as="span" display="inline-flex" align-items="center">
-        <ChevronLeft size={20} />
+    <StyledLink {...rest} fontSize="200" lineHeight="450" fontWeight="medium">
+      <Box as="span" display="inline-flex" align-items="center" lineHeight={tokens.spacing_450}>
+        <ChevronLeft size={tokens.spacing_450} />
         {content}
       </Box>
     </StyledLink>

--- a/packages/matchbox/src/components/Page/Page.js
+++ b/packages/matchbox/src/components/Page/Page.js
@@ -11,7 +11,6 @@ import { Popover } from '../Popover';
 import { UnstyledLink } from '../UnstyledLink';
 import { ScreenReaderOnly } from '../ScreenReaderOnly';
 import { filterByVisible } from '../../helpers/array';
-import { tokens } from '@sparkpost/design-tokens';
 
 const StyledLink = styled(UnstyledLink)`
   text-decoration: none;
@@ -19,9 +18,9 @@ const StyledLink = styled(UnstyledLink)`
 
 function Breadcrumb({ content, ...rest }) {
   return (
-    <StyledLink {...rest} fontSize="200" lineHeight="450" fontWeight="medium">
-      <Box as="span" display="inline-flex" align-items="center" lineHeight={tokens.spacing_450}>
-        <ChevronLeft size={tokens.spacing_450} />
+    <StyledLink {...rest} fontSize="200" lineHeight="80px" fontWeight="medium">
+      <Box as="span" display="inline-flex" alignItems="center">
+        <ChevronLeft size="20" />
         {content}
       </Box>
     </StyledLink>


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed

- Fixes bug where chevron is not aligned with breadcrumbs in `Page` component

### How To Test or Verify

- `npm run start:storybook`
- Verify stories at http://localhost:9001/?path=/story/layout-page--basic-example

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
