### PR TITLE
UX-395 Remove spreading of unknown Banner props

### DIFF
--- a/packages/matchbox/src/components/Banner/Banner.js
+++ b/packages/matchbox/src/components/Banner/Banner.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { deprecate } from '../../helpers/propTypes';
-import { omit } from '../../helpers/props';
+import { pick, omit } from '../../helpers/props';
 import { createPropTypes } from '@styled-system/prop-types';
 import { Close } from '@sparkpost/matchbox-icons';
 import { Box } from '../Box';
@@ -73,6 +73,7 @@ const StyledDismiss = styled(Box)`
 
 const Banner = React.forwardRef(function Banner(props, ref) {
   const { children, title, status, action, actions, onDismiss, size, ...rest } = props;
+  const systemProps = pick(rest, margin.propNames);
 
   const titleMarkup = title ? (
     <Box pt={status !== 'muted' ? ['300', null, '200'] : null} mb="200">
@@ -141,7 +142,7 @@ const Banner = React.forwardRef(function Banner(props, ref) {
       py={size === 'large' ? null : '200'}
       borderRadius="100"
       status={status}
-      {...rest}
+      {...systemProps}
       ref={ref}
       tabIndex="-1"
       overflow="hidden"

--- a/packages/matchbox/src/components/Banner/Banner.js
+++ b/packages/matchbox/src/components/Banner/Banner.js
@@ -71,7 +71,7 @@ const StyledDismiss = styled(Box)`
   ${dismissColor}
 `;
 
-const Banner = React.forwardRef(function Banner(props, ref) {
+const Banner = React.forwardRef(function Banner(props, userRef) {
   const { children, title, status, action, actions, onDismiss, size, ...rest } = props;
   const systemProps = pick(rest, margin.propNames);
 
@@ -143,9 +143,10 @@ const Banner = React.forwardRef(function Banner(props, ref) {
       borderRadius="100"
       status={status}
       {...systemProps}
-      ref={ref}
+      ref={userRef}
       tabIndex="-1"
       overflow="hidden"
+      data-id={rest['data-id']}
     >
       {status !== 'muted' && <IconSection status={status} size={size} />}
       <Box flex="1" order={['1', null, '0']} flexBasis={['100%', null, 'auto']}>
@@ -163,6 +164,7 @@ const Banner = React.forwardRef(function Banner(props, ref) {
 
 Banner.displayName = 'Banner';
 Banner.propTypes = {
+  'data-id': PropTypes.string,
   /**
    * The type of banner. 'default' | 'success' | 'warning' | 'danger' | 'info'
    */

--- a/packages/matchbox/src/components/Banner/Banner.js
+++ b/packages/matchbox/src/components/Banner/Banner.js
@@ -72,7 +72,18 @@ const StyledDismiss = styled(Box)`
 `;
 
 const Banner = React.forwardRef(function Banner(props, userRef) {
-  const { children, title, status, action, actions, onDismiss, size, ...rest } = props;
+  const {
+    children,
+    'data-id': dataId,
+    id,
+    title,
+    status,
+    action,
+    actions,
+    onDismiss,
+    size,
+    ...rest
+  } = props;
   const systemProps = pick(rest, margin.propNames);
 
   const titleMarkup = title ? (
@@ -146,7 +157,8 @@ const Banner = React.forwardRef(function Banner(props, userRef) {
       ref={userRef}
       tabIndex="-1"
       overflow="hidden"
-      data-id={rest['data-id']}
+      data-id={dataId}
+      id={id}
     >
       {status !== 'muted' && <IconSection status={status} size={size} />}
       <Box flex="1" order={['1', null, '0']} flexBasis={['100%', null, 'auto']}>
@@ -165,6 +177,7 @@ const Banner = React.forwardRef(function Banner(props, userRef) {
 Banner.displayName = 'Banner';
 Banner.propTypes = {
   'data-id': PropTypes.string,
+  id: PropTypes.string,
   /**
    * The type of banner. 'default' | 'success' | 'warning' | 'danger' | 'info'
    */

--- a/packages/matchbox/src/components/Banner/tests/Banner.test.js
+++ b/packages/matchbox/src/components/Banner/tests/Banner.test.js
@@ -39,6 +39,12 @@ describe('Banner', () => {
     expect(wrapper).toHaveStyleRule('background', tokens.color_blue_100);
   });
 
+  it('renders correctly with id and data-id props', () => {
+    const wrapper = subject({ 'data-id': 'data-id', id: 'id' });
+    expect(wrapper.find('[data-id="data-id"]')).toExist();
+    expect(wrapper.find('#id')).toExist();
+  });
+
   it('renders status icons and background colors', () => {
     let wrapper = subject({ status: 'success' });
     expect(wrapper.find('[aria-label="Success"]')).toExist();

--- a/packages/matchbox/src/components/Banner/tests/Banner.test.js
+++ b/packages/matchbox/src/components/Banner/tests/Banner.test.js
@@ -137,9 +137,7 @@ describe('Banner', () => {
   });
 
   it('renders Banner.Action', () => {
-    const onClick = jest.fn();
-
-    const wrapper = subject({ onClick });
+    const wrapper = subject();
 
     wrapper
       .find('button')
@@ -151,6 +149,6 @@ describe('Banner', () => {
         .at(0)
         .text(),
     ).toEqual('Banner Action');
-    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(props.onClick).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
### What Changed
- Removes spreading of unknown props on Banner
- Explicitly picks system props

### How To Test or Verify
- Verify story renders as expected: http://localhost:9001/?path=/story/feedback-banner--default-banner
- Verify tests did not break
- Verify 2web2ui does not use any props that are not explicitly defined: https://proply-2web2ui.vercel.app/

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
