### PR TITLE
UX-452 Remove spreading of unknown Tag props

### DIFF
--- a/packages/matchbox/src/components/Tag/Tag.js
+++ b/packages/matchbox/src/components/Tag/Tag.js
@@ -25,7 +25,7 @@ const StyledContent = styled('span')`
 `;
 
 const Tag = React.forwardRef(function Tag(props, userRef) {
-  const { color, children, onRemove, className, ...rest } = props;
+  const { color, children, onRemove, className, 'data-id': dataId, id, ...rest } = props;
   const systemProps = pick(rest, margin.propNames);
 
   const closeMarkup = onRemove ? (
@@ -39,7 +39,8 @@ const Tag = React.forwardRef(function Tag(props, userRef) {
     <StyledTag
       as="span"
       className={className}
-      data-id={rest['data-id']}
+      data-id={dataId}
+      id={id}
       tagColor={color}
       hasRemove={!!onRemove}
       {...systemProps}
@@ -70,6 +71,7 @@ Tag.propTypes = {
     'darkGray',
   ]),
   'data-id': PropTypes.string,
+  id: PropTypes.string,
   /**
    * Close button is hidden unless this is provided
    */

--- a/packages/matchbox/src/components/Tag/Tag.js
+++ b/packages/matchbox/src/components/Tag/Tag.js
@@ -39,6 +39,7 @@ function Tag(props) {
     <StyledTag
       as="span"
       className={className}
+      data-id={rest['data-id']}
       tagColor={color}
       hasRemove={!!onRemove}
       {...systemProps}
@@ -67,6 +68,7 @@ Tag.propTypes = {
     'lightGray',
     'darkGray',
   ]),
+  'data-id': PropTypes.string,
   /**
    * Close button is hidden unless this is provided
    */

--- a/packages/matchbox/src/components/Tag/Tag.js
+++ b/packages/matchbox/src/components/Tag/Tag.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Box } from '../Box';
-import { ScreenReaderOnly } from '../ScreenReaderOnly';
 import styled from 'styled-components';
 import { Close } from '@sparkpost/matchbox-icons';
 import { createPropTypes } from '@styled-system/prop-types';
 import { margin } from 'styled-system';
+import { Box } from '../Box';
+import { ScreenReaderOnly } from '../ScreenReaderOnly';
+import { pick } from '../../helpers/props';
 import { tagBase, tagColor, closeBase, closeColor, content } from './styles';
 
 const StyledTag = styled(Box)`
@@ -25,6 +26,7 @@ const StyledContent = styled('span')`
 
 function Tag(props) {
   const { color, children, onRemove, className, ...rest } = props;
+  const systemProps = pick(rest, margin.propNames);
 
   const closeMarkup = onRemove ? (
     <StyledClose onClick={onRemove} tagColor={color} type="button">
@@ -34,7 +36,13 @@ function Tag(props) {
   ) : null;
 
   return (
-    <StyledTag as="span" className={className} tagColor={color} hasRemove={!!onRemove} {...rest}>
+    <StyledTag
+      as="span"
+      className={className}
+      tagColor={color}
+      hasRemove={!!onRemove}
+      {...systemProps}
+    >
       <StyledContent>{children}</StyledContent>
       {closeMarkup}
     </StyledTag>

--- a/packages/matchbox/src/components/Tag/Tag.js
+++ b/packages/matchbox/src/components/Tag/Tag.js
@@ -24,7 +24,7 @@ const StyledContent = styled('span')`
   ${content}
 `;
 
-function Tag(props) {
+const Tag = React.forwardRef(function Tag(props, userRef) {
   const { color, children, onRemove, className, ...rest } = props;
   const systemProps = pick(rest, margin.propNames);
 
@@ -43,12 +43,13 @@ function Tag(props) {
       tagColor={color}
       hasRemove={!!onRemove}
       {...systemProps}
+      ref={userRef}
     >
       <StyledContent>{children}</StyledContent>
       {closeMarkup}
     </StyledTag>
   );
-}
+});
 
 Tag.displayName = 'Tag';
 Tag.propTypes = {

--- a/packages/matchbox/src/components/Tag/tests/Tag.test.js
+++ b/packages/matchbox/src/components/Tag/tests/Tag.test.js
@@ -11,9 +11,14 @@ describe('Tag', () => {
     expect(wrapper.find('button')).not.toExist();
   });
 
-  it('should render with data-id', () => {
-    const wrapper = global.mountStyled(<Tag data-id="test-id">Hola!</Tag>);
-    expect(wrapper.find('[data-id="test-id"]')).toExist();
+  it('should render with data-id and id', () => {
+    const wrapper = global.mountStyled(
+      <Tag id="id" data-id="data-id">
+        Hola!
+      </Tag>,
+    );
+    expect(wrapper.find('[data-id="data-id"]')).toExist();
+    expect(wrapper.find('#id')).toExist();
   });
 
   it('should render a remove button', () => {

--- a/packages/matchbox/src/components/Tag/tests/Tag.test.js
+++ b/packages/matchbox/src/components/Tag/tests/Tag.test.js
@@ -11,6 +11,11 @@ describe('Tag', () => {
     expect(wrapper.find('button')).not.toExist();
   });
 
+  it('should render with data-id', () => {
+    const wrapper = global.mountStyled(<Tag data-id="test-id">Hola!</Tag>);
+    expect(wrapper.find('[data-id="test-id"]')).toExist();
+  });
+
   it('should render a remove button', () => {
     const wrapper = global.mountStyled(<Tag onRemove={jest.fn()}>Hola!</Tag>);
     expect(wrapper.find('button').text()).toEqual('Remove');


### PR DESCRIPTION
### What Changed
- Removes spreading of unknown props on Tag
- Explicitly picks system props
- Adds data-id and forwardRef

### How To Test or Verify
- Verify story renders as expected: http://localhost:9001/?path=/story/feedback-tag--colors
- Verify tests did not break
- Verify 2web2ui does not use any props that are not explicitly defined: https://proply-2web2ui.vercel.app/

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
