### PR TITLE
UX-439 Add data-id to Error component

### DIFF
--- a/cypress/integration/Checkbox.spec.js
+++ b/cypress/integration/Checkbox.spec.js
@@ -3,12 +3,14 @@ describe('The Checkbox component', () => {
     cy.visit('/iframe.html?id=form-checkbox--basic-checkbox');
     cy.get('label').click();
     cy.get('input').should('have.focus');
+    cy.get('[data-id="error-message"]').should('not.exist');
     cy.get('[aria-invalid="false"]').should('exist');
   });
 
   it('renders with an error correctly', () => {
     cy.visit('/iframe.html?id=form-checkbox--with-error-and-required');
     cy.get('[aria-invalid="true"]').should('exist');
+    cy.get('[data-id="error-message"]').should('exist');
     cy.findAllByText("I'm an error").should('exist');
   });
 });

--- a/cypress/integration/ListBox.spec.js
+++ b/cypress/integration/ListBox.spec.js
@@ -101,6 +101,7 @@ describe('The ListBox component', () => {
       cy.focused().should('have.text', 'Charlie');
       cy.get('[name="listbox-test"]').should('have.value', 'charlie');
       cy.get('[aria-invalid="false"]').should('exist');
+      cy.get('[data-id="error-message"]').should('not.exist');
     });
   });
 
@@ -111,6 +112,7 @@ describe('The ListBox component', () => {
 
     it('renders correctly', () => {
       cy.get('[aria-invalid="true"]').should('exist');
+      cy.get('[data-id="error-message"]').should('exist');
       cy.findAllByText('You must select an option').should('exist');
     });
   });

--- a/cypress/integration/Select.spec.js
+++ b/cypress/integration/Select.spec.js
@@ -3,12 +3,14 @@ describe('The Select component', () => {
     cy.visit('/iframe.html?id=form-select--basic-select');
     cy.get('label').click();
     cy.get('select').should('have.focus');
+    cy.get('[data-id="error-message"]').should('not.exist');
     cy.get('[aria-invalid="false"]').should('exist');
   });
 
   it('renders with an error correctly', () => {
     cy.visit('/iframe.html?id=form-select--with-help-text-and-error');
     cy.get('[aria-invalid="true"]').should('exist');
+    cy.get('[data-id="error-message"]').should('exist');
     cy.findAllByText('You forgot to select').should('exist');
   });
 });

--- a/cypress/integration/TextField.spec.js
+++ b/cypress/integration/TextField.spec.js
@@ -3,12 +3,14 @@ describe('The TextField component', () => {
     cy.visit('/iframe.html?id=form-textfield--basic-textfield');
     cy.get('label').click();
     cy.get('input').should('have.focus');
+    cy.get('[data-id="error-message"]').should('not.exist');
     cy.get('[aria-invalid="false"]').should('exist');
   });
 
   it('renders with an error correctly', () => {
     cy.visit('/iframe.html?id=form-textfield--with-an-error');
     cy.get('[aria-invalid="true"]').should('exist');
+    cy.get('[data-id="error-message"]').should('exist');
     cy.findAllByText('You forgot an ID!').should('exist');
   });
 });

--- a/packages/matchbox/src/components/Error/Error.js
+++ b/packages/matchbox/src/components/Error/Error.js
@@ -6,7 +6,7 @@ function Error(props) {
   const { className, error, wrapper: WrapperComponent = 'div', id, ml = '0' } = props;
 
   return (
-    <Box id={id} as={WrapperComponent} className={className} ml={ml}>
+    <Box id={id} as={WrapperComponent} className={className} ml={ml} data-id="error-message">
       <Box as="span" color="red.700" fontSize="200" lineHeight="200">
         <Box as="span" display="inline-block" mr="100">
           <ErrorIcon size={14} label="Error" />

--- a/packages/matchbox/src/components/Error/tests/Error.test.js
+++ b/packages/matchbox/src/components/Error/tests/Error.test.js
@@ -14,5 +14,6 @@ describe('Error', () => {
         .first()
         .prop('className'),
     ).toContain('test-class');
+    expect(wrapper).toHaveAttributeValue('data-id', 'error-message');
   });
 });


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed
- Hardcodes `data-id="error-message"` to the `Error` component
  - Surfaced in: TextField, Checkbox, Select, ListBox

### How To Test or Verify
- Run storybook
- Verify the attribute is set correctly on the error message

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
