### PR TITLE
UX-432 Add aria-invalid to Checkbox Radio Select Textfield and ListBox

### DIFF
--- a/cypress/integration/Checkbox.spec.js
+++ b/cypress/integration/Checkbox.spec.js
@@ -1,0 +1,14 @@
+describe('The Checkbox component', () => {
+  it('focuses on the `<input/>` element when clicking on the `<label>`', () => {
+    cy.visit('/iframe.html?id=form-checkbox--basic-checkbox');
+    cy.get('label').click();
+    cy.get('input').should('have.focus');
+    cy.get('[aria-invalid="false"]').should('exist');
+  });
+
+  it('renders with an error correctly', () => {
+    cy.visit('/iframe.html?id=form-checkbox--with-error-and-required');
+    cy.get('[aria-invalid="true"]').should('exist');
+    cy.findAllByText("I'm an error").should('exist');
+  });
+});

--- a/cypress/integration/ListBox.spec.js
+++ b/cypress/integration/ListBox.spec.js
@@ -1,105 +1,117 @@
 /// <reference types="Cypress" />
 
 describe('The ListBox component', () => {
-  beforeEach(() => {
-    cy.visit(
-      '/iframe.html?selectedKind=Form%7CListBox&selectedStory=Printable%20Character&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel',
-    );
-  });
+  describe('interactions', () => {
+    beforeEach(() => {
+      cy.visit('/iframe.html?id=form-listbox--printable-character');
+    });
 
-  it('opens the listbox when clicking on the `<label>`', () => {
-    cy.get('label').click();
+    it('opens the listbox when clicking on the `<label>`', () => {
+      cy.get('label').click();
+      cy.contains('Alpha').should('be.visible');
+    });
 
-    cy.contains('Alpha').should('be.visible');
-  });
+    it('searches options when typing', () => {
+      cy.get('label').click();
 
-  it('searches options when typing', () => {
-    cy.get('label').click();
+      cy.get('[data-id="open-listbox"]').trigger('keydown', {
+        key: 'a',
+        keyCode: 65,
+        shiftKey: false,
+      });
+    });
 
-    cy.get('[data-id="open-listbox"]').trigger('keydown', {
-      key: 'a',
-      keyCode: 65,
-      shiftKey: false,
+    it('selects focused option when clicking enter key', () => {
+      cy.get('label').click();
+
+      cy.get('[data-id="open-listbox"]').trigger('keydown', {
+        key: 'a',
+        keyCode: 65,
+        shiftKey: false,
+      });
+
+      cy.get('[data-id="open-listbox"]').trigger('keydown', {
+        key: 'Enter',
+        keycode: 13,
+        shiftKey: false,
+      });
+
+      cy.contains('Alpha').should('be.visible');
+    });
+
+    it('changes focus when navigating with up and down arrows', () => {
+      cy.get('label').click();
+
+      cy.get('[data-id="open-listbox"]').trigger('keydown', {
+        key: 'ArrowUp',
+        keycode: 38,
+        shiftKey: false,
+      });
+
+      cy.focused().should('have.text', 'Alpha');
+
+      cy.get('[data-id="open-listbox"]').trigger('keydown', {
+        key: 'ArrowDown',
+        keycode: 40,
+        shiftKey: false,
+      });
+
+      cy.get('[data-id="open-listbox"]').trigger('keydown', {
+        key: 'ArrowDown',
+        keycode: 40,
+        shiftKey: false,
+      });
+
+      cy.focused().should('have.text', 'Charlie');
+    });
+
+    it('tabs through properly without opening', () => {
+      cy.wait(100);
+      cy.get('body').tab();
+      cy.focused().should('have.attr', 'id', 'listbox-1');
+      cy.focused().tab();
+      cy.focused().should('have.text', 'end focus test');
+    });
+
+    it('tabs through properly while open', () => {
+      cy.get('label').click();
+      cy.get('body').tab();
+      cy.focused().should('have.text', 'Bravo');
+      cy.focused().tab();
+      cy.focused().should('have.text', 'end focus test');
+    });
+
+    it('opens the menu when focused and closed with keyboard arrows', () => {
+      cy.wait(100);
+      cy.get('body').tab();
+      cy.focused().trigger('keydown', {
+        key: 'ArrowDown',
+        keycode: 40,
+        shiftKey: false,
+      });
+      cy.contains('Alpha').should('be.visible');
+    });
+
+    it('selects item on click and returns focus to button', () => {
+      cy.get('label').click();
+      cy.get('button')
+        .eq(3)
+        .click();
+      cy.wait(100);
+      cy.focused().should('have.text', 'Charlie');
+      cy.get('[name="listbox-test"]').should('have.value', 'charlie');
+      cy.get('[aria-invalid="false"]').should('exist');
     });
   });
 
-  it('selects focused option when clicking enter key', () => {
-    cy.get('label').click();
-
-    cy.get('[data-id="open-listbox"]').trigger('keydown', {
-      key: 'a',
-      keyCode: 65,
-      shiftKey: false,
+  describe('with an error', () => {
+    beforeEach(() => {
+      cy.visit('/iframe.html?id=form-listbox--with-error');
     });
 
-    cy.get('[data-id="open-listbox"]').trigger('keydown', {
-      key: 'Enter',
-      keycode: 13,
-      shiftKey: false,
+    it('renders correctly', () => {
+      cy.get('[aria-invalid="true"]').should('exist');
+      cy.findAllByText('You must select an option').should('exist');
     });
-
-    cy.contains('Alpha').should('be.visible');
-  });
-
-  it('changes focus when navigating with up and down arrows', () => {
-    cy.get('label').click();
-
-    cy.get('[data-id="open-listbox"]').trigger('keydown', {
-      key: 'ArrowUp',
-      keycode: 38,
-      shiftKey: false,
-    });
-
-    cy.focused().should('have.text', 'Alpha');
-
-    cy.get('[data-id="open-listbox"]').trigger('keydown', {
-      key: 'ArrowDown',
-      keycode: 40,
-      shiftKey: false,
-    });
-
-    cy.get('[data-id="open-listbox"]').trigger('keydown', {
-      key: 'ArrowDown',
-      keycode: 40,
-      shiftKey: false,
-    });
-
-    cy.focused().should('have.text', 'Charlie');
-  });
-
-  it('tabs through properly without opening', () => {
-    cy.wait(100);
-    cy.get('body').tab();
-    cy.focused().should('have.attr', 'id', 'listbox-1');
-    cy.focused().tab();
-    cy.focused().should('have.text', 'end focus test');
-  });
-
-  it('tabs through properly while open', () => {
-    cy.get('label').click();
-    cy.get('body').tab();
-    cy.focused().should('have.text', 'Bravo');
-    cy.focused().tab();
-    cy.focused().should('have.text', 'end focus test');
-  });
-
-  it('opens the menu when focused and closed with keyboard arrows', () => {
-    cy.wait(100);
-    cy.get('body').tab();
-    cy.focused().trigger('keydown', {
-      key: 'ArrowDown',
-      keycode: 40,
-      shiftKey: false,
-    });
-    cy.contains('Alpha').should('be.visible');
-  });
-
-  it('selects item on click and returns focus to button', () => {
-    cy.get('label').click();
-    cy.get('button')
-      .eq(3)
-      .click();
-    cy.wait(100);
-    cy.focused().should('have.text', 'Charlie');
   });
 });

--- a/cypress/integration/Select.spec.js
+++ b/cypress/integration/Select.spec.js
@@ -1,13 +1,14 @@
-/// <reference types="Cypress" />
-
 describe('The Select component', () => {
-  beforeEach(() => {
-    cy.visit('/iframe.html?selectedKind=Form%7CSelect&selectedStory=Basic%20Select&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel');
+  it('focuses on the `<select/>` element when clicking on the `<label>`', () => {
+    cy.visit('/iframe.html?id=form-select--basic-select');
+    cy.get('label').click();
+    cy.get('select').should('have.focus');
+    cy.get('[aria-invalid="false"]').should('exist');
   });
 
-  it('focuses on the `<select/>` element when clicking on the `<label>`', () => {
-    cy.get('label').click();
-
-    cy.get('select').should('have.focus');
+  it('renders with an error correctly', () => {
+    cy.visit('/iframe.html?id=form-select--with-help-text-and-error');
+    cy.get('[aria-invalid="true"]').should('exist');
+    cy.findAllByText('You forgot to select').should('exist');
   });
 });

--- a/cypress/integration/TextField.spec.js
+++ b/cypress/integration/TextField.spec.js
@@ -1,0 +1,14 @@
+describe('The TextField component', () => {
+  it('focuses on the `<input/>` element when clicking on the `<label>`', () => {
+    cy.visit('/iframe.html?id=form-textfield--basic-textfield');
+    cy.get('label').click();
+    cy.get('input').should('have.focus');
+    cy.get('[aria-invalid="false"]').should('exist');
+  });
+
+  it('renders with an error correctly', () => {
+    cy.visit('/iframe.html?id=form-textfield--with-an-error');
+    cy.get('[aria-invalid="true"]').should('exist');
+    cy.findAllByText('You forgot an ID!').should('exist');
+  });
+});

--- a/packages/matchbox/src/components/Checkbox/Checkbox.js
+++ b/packages/matchbox/src/components/Checkbox/Checkbox.js
@@ -56,6 +56,7 @@ const Checkbox = React.forwardRef(function Checkbox(props, userRef) {
     <Wrapper {...systemProps}>
       <StyledLabel error={error} htmlFor={id} disabled={disabled}>
         <StyledInput
+          aria-invalid={!!error}
           id={id}
           value={value}
           defaultChecked={defaultChecked}

--- a/packages/matchbox/src/components/ListBox/ListBox.js
+++ b/packages/matchbox/src/components/ListBox/ListBox.js
@@ -198,6 +198,7 @@ const ListBox = React.forwardRef(function ListBox(props, userRef) {
               textAlign="left"
               fullWidth
               variant="mutedOutline"
+              aria-invalid={!!error}
               aria-haspopup="listbox"
               aria-pressed={open}
               aria-expanded={open}
@@ -230,7 +231,7 @@ const ListBox = React.forwardRef(function ListBox(props, userRef) {
       </Popover>
       {error && !errorInLabel && <Error id={errorId} error={error} />}
       {helpMarkup}
-      <input type="hidden" name={name} value={currentValue} aria-invalid={!!error} />
+      <input type="hidden" name={name} value={currentValue} />
     </StyledWrapper>
   );
 });

--- a/packages/matchbox/src/components/ListBox/ListBox.js
+++ b/packages/matchbox/src/components/ListBox/ListBox.js
@@ -202,7 +202,6 @@ const ListBox = React.forwardRef(function ListBox(props, userRef) {
               aria-haspopup="listbox"
               aria-pressed={open}
               aria-expanded={open}
-              aria-labelledby={id}
               onClick={togglePopover}
               onKeyDown={activatorKeyDown}
               disabled={disabled}

--- a/packages/matchbox/src/components/ListBox/ListBox.js
+++ b/packages/matchbox/src/components/ListBox/ListBox.js
@@ -39,6 +39,8 @@ const StyledButton = styled(Button)`
   font-weight: ${props => props.theme.fontWeights['medium']};
   background: ${props => (props.disabled ? props.theme.colors.gray['200'] : '')};
   padding-right: ${props => props.theme.space[650]};
+  border: ${props =>
+    props.hasError ? `1px solid ${props.theme.colors.red[700]}` : `${props.theme.borders[400]}`};
   &:hover {
     background: ${props => (props.disabled ? props.theme.colors.gray['200'] : 'transparent')};
   }
@@ -76,6 +78,7 @@ const ListBox = React.forwardRef(function ListBox(props, userRef) {
     defaultValue,
     value,
     onChange,
+    name,
     ...rest
   } = props;
 
@@ -202,6 +205,7 @@ const ListBox = React.forwardRef(function ListBox(props, userRef) {
               onClick={togglePopover}
               onKeyDown={activatorKeyDown}
               disabled={disabled}
+              hasError={!!error}
               {...componentProps}
               {...describedBy}
               ref={assignRefs}
@@ -226,6 +230,7 @@ const ListBox = React.forwardRef(function ListBox(props, userRef) {
       </Popover>
       {error && !errorInLabel && <Error id={errorId} error={error} />}
       {helpMarkup}
+      <input type="hidden" name={name} value={currentValue} aria-invalid={!!error} />
     </StyledWrapper>
   );
 });
@@ -241,6 +246,7 @@ ListBox.propTypes = {
   errorInLabel: PropTypes.bool,
   disabled: PropTypes.bool,
   required: PropTypes.bool,
+  name: PropTypes.string,
   optional: PropTypes.bool,
   onChange: PropTypes.func,
   onFocus: PropTypes.func,

--- a/packages/matchbox/src/components/Radio/Radio.js
+++ b/packages/matchbox/src/components/Radio/Radio.js
@@ -43,6 +43,7 @@ const Radio = React.forwardRef(function Radio(props, userRef) {
     <Wrapper {...systemProps}>
       <StyledLabel error={error} htmlFor={id} disabled={disabled}>
         <StyledInput
+          aria-invalid={!!error}
           id={id}
           name={name}
           value={value}

--- a/packages/matchbox/src/components/Select/Select.js
+++ b/packages/matchbox/src/components/Select/Select.js
@@ -58,21 +58,23 @@ const StyledInput = styled(Box)`
 `;
 
 const SelectBox = React.forwardRef(function SelectBox(props, userRef) {
+  const { hasError, disabled, ...rest } = props;
   return (
     <StyledInputWrapper>
       <StyledInput
+        aria-invalid={!!hasError}
         as="select"
-        disabled={props.disabled}
+        disabled={disabled}
         width="100%"
-        border={props.hasError ? `1px solid ${tokens.color_red_700}` : '400'}
+        border={hasError ? `1px solid ${tokens.color_red_700}` : '400'}
         borderRadius="100"
-        bg={props.disabled ? 'gray.200' : 'white'}
+        bg={disabled ? 'gray.200' : 'white'}
         pl="400"
         pr="600"
         lineHeight="2.5rem"
         height="2.5rem"
         color="gray.900"
-        {...props}
+        {...rest}
         ref={userRef}
       />
     </StyledInputWrapper>

--- a/packages/matchbox/src/components/TextField/TextField.js
+++ b/packages/matchbox/src/components/TextField/TextField.js
@@ -31,22 +31,25 @@ const StyledInput = styled(Box)`
 `;
 
 const FieldBox = React.forwardRef(function FieldBox(props, userRef) {
+  const { hasError, disabled, height, lineHeight, required, py, ...rest } = props;
+
   return (
     <StyledInputWrapper>
       <StyledInput
+        aria-invalid={!!hasError}
         as="input"
         px="400"
-        {...props}
-        disabled={props.disabled}
+        {...rest}
+        disabled={disabled}
         width="100%"
-        border={props.hasError ? `1px solid ${tokens.color_red_700}` : '400'}
+        border={hasError ? `1px solid ${tokens.color_red_700}` : '400'}
         borderRadius="100"
-        bg={props.disabled ? 'gray.200' : 'white'}
+        bg={disabled ? 'gray.200' : 'white'}
         color="gray.900"
-        height={props.height}
-        lineHeight={props.lineHeight}
-        py={props.py}
-        required={props.required}
+        height={height}
+        lineHeight={lineHeight}
+        py={py}
+        required={required}
         ref={userRef}
       />
     </StyledInputWrapper>
@@ -138,6 +141,7 @@ const TextField = React.forwardRef(function TextField(props, userRef) {
     height: multiline ? 'auto' : '2.5rem',
     lineHeight: multiline ? '300' : '2.5rem',
     py: multiline ? '300' : '0',
+    hasError: !!error,
     name,
     id,
     type,

--- a/stories/form/ListBox.stories.js
+++ b/stories/form/ListBox.stories.js
@@ -22,7 +22,7 @@ export const BasicListbox = withInfo()(() => (
 
 export const PrintableCharacter = withInfo()(() => (
   <>
-    <ListBox id="listbox-1" defaultValue="bravo" label="Select an option">
+    <ListBox id="listbox-1" defaultValue="bravo" label="Select an option" name="listbox-test">
       <ListBox.Option value="alpha">Alpha</ListBox.Option>
       <ListBox.Option value="bravo">Bravo</ListBox.Option>
       <ListBox.Option value="charlie">Charlie</ListBox.Option>


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed
- Adds `aria-invalid` on all `<input>` components that support errors
- Skips `Toggle` and `RadioCard`

### How To Test or Verify
- Run storybook
- Verify `aria-invalid` is properly set on:
  - Checkbox
  - Radio 
  - Select
  - TextField
  - ListBox

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
