### PR TITLE
UX-397 Remove spreading of unknown Snackbar props

### DIFF
--- a/packages/matchbox/src/components/Snackbar/Snackbar.js
+++ b/packages/matchbox/src/components/Snackbar/Snackbar.js
@@ -23,7 +23,7 @@ const StyledClose = styled(Box)`
 `;
 
 const Snackbar = React.forwardRef(function Snackbar(props, userRef) {
-  const { children, status, maxWidth, onDismiss, ...rest } = props;
+  const { children, status, maxWidth, onDismiss, 'data-id': dataId, ...rest } = props;
   const systemProps = pick(rest, margin.propNames);
 
   return (
@@ -35,7 +35,7 @@ const Snackbar = React.forwardRef(function Snackbar(props, userRef) {
       ref={userRef}
       tabIndex="-1"
       {...systemProps}
-      data-id={rest['data-id']}
+      data-id={dataId}
     >
       <Box mr="300">
         {status === 'default' && <Info size="20" label="Info" />}

--- a/packages/matchbox/src/components/Snackbar/Snackbar.js
+++ b/packages/matchbox/src/components/Snackbar/Snackbar.js
@@ -5,9 +5,10 @@ import { ScreenReaderOnly } from '../ScreenReaderOnly';
 import PropTypes from 'prop-types';
 import { createPropTypes } from '@styled-system/prop-types';
 import { Close, Info, CheckCircle, Warning, ErrorIcon } from '@sparkpost/matchbox-icons';
-import { margin, maxWidth } from 'styled-system';
+import { margin, maxWidth as maxWidthSystem } from 'styled-system';
 import { base, status, dismiss, dismissStatus } from './styles';
 import { buttonReset } from '../../styles/helpers';
+import { pick } from '../../helpers/props';
 
 const StyledBox = styled(Box)`
   ${base}
@@ -23,6 +24,7 @@ const StyledClose = styled(Box)`
 
 const Snackbar = React.forwardRef(function Snackbar(props, ref) {
   const { children, status, maxWidth, onDismiss, ...rest } = props;
+  const systemProps = pick(rest, margin.propNames);
 
   return (
     <StyledBox
@@ -31,8 +33,8 @@ const Snackbar = React.forwardRef(function Snackbar(props, ref) {
       p="300"
       borderRadius="100"
       ref={ref}
-      {...rest}
       tabIndex="-1"
+      {...systemProps}
     >
       <Box mr="300">
         {status === 'default' && <Info size="20" label="Info" />}
@@ -79,7 +81,7 @@ Snackbar.propTypes = {
    */
   children: PropTypes.node,
   ...createPropTypes(margin.propNames),
-  ...createPropTypes(maxWidth.propNames),
+  ...createPropTypes(maxWidthSystem.propNames),
 };
 
 export default Snackbar;

--- a/packages/matchbox/src/components/Snackbar/Snackbar.js
+++ b/packages/matchbox/src/components/Snackbar/Snackbar.js
@@ -22,7 +22,7 @@ const StyledClose = styled(Box)`
   ${dismissStatus}
 `;
 
-const Snackbar = React.forwardRef(function Snackbar(props, ref) {
+const Snackbar = React.forwardRef(function Snackbar(props, userRef) {
   const { children, status, maxWidth, onDismiss, ...rest } = props;
   const systemProps = pick(rest, margin.propNames);
 
@@ -32,9 +32,10 @@ const Snackbar = React.forwardRef(function Snackbar(props, ref) {
       role="alert"
       p="300"
       borderRadius="100"
-      ref={ref}
+      ref={userRef}
       tabIndex="-1"
       {...systemProps}
+      data-id={rest['data-id']}
     >
       <Box mr="300">
         {status === 'default' && <Info size="20" label="Info" />}
@@ -66,6 +67,7 @@ Snackbar.defaultProps = {
   maxWidth: 380,
 };
 Snackbar.propTypes = {
+  'data-id': PropTypes.string,
   /**
    * The type of snackbar.
    */

--- a/packages/matchbox/src/components/Snackbar/tests/Snackbar.test.js
+++ b/packages/matchbox/src/components/Snackbar/tests/Snackbar.test.js
@@ -4,6 +4,7 @@ import Snackbar from '../Snackbar';
 describe('Snackbar', () => {
   const defaults = {
     onDismiss: jest.fn(),
+    'data-id': 'test-id',
   };
 
   const subject = props =>
@@ -16,6 +17,7 @@ describe('Snackbar', () => {
   it('renders default status and text content correctly', () => {
     const wrapper = subject();
     expect(wrapper.find('[aria-label="Info"]')).toExist();
+    expect(wrapper.find('[data-id="test-id"]')).toExist();
     expect(
       wrapper
         .find('Box')


### PR DESCRIPTION
### What Changed
- Removes spreading of unknown props on Snackbar
- Explicitly picks system props

### How To Test or Verify
- Verify story renders as expected: http://localhost:9001/?path=/story/feedback-snackbar--responsive-system-props
- Verify tests did not break
- Verify 2web2ui does not use any props that are not explicitly defined: https://proply-2web2ui.vercel.app/

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
