### PR TITLE
UX-450 move error below help text in form components

### DIFF
--- a/packages/matchbox/src/components/Checkbox/Checkbox.js
+++ b/packages/matchbox/src/components/Checkbox/Checkbox.js
@@ -117,12 +117,12 @@ const Checkbox = React.forwardRef(function Checkbox(props, userRef) {
           </Label>
         </Box>
       </StyledLabel>
-      {error && <Error id={errorId} error={error} ml="500" />}
       {helpText && (
         <HelpText id={helpTextId} ml="500" mt="0">
           {helpText}
         </HelpText>
       )}
+      {error && <Error id={errorId} error={error} ml="500" />}
     </Wrapper>
   );
 });

--- a/packages/matchbox/src/components/ComboBox/ComboBoxTextField.js
+++ b/packages/matchbox/src/components/ComboBox/ComboBoxTextField.js
@@ -130,8 +130,8 @@ function ComboBoxTextField(props) {
       </StyledInputWrapper>
       {/* Menu is rendered here so it is positioned correctly before error and helptext */}
       {children}
-      {error && !errorInLabel && <Error id={errorId} error={error} />}
       {helpText && <HelpText id={helpTextId}>{helpText}</HelpText>}
+      {error && !errorInLabel && <Error id={errorId} error={error} />}
     </StyledWrapper>
   );
 }

--- a/packages/matchbox/src/components/ListBox/ListBox.js
+++ b/packages/matchbox/src/components/ListBox/ListBox.js
@@ -228,8 +228,8 @@ const ListBox = React.forwardRef(function ListBox(props, userRef) {
           {optionsMarkup}
         </StyledList>
       </Popover>
-      {error && !errorInLabel && <Error id={errorId} error={error} />}
       {helpMarkup}
+      {error && !errorInLabel && <Error id={errorId} error={error} />}
       <input type="hidden" name={name} value={currentValue} />
     </StyledWrapper>
   );

--- a/packages/matchbox/src/components/Radio/Radio.js
+++ b/packages/matchbox/src/components/Radio/Radio.js
@@ -79,12 +79,12 @@ const Radio = React.forwardRef(function Radio(props, userRef) {
           />
         </Box>
       </StyledLabel>
-      {error && <Error id={errorId} error={error} ml="500" />}
       {helpText && (
         <HelpText id={helpTextId} ml="500" mt="0">
           {helpText}
         </HelpText>
       )}
+      {error && <Error id={errorId} error={error} ml="500" />}
     </Wrapper>
   );
 });

--- a/packages/matchbox/src/components/Select/Select.js
+++ b/packages/matchbox/src/components/Select/Select.js
@@ -162,8 +162,8 @@ const Select = React.forwardRef(function Select(props, userRef) {
         </StyledSelect>
         <StyledChevron size={24} disabled={disabled} />
       </Box>
-      {error && !errorInLabel && <Error id={errorId} error={error} />}
       {helpMarkup}
+      {error && !errorInLabel && <Error id={errorId} error={error} />}
     </StyledWrapper>
   );
 });

--- a/packages/matchbox/src/components/TextField/TextField.js
+++ b/packages/matchbox/src/components/TextField/TextField.js
@@ -189,8 +189,8 @@ const TextField = React.forwardRef(function TextField(props, userRef) {
           />
         </Box>
       </Connect>
-      {error && !errorInLabel && <Error id={errorId} error={error} />}
       {helpText && <HelpText id={helpTextId}>{helpText}</HelpText>}
+      {error && !errorInLabel && <Error id={errorId} error={error} />}
     </StyledWrapper>
   );
 });

--- a/stories/form/Checkbox.stories.js
+++ b/stories/form/Checkbox.stories.js
@@ -32,6 +32,10 @@ export const WithHelpText = withInfo()(() => (
   <Checkbox id="id" label="Check Me" helpText="Check this box" />
 ));
 
+export const WithErrorAndHelpText = withInfo()(() => (
+  <Checkbox id="id" label="Check Me" helpText="Check this box" error="I'm an error" />
+));
+
 export const WithErrorAndRequired = withInfo()(() => (
   <Checkbox id="id" label="Check Me" error="I'm an error" required />
 ));

--- a/stories/form/ComboBox.stories.js
+++ b/stories/form/ComboBox.stories.js
@@ -157,6 +157,21 @@ export const TextFieldWithError = withInfo({
   />
 ));
 
+export const TextFieldWithErrorAndHelpText = withInfo({
+  propTables: [ComboBoxTextField],
+})(() => (
+  <ComboBoxTextField
+    id="story-id"
+    selectedItems={[{ name: 'foo' }, { name: 'bar' }]}
+    itemToString={({ name }) => name}
+    defaultValue="input value"
+    label="Filters"
+    error="Required"
+    helpText="Remember to filter something"
+    required
+  />
+));
+
 export const TextFieldWhileDisabled = withInfo({
   propTables: [ComboBoxTextField],
 })(() => (

--- a/stories/form/Radio.stories.js
+++ b/stories/form/Radio.stories.js
@@ -33,6 +33,10 @@ export const WithHelpText = withInfo()(() => (
 
 export const WithError = withInfo()(() => <Radio id="id" label="Check Me" error="I'm an error" />);
 
+export const WithErrorAndHelpText = withInfo()(() => (
+  <Radio id="id" label="Check Me" helpText="Check this box" error="Required" />
+));
+
 export const GroupWithLabel = withInfo()(() => (
   <Radio.Group label="This is a radio group">
     <Radio id="id" label="Option 1" name="group" />


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed

- Moved `error` below `helpText` in `Select`, `ComboBox`, `ListBox`, `Checkbox`, `Radio`, Select`, and `TextField`
- Updated stories to include examples with help text and an error

### How To Test or Verify

- `npm run start:storybook`
- Verify form stories
  - `Checkbox`: http://localhost:9001/?path=/story/form-checkbox--with-error-and-help-text
  - `ComboBox`: http://localhost:9001/?path=/story/form-combobox--text-field-with-error-and-help-text
  - `ListBox`: http://localhost:9001/?path=/story/form-combobox--text-field-with-error-and-help-text 
  - `Radio`: http://localhost:9001/?path=/story/form-radio--with-error-and-help-text
  - `Select`: http://localhost:9001/?path=/story/form-select--with-help-text-and-error
  - `TextField`: http://localhost:9001/?path=/story/form-textfield--help-text-and-error
 
### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
