### PR TITLE
UX-394 Remove spreading of unknown ProgressBar props

### DIFF
--- a/packages/matchbox/src/components/ProgressBar/ProgressBar.js
+++ b/packages/matchbox/src/components/ProgressBar/ProgressBar.js
@@ -23,7 +23,7 @@ export const StyledProgressBarInner = styled(Box)`
   ${calculatedWidth}
 `;
 
-function ProgressBar(props) {
+const ProgressBar = React.forwardRef(function ProgressBar(props, userRef) {
   const { completed = 0, label, size, valueText, ...rest } = props;
   const systemProps = pick(rest, system.propNames);
 
@@ -38,11 +38,13 @@ function ProgressBar(props) {
       aria-valuemax="100"
       aria-valuetext={valueText}
       {...systemProps}
+      data-id={rest['data-id']}
+      ref={userRef}
     >
       <StyledProgressBarInner as="div" completed={completed} visualSize={size} />
     </StyledProgressBarOuter>
   );
-}
+});
 
 ProgressBar.displayName = 'ProgressBar';
 
@@ -52,6 +54,7 @@ ProgressBar.propTypes = {
     PropTypes.oneOf(['orange', 'blue', 'navy', 'purple', 'red']),
     'Color is always blue for now. This may be updated in the future.',
   ),
+  'data-id': PropTypes.string,
   size: PropTypes.oneOf(['normal', 'small']),
   /**
    * Describes what the progressbar represents - content is visually hidden

--- a/packages/matchbox/src/components/ProgressBar/ProgressBar.js
+++ b/packages/matchbox/src/components/ProgressBar/ProgressBar.js
@@ -23,13 +23,12 @@ export const StyledProgressBarInner = styled(Box)`
 `;
 
 function ProgressBar(props) {
-  const { completed = 0, label, size, valueText, ...rest } = props;
+  const { completed = 0, label, size, valueText } = props;
 
   return (
     <StyledProgressBarOuter
       as="div"
       visualSize={size}
-      {...rest}
       role="progressbar"
       aria-label={label}
       aria-valuenow={`${completed}`}

--- a/packages/matchbox/src/components/ProgressBar/ProgressBar.js
+++ b/packages/matchbox/src/components/ProgressBar/ProgressBar.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { deprecate } from '../../helpers/propTypes';
 import styled from 'styled-components';
 import { margin, compose } from 'styled-system';
 import { createPropTypes } from '@styled-system/prop-types';
+import { deprecate } from '../../helpers/propTypes';
+import { pick } from '../../helpers/props';
 import { Box } from '../Box';
 
 import { outerBase, innerBase, visualSize, calculatedWidth } from './styles.js';
@@ -23,7 +24,8 @@ export const StyledProgressBarInner = styled(Box)`
 `;
 
 function ProgressBar(props) {
-  const { completed = 0, label, size, valueText } = props;
+  const { completed = 0, label, size, valueText, ...rest } = props;
+  const systemProps = pick(rest, system.propNames);
 
   return (
     <StyledProgressBarOuter
@@ -35,6 +37,7 @@ function ProgressBar(props) {
       aria-valuemin="0"
       aria-valuemax="100"
       aria-valuetext={valueText}
+      {...systemProps}
     >
       <StyledProgressBarInner as="div" completed={completed} visualSize={size} />
     </StyledProgressBarOuter>

--- a/packages/matchbox/src/components/ProgressBar/ProgressBar.js
+++ b/packages/matchbox/src/components/ProgressBar/ProgressBar.js
@@ -24,7 +24,7 @@ export const StyledProgressBarInner = styled(Box)`
 `;
 
 const ProgressBar = React.forwardRef(function ProgressBar(props, userRef) {
-  const { completed = 0, label, size, valueText, ...rest } = props;
+  const { completed = 0, label, size, valueText, id, 'data-id': dataId, ...rest } = props;
   const systemProps = pick(rest, system.propNames);
 
   return (
@@ -38,7 +38,8 @@ const ProgressBar = React.forwardRef(function ProgressBar(props, userRef) {
       aria-valuemax="100"
       aria-valuetext={valueText}
       {...systemProps}
-      data-id={rest['data-id']}
+      data-id={dataId}
+      id={id}
       ref={userRef}
     >
       <StyledProgressBarInner as="div" completed={completed} visualSize={size} />
@@ -55,6 +56,7 @@ ProgressBar.propTypes = {
     'Color is always blue for now. This may be updated in the future.',
   ),
   'data-id': PropTypes.string,
+  id: PropTypes.string,
   size: PropTypes.oneOf(['normal', 'small']),
   /**
    * Describes what the progressbar represents - content is visually hidden


### PR DESCRIPTION

### What Changed
- Removes spreading of unknown props on ProgressBar
- Explicitly picks system props

### How To Test or Verify
- Verify ProgressBar story renders as expected: http://localhost:9001/?path=/story/feedback-progressbar--default
- Verify ProgressBar tests did not break
- Verify 2web2ui does not use any props that are not explicitly defined: https://proply-2web2ui.vercel.app/

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
