### PR TITLE
UX-424 Add Toggle to routes file

### DIFF
--- a/site/src/routes/routes.json
+++ b/site/src/routes/routes.json
@@ -136,6 +136,11 @@
         "section": "Form"
       },
       {
+        "path": "/components/toggle",
+        "label": "Toggle",
+        "section": "Form"
+      },
+      {
         "path": "/components/listbox",
         "label": "ListBox",
         "tag": "new",


### PR DESCRIPTION
### What Changed
- Adds the missing Toggle route to the side nav

### How To Test or Verify
- Run the site with `npm run start:site` and verify `Toggle` is in the nav


### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
