### PR TITLE
UX-445 Expandable update vertical padding with subtitle

### DIFF
--- a/packages/matchbox/src/components/Expandable/Expandable.js
+++ b/packages/matchbox/src/components/Expandable/Expandable.js
@@ -105,6 +105,7 @@ function Expandable(props) {
           ref={header}
           data-id="expandable-toggle"
           type="button"
+          variant={variant}
         >
           {iconMarkup}
           <Box display="inline-block" flex="1">

--- a/packages/matchbox/src/components/Expandable/Expandable.js
+++ b/packages/matchbox/src/components/Expandable/Expandable.js
@@ -23,7 +23,7 @@ const StyledTitle = styled('h3')`
   ${title}
 `;
 
-const StyledSubtitle = styled('h6')`
+const StyledSubtitle = styled(Box)`
   ${subtitle}
 `;
 
@@ -85,7 +85,11 @@ function Expandable(props) {
     </StyledIcon>
   ) : null;
 
-  const subtitleMarkup = subtitle ? <StyledSubtitle>{subtitle}</StyledSubtitle> : null;
+  const subtitleMarkup = subtitle ? (
+    <StyledSubtitle as="h6" mb="100">
+      {subtitle}
+    </StyledSubtitle>
+  ) : null;
 
   const contentSpacer = icon ? <Box flex="0" minWidth="40px" maxWidth="40px" mr="500" /> : null;
 

--- a/packages/matchbox/src/components/Expandable/styles.js
+++ b/packages/matchbox/src/components/Expandable/styles.js
@@ -7,10 +7,10 @@ export const StyledHeader = styled('button')`
   ${buttonReset}
   user-select: none;
   outline: none;
-  ${() =>
+  ${props =>
     css({
       px: '450',
-      py: '300',
+      py: props.variant === 'borderless' ? '200' : '300',
     })}
 
   display: flex;

--- a/packages/matchbox/src/components/Expandable/styles.js
+++ b/packages/matchbox/src/components/Expandable/styles.js
@@ -10,7 +10,7 @@ export const StyledHeader = styled('button')`
   ${() =>
     css({
       px: '450',
-      py: '200',
+      py: '300',
     })}
 
   display: flex;
@@ -96,6 +96,7 @@ export const title = ({ variant }) => `
 
 export const subtitle = () => `
   font-weight: ${tokens.fontWeight_normal};
+
 `;
 
 export const accent = props => {

--- a/stories/layout/Expandable.stories.js
+++ b/stories/layout/Expandable.stories.js
@@ -34,14 +34,6 @@ export const WithImageTitleAndSubtitle = withInfo()(() => (
       >
         Content here
       </Expandable>
-      <Expandable
-        defaultOpen={true}
-        title="Slack"
-        id="example"
-        subtitle="Integrate alerts into your team's Slack channels"
-      >
-        Content here
-      </Expandable>
     </Panel.Section>
   </Panel>
 ));

--- a/stories/layout/Expandable.stories.js
+++ b/stories/layout/Expandable.stories.js
@@ -34,6 +34,14 @@ export const WithImageTitleAndSubtitle = withInfo()(() => (
       >
         Content here
       </Expandable>
+      <Expandable
+        defaultOpen={true}
+        title="Slack"
+        id="example"
+        subtitle="Integrate alerts into your team's Slack channels"
+      >
+        Content here
+      </Expandable>
     </Panel.Section>
   </Panel>
 ));

--- a/stories/layout/Expandable.stories.js
+++ b/stories/layout/Expandable.stories.js
@@ -79,7 +79,13 @@ export const Borderless = () => (
       </Expandable>
     </Panel.Section>
     <Panel.Section p="0">
-      <Expandable variant="borderless" defaultOpen={false} title="Comparisons" id="example-3">
+      <Expandable
+        variant="borderless"
+        defaultOpen={false}
+        title="Comparisons"
+        id="example-3"
+        subtitle="Subtitle"
+      >
         Content here
       </Expandable>
     </Panel.Section>


### PR DESCRIPTION
 update vertical padding on Expandable with Subtitle

<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed

- updated vertical padding of `Expandable` with `subtitle` to match horizontal spacing

### How To Test or Verify

- `npm run start:storybook`
- Verify story http://localhost:9001/?path=/story/layout-expandable--with-image-title-and-subtitle

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
