### PR TITLE
UX-444 Update Snackbar component props to accept maxWidth styled prop

### DIFF
--- a/packages/matchbox/src/components/Snackbar/Snackbar.js
+++ b/packages/matchbox/src/components/Snackbar/Snackbar.js
@@ -5,7 +5,7 @@ import { ScreenReaderOnly } from '../ScreenReaderOnly';
 import PropTypes from 'prop-types';
 import { createPropTypes } from '@styled-system/prop-types';
 import { Close, Info, CheckCircle, Warning, ErrorIcon } from '@sparkpost/matchbox-icons';
-import { margin } from 'styled-system';
+import { margin, maxWidth } from 'styled-system';
 import { base, status, dismiss, dismissStatus } from './styles';
 import { buttonReset } from '../../styles/helpers';
 
@@ -70,11 +70,6 @@ Snackbar.propTypes = {
   status: PropTypes.oneOf(['default', 'success', 'danger', 'error', 'warning']),
 
   /**
-   * Snackbar max-width in pixels.
-   */
-  maxWidth: PropTypes.number,
-
-  /**
    * Callback when dismiss button is clicked.
    */
   onDismiss: PropTypes.func.isRequired,
@@ -84,6 +79,7 @@ Snackbar.propTypes = {
    */
   children: PropTypes.node,
   ...createPropTypes(margin.propNames),
+  ...createPropTypes(maxWidth.propNames),
 };
 
 export default Snackbar;

--- a/packages/matchbox/src/components/Snackbar/tests/Snackbar.test.js
+++ b/packages/matchbox/src/components/Snackbar/tests/Snackbar.test.js
@@ -26,8 +26,8 @@ describe('Snackbar', () => {
   });
 
   it('renders Snackbar with a danger status and maxwidth', () => {
-    const wrapper = subject({ status: 'danger', maxWidth: 100 });
-    expect(wrapper.find('Box').at(1)).toHaveStyleRule('max-width', '100px');
+    const wrapper = subject({ status: 'danger', maxWidth: '1000px' });
+    expect(wrapper.find('Box').at(1)).toHaveStyleRule('max-width', '1000px');
     expect(wrapper).toHaveStyleRule('background', '#d9363e');
     expect(wrapper.find('[aria-label="Error"]')).toExist();
   });

--- a/stories/feedback/Snackbar.stories.js
+++ b/stories/feedback/Snackbar.stories.js
@@ -25,7 +25,7 @@ export const Statuses = withInfo({ propTables: [Snackbar] })(() => (
 ));
 
 export const Large = withInfo()(() => (
-  <Snackbar maxWidth={700}>
+  <Snackbar maxWidth={['400px', null, null, '800px']}>
     This one is large enough to get into some bacon ipsum dolor amet pork loin tri-tip turkey
     capicola. Rump doner short ribs biltong burgdoggen meatloaf. Prosciutto pork loin bacon, biltong
     landjaeger salami ham spare ribs flank cupim porchetta leberkas.{' '}


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed

- Snackbar component now accepts `maxWidth` prop as a styled prop and not just a number

### How To Test or Verify

- Verify Snackbar [story](http://localhost:9001/?path=/story/feedback-snackbar--large)

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
