### PR TITLE
UX-430 Create inverted color scheme for Panel component

### DIFF
--- a/packages/matchbox/src/components/Panel/Header.js
+++ b/packages/matchbox/src/components/Panel/Header.js
@@ -6,13 +6,14 @@ import { Button } from '../Button';
 import { Column } from '../Column';
 import { Columns } from '../Columns';
 import { getChild, excludeChild } from '../../helpers/children';
-import { PanelPaddingContext } from './context';
+import { PanelPaddingContext, PanelAppearanceContext } from './context';
 
 const Header = React.forwardRef(function Header(props, userRef) {
   const { as, borderBottom, children, className } = props;
   const actions = getChild('Panel.Action', children);
   const title = excludeChild(['Panel.Action'], children);
   const paddingContext = React.useContext(PanelPaddingContext);
+  const appearanceContext = React.useContext(PanelAppearanceContext);
 
   return (
     <Box
@@ -24,6 +25,7 @@ const Header = React.forwardRef(function Header(props, userRef) {
       pb={borderBottom ? null : [0, null, 0]}
       ref={userRef}
       tabIndex="-1"
+      color={appearanceContext === 'inverted' ? 'white' : ''}
     >
       <Columns collapseBelow="xs" space="300" alignY="top" align="right">
         <Column>

--- a/packages/matchbox/src/components/Panel/Header.js
+++ b/packages/matchbox/src/components/Panel/Header.js
@@ -9,11 +9,11 @@ import { getChild, excludeChild } from '../../helpers/children';
 import { PanelPaddingContext, PanelAppearanceContext } from './context';
 
 const Header = React.forwardRef(function Header(props, userRef) {
-  const { as, borderBottom, children, className } = props;
+  const { as, appearance, borderBottom, children, className } = props;
   const actions = getChild('Panel.Action', children);
   const title = excludeChild(['Panel.Action'], children);
   const paddingContext = React.useContext(PanelPaddingContext);
-  const appearanceContext = React.useContext(PanelAppearanceContext);
+  const appearanceContext = appearance || React.useContext(PanelAppearanceContext);
 
   return (
     <Box
@@ -26,6 +26,7 @@ const Header = React.forwardRef(function Header(props, userRef) {
       ref={userRef}
       tabIndex="-1"
       color={appearanceContext === 'inverted' ? 'white' : ''}
+      bg={appearanceContext === 'inverted' ? 'gray.900' : ''}
     >
       <Columns collapseBelow="xs" space="300" alignY="top" align="right">
         <Column>
@@ -49,6 +50,7 @@ Header.defaultProps = {
 };
 Header.propTypes = {
   as: PropTypes.string,
+  appearance: PropTypes.oneOf(['inverted', 'default']),
   borderBottom: PropTypes.bool,
   children: PropTypes.node,
   className: PropTypes.string,

--- a/packages/matchbox/src/components/Panel/Panel.js
+++ b/packages/matchbox/src/components/Panel/Panel.js
@@ -36,7 +36,6 @@ const Panel = React.forwardRef(function Panel(props, userRef) {
         {...innerSystemProps}
         height={innerHeight}
         bg={appearance === 'inverted' ? 'gray.900' : ''}
-        borderColor={appearance === 'inverted' ? 'gray.600' : ''}
       >
         {accent && <Accent accentColor={accent} />}
         <PanelPaddingContext.Provider

--- a/packages/matchbox/src/components/Panel/Panel.js
+++ b/packages/matchbox/src/components/Panel/Panel.js
@@ -36,6 +36,7 @@ const Panel = React.forwardRef(function Panel(props, userRef) {
         {...innerSystemProps}
         height={innerHeight}
         bg={appearance === 'inverted' ? 'gray.900' : ''}
+        borderColor={appearance === 'inverted' ? 'gray.600' : ''}
       >
         {accent && <Accent accentColor={accent} />}
         <PanelPaddingContext.Provider

--- a/packages/matchbox/src/components/Panel/Panel.js
+++ b/packages/matchbox/src/components/Panel/Panel.js
@@ -10,13 +10,13 @@ import Header from './Header';
 import SubHeader from './SubHeader';
 import Section from './Section';
 import { pick } from '../../helpers/props';
-import { PanelPaddingContext } from './context';
+import { PanelPaddingContext, PanelAppearanceContext } from './context';
 
 const systemOuter = compose(margin, width, height);
 const systemInner = compose(border, height);
 
 const Panel = React.forwardRef(function Panel(props, userRef) {
-  const { accent, children, className, ...rest } = props;
+  const { accent, appearance, children, className, ...rest } = props;
 
   const outerSystemProps = pick(rest, systemOuter.propNames);
   const innerSystemProps = pick(rest, systemInner.propNames);
@@ -35,12 +35,15 @@ const Panel = React.forwardRef(function Panel(props, userRef) {
         position="relative"
         {...innerSystemProps}
         height={innerHeight}
+        bg={appearance === 'inverted' ? 'gray.900' : ''}
       >
         {accent && <Accent accentColor={accent} />}
         <PanelPaddingContext.Provider
           value={{ p: contextP || contextPadding || [400, null, 450], ...context }}
         >
-          {children}
+          <PanelAppearanceContext.Provider value={appearance}>
+            {children}
+          </PanelAppearanceContext.Provider>
         </PanelPaddingContext.Provider>
       </Box>
     </Box>
@@ -53,6 +56,7 @@ Panel.propTypes = {
     PropTypes.bool,
     PropTypes.oneOf(['orange', 'blue', 'red', 'yellow', 'green', 'gray']),
   ]),
+  appearance: PropTypes.oneOf(['inverted', 'default']),
   children: PropTypes.node,
   className: PropTypes.string,
   'data-id': PropTypes.string,
@@ -61,6 +65,10 @@ Panel.propTypes = {
   ...createPropTypes(margin.propNames),
   ...createPropTypes(padding.propNames),
   ...createPropTypes(width.propNames),
+};
+
+Panel.defaultProps = {
+  appearance: 'default',
 };
 
 Panel.LEGACY = Legacy;

--- a/packages/matchbox/src/components/Panel/Section.js
+++ b/packages/matchbox/src/components/Panel/Section.js
@@ -43,7 +43,6 @@ const Section = React.forwardRef(function Section(props, userRef) {
       {...paddingProps}
       bg={appearanceContext === 'inverted' ? 'gray.900' : ''}
       color={appearanceContext === 'inverted' ? 'white' : ''}
-      borderColor={appearanceContext === 'inverted' ? 'gray.600' : ''}
     >
       <Columns collapseBelow="xs" space="300" alignY="top" align="right">
         <Column>{content}</Column>

--- a/packages/matchbox/src/components/Panel/Section.js
+++ b/packages/matchbox/src/components/Panel/Section.js
@@ -9,7 +9,7 @@ import { Column } from '../Column';
 import { Columns } from '../Columns';
 import { getChild, excludeChild } from '../../helpers/children';
 import { pick } from '../../helpers/props';
-import { PanelPaddingContext } from './context';
+import { PanelPaddingContext, PanelAppearanceContext } from './context';
 
 const StyledSection = styled(Box)`
   &:last-child {
@@ -22,6 +22,7 @@ const Section = React.forwardRef(function Section(props, userRef) {
   const actions = getChild('Panel.Action', children);
   const content = excludeChild(['Panel.Action'], children);
   const paddingContext = React.useContext(PanelPaddingContext);
+  const appearanceContext = React.useContext(PanelAppearanceContext);
   const systemProps = pick(rest, padding.propNames);
 
   // Checks if 'padding', and overwrite 'p' instead of using the 'padding' key
@@ -40,6 +41,8 @@ const Section = React.forwardRef(function Section(props, userRef) {
       ref={userRef}
       tabIndex="-1"
       {...paddingProps}
+      bg={appearanceContext === 'inverted' ? 'gray.900' : ''}
+      color={appearanceContext === 'inverted' ? 'white' : ''}
     >
       <Columns collapseBelow="xs" space="300" alignY="top" align="right">
         <Column>{content}</Column>

--- a/packages/matchbox/src/components/Panel/Section.js
+++ b/packages/matchbox/src/components/Panel/Section.js
@@ -18,11 +18,11 @@ const StyledSection = styled(Box)`
 `;
 
 const Section = React.forwardRef(function Section(props, userRef) {
-  const { children, className, ...rest } = props;
+  const { children, className, appearance, ...rest } = props;
   const actions = getChild('Panel.Action', children);
   const content = excludeChild(['Panel.Action'], children);
   const paddingContext = React.useContext(PanelPaddingContext);
-  const appearanceContext = React.useContext(PanelAppearanceContext);
+  const appearanceContext = appearance || React.useContext(PanelAppearanceContext);
   const systemProps = pick(rest, padding.propNames);
 
   // Checks if 'padding', and overwrite 'p' instead of using the 'padding' key
@@ -43,6 +43,7 @@ const Section = React.forwardRef(function Section(props, userRef) {
       {...paddingProps}
       bg={appearanceContext === 'inverted' ? 'gray.900' : ''}
       color={appearanceContext === 'inverted' ? 'white' : ''}
+      borderColor={appearanceContext === 'inverted' ? 'gray.600' : ''}
     >
       <Columns collapseBelow="xs" space="300" alignY="top" align="right">
         <Column>{content}</Column>
@@ -58,6 +59,7 @@ const Section = React.forwardRef(function Section(props, userRef) {
 
 Section.displayName = 'Panel.Section';
 Section.propTypes = {
+  appearance: PropTypes.oneOf(['inverted', 'default']),
   children: PropTypes.node,
   className: PropTypes.string,
   ...createPropTypes(padding.propNames),

--- a/packages/matchbox/src/components/Panel/SubHeader.js
+++ b/packages/matchbox/src/components/Panel/SubHeader.js
@@ -4,10 +4,10 @@ import { Box } from '../Box';
 import { PanelPaddingContext, PanelAppearanceContext } from './context';
 
 const SubHeader = React.forwardRef(function SubHeader(props, userRef) {
-  const { as, children, className } = props;
+  const { as, children, className, appearance } = props;
 
   const paddingContext = React.useContext(PanelPaddingContext);
-  const appearanceContext = React.useContext(PanelAppearanceContext);
+  const appearanceContext = appearance || React.useContext(PanelAppearanceContext);
 
   return (
     <Box
@@ -18,7 +18,8 @@ const SubHeader = React.forwardRef(function SubHeader(props, userRef) {
       fontSize="200"
       fontWeight="normal"
       lineHeight="200"
-      color={appearanceContext === 'inverted' ? 'white' : 'gray.700'}
+      color={appearanceContext === 'inverted' ? 'gray.300' : 'gray.700'}
+      bg={appearanceContext === 'inverted' ? 'gray.900' : ''}
       tabIndex="-1"
       ref={userRef}
     >
@@ -33,6 +34,7 @@ SubHeader.defaultProps = {
 };
 SubHeader.propTypes = {
   as: PropTypes.string,
+  appearance: PropTypes.oneOf(['appearance', 'default']),
   children: PropTypes.node,
   className: PropTypes.string,
 };

--- a/packages/matchbox/src/components/Panel/SubHeader.js
+++ b/packages/matchbox/src/components/Panel/SubHeader.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box } from '../Box';
-import { PanelPaddingContext } from './context';
+import { PanelPaddingContext, PanelAppearanceContext } from './context';
 
 const SubHeader = React.forwardRef(function SubHeader(props, userRef) {
   const { as, children, className } = props;
 
   const paddingContext = React.useContext(PanelPaddingContext);
+  const appearanceContext = React.useContext(PanelAppearanceContext);
 
   return (
     <Box
@@ -17,7 +18,7 @@ const SubHeader = React.forwardRef(function SubHeader(props, userRef) {
       fontSize="200"
       fontWeight="normal"
       lineHeight="200"
-      color="gray.700"
+      color={appearanceContext === 'inverted' ? 'white' : 'gray.700'}
       tabIndex="-1"
       ref={userRef}
     >

--- a/packages/matchbox/src/components/Panel/context.js
+++ b/packages/matchbox/src/components/Panel/context.js
@@ -5,3 +5,9 @@ import React from 'react';
  * to Panel.Header and Panel.Section
  */
 export const PanelPaddingContext = React.createContext({});
+
+/**
+ * Context is created here to pass appearance prop
+ * to Panel.Header, Panel.SubHeader, and Panel.Section
+ */
+export const PanelAppearanceContext = React.createContext({});

--- a/packages/matchbox/src/components/Panel/tests/Panel.test.js
+++ b/packages/matchbox/src/components/Panel/tests/Panel.test.js
@@ -75,6 +75,21 @@ describe('Panel Components', () => {
       });
       expect(wrapper.find(Panel.SubHeader)).toHaveStyleRule('padding', '1.5rem');
     });
+
+    it('renders inverted appearance correctly', () => {
+      let wrapper = subject({
+        appearance: 'inverted',
+        children: (
+          <>
+            <Panel.Header>The Header</Panel.Header>
+            <Panel.Section>Panel Section</Panel.Section>
+          </>
+        ),
+      });
+
+      expect(wrapper.find(Panel.Section)).toHaveStyleRule('color', 'white');
+      expect(wrapper.find(Panel.Header)).toHaveStyleRule('color', 'white');
+    });
   });
 
   describe('Panel.Header', () => {

--- a/stories/layout/Panel.stories.js
+++ b/stories/layout/Panel.stories.js
@@ -13,10 +13,23 @@ export const WithAHeader = withInfo()(() => (
   </Panel>
 ));
 
-export const InvertedAppearance = withInfo()(() => (
+export const InvertedAppearancePanel = withInfo()(() => (
   <Panel data-id="my-panel" appearance="inverted">
-    <Panel.Header>Title</Panel.Header>
+    <Panel.Header>Header</Panel.Header>
     <Panel.Section>Section Content</Panel.Section>
+    <Panel.SubHeader>SubHeader</Panel.SubHeader>
+    <Panel.Section>Section two</Panel.Section>
+  </Panel>
+));
+
+export const InvertedAppearancePanelSection = withInfo()(() => (
+  <Panel data-id="my-panel">
+    <Panel.Header>Header</Panel.Header>
+    <Panel.Section>Section Content</Panel.Section>
+    <Panel.Header appearance="inverted">Header</Panel.Header>
+    <Panel.Section appearance="inverted">Section two</Panel.Section>
+    <Panel.SubHeader appearance="inverted">SubHeader</Panel.SubHeader>
+    <Panel.Section appearance="inverted">Section three</Panel.Section>
   </Panel>
 ));
 

--- a/stories/layout/Panel.stories.js
+++ b/stories/layout/Panel.stories.js
@@ -13,6 +13,13 @@ export const WithAHeader = withInfo()(() => (
   </Panel>
 ));
 
+export const InvertedAppearance = withInfo()(() => (
+  <Panel data-id="my-panel" appearance="inverted">
+    <Panel.Header>Title</Panel.Header>
+    <Panel.Section>Section Content</Panel.Section>
+  </Panel>
+));
+
 export const WithASubheader = withInfo()(() => (
   <Panel data-id="my-panel">
     <Panel.SubHeader>Details and Definition</Panel.SubHeader>


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed

- New `appearance` prop on `Panel` component which accepts `inverted` or `default`
- Implemented with context to pass down to `Panel.Header` `Panel.SubHeader` and `Panel.Section`

### How To Test or Verify

- `npm run start:storybook`
- Verify `Panel` stories http://localhost:9001/?path=/story/layout-panel--inverted-appearance

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
