### PR TITLE
UX-433 UnstyledLink add 'as' prop and deprecate 'component'

### DIFF
--- a/packages/matchbox/src/components/Tabs/Tab.js
+++ b/packages/matchbox/src/components/Tabs/Tab.js
@@ -31,7 +31,7 @@ const Tab = React.forwardRef(function Tab(props, ref) {
   return (
     <StyledTab
       aria-selected={selected === index}
-      component={wrapper}
+      as={wrapper}
       selected={selected === index}
       fitted={fitted}
       ref={ref}

--- a/packages/matchbox/src/components/UnstyledLink/UnstyledLink.js
+++ b/packages/matchbox/src/components/UnstyledLink/UnstyledLink.js
@@ -26,6 +26,7 @@ const UnstyledLink = React.forwardRef(function UnstyledLink(props, ref) {
     title,
     Component,
     component,
+    as,
     external,
     onClick,
     role,
@@ -34,7 +35,7 @@ const UnstyledLink = React.forwardRef(function UnstyledLink(props, ref) {
     ...rest
   } = props;
 
-  const WrapperComponent = component || Component;
+  const WrapperComponent = as || component || Component;
   const linkTitle = external && !title ? 'Opens in a new tab' : title;
   const linkRole = role ? role : !!onClick ? 'button' : null;
 
@@ -103,8 +104,9 @@ UnstyledLink.propTypes = {
   disabled: PropTypes.bool,
   title: PropTypes.string,
   external: PropTypes.bool,
-  component: PropTypes.elementType,
-  Component: deprecate(PropTypes.elementType, 'Use "component" instead'),
+  component: deprecate(PropTypes.elementType, 'Use "as" instead'),
+  Component: deprecate(PropTypes.elementType, 'Use "as" instead'),
+  as: PropTypes.elementType,
   children: PropTypes.node,
   onClick: PropTypes.func,
   role: PropTypes.string,

--- a/packages/matchbox/src/components/UnstyledLink/tests/UnstyledLink.test.js
+++ b/packages/matchbox/src/components/UnstyledLink/tests/UnstyledLink.test.js
@@ -32,14 +32,20 @@ describe('UnstyledLink', () => {
     expect(wrapper.prop('role')).toBeUndefined();
   });
 
-  it('renders with wrapper component', () => {
+  it('supports deprecated wrapper component', () => {
     let wrapper = subject({ component: 'button' });
     expect(wrapper.find('button').text()).toEqual('Hola!');
     expect(wrapper.prop('role')).toBeUndefined();
   });
 
-  it('renders with wrapper component with a role', () => {
-    let wrapper = subject({ component: 'button', role: 'test-role' });
+  it('renders with "as" component', () => {
+    let wrapper = subject({ as: 'button' });
+    expect(wrapper.find('button').text()).toEqual('Hola!');
+    expect(wrapper.prop('role')).toBeUndefined();
+  });
+
+  it('renders with "as" wrapper component with a role', () => {
+    let wrapper = subject({ as: 'button', role: 'test-role' });
     expect(wrapper.find('button').text()).toEqual('Hola!');
     expect(wrapper.find('button').prop('role')).toEqual('test-role');
   });

--- a/site/src/pages/components/unstyledlink.mdx
+++ b/site/src/pages/components/unstyledlink.mdx
@@ -44,7 +44,7 @@ None
 <Prop name="disabled" type="bool">
   Disables the link
 </Prop>
-<Prop name="component" type="elementType">
+<Prop name="as" type="elementType">
   Optional component wrapper for the link
 </Prop>
 <Prop name="external" type="bool">

--- a/stories/navigation/UnstyledLink.stories.js
+++ b/stories/navigation/UnstyledLink.stories.js
@@ -22,8 +22,8 @@ export const WithAnExternalLink = withInfo()(() => (
 
 export const WithWrapperComponents = withInfo()(() => (
   <>
-    <UnstyledLink component={({ children }) => <a>{children}</a>}>A Function</UnstyledLink>
-    <UnstyledLink component={DemoWrapper}>A Component</UnstyledLink>
+    <UnstyledLink as={({ children }) => <a>{children}</a>}>A Function</UnstyledLink>
+    <UnstyledLink as={DemoWrapper}>A Component</UnstyledLink>
   </>
 ));
 


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed

- Adds new `as` prop to UnstyledLink
- Deprecates `component`
- Update tests to verify new `as` prop while testing backward compatibility

### How To Test or Verify

- `npm run start:storybook`
- Verify stories at http://localhost:9001/?path=/story/navigation-unstyledlink--with-wrapper-components

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
