### PR TITLE
UX-443 Vertical align `Error` icon and text

### DIFF
--- a/packages/matchbox/src/components/Error/Error.js
+++ b/packages/matchbox/src/components/Error/Error.js
@@ -7,8 +7,15 @@ function Error(props) {
 
   return (
     <Box id={id} as={WrapperComponent} className={className} ml={ml} data-id="error-message">
-      <Box as="span" color="red.700" fontSize="200" lineHeight="200">
-        <Box as="span" display="inline-block" mr="100">
+      <Box
+        as="span"
+        color="red.700"
+        fontSize="200"
+        lineHeight="200"
+        display="inline-flex"
+        alignItems="center"
+      >
+        <Box as="span" display="inline-block" mr="100" lineHeight="0">
           <ErrorIcon size={14} label="Error" />
         </Box>
         <span>{error}</span>


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed

- Fixes vertical alignment of `Error` component

### How To Test or Verify

- `npm run start:storybook`
- Verify stories with errors http://localhost:9001/?path=/story/form-textfield--with-an-error

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
