### PR TITLE
UX-465 Fix empty Panel.Section rendering

### DIFF
--- a/packages/matchbox/src/components/Panel/Section.js
+++ b/packages/matchbox/src/components/Panel/Section.js
@@ -43,7 +43,7 @@ const Section = React.forwardRef(function Section(props, userRef) {
     >
       <Columns collapseBelow="xs" space="300" alignY="top" align="right">
         <Column>{content}</Column>
-        {actions.length ? (
+        {actions && actions.length ? (
           <Column width="content">
             <Button.Group>{actions}</Button.Group>
           </Column>

--- a/packages/matchbox/src/components/Panel/tests/Panel.test.js
+++ b/packages/matchbox/src/components/Panel/tests/Panel.test.js
@@ -130,6 +130,11 @@ describe('Panel Components', () => {
       expect(wrapper.text()).toEqual('Section Content');
     });
 
+    it('renders with empty children correctly', () => {
+      let wrapper = subject({ children: <Panel.Section data-id="test"></Panel.Section> });
+      expect(wrapper.find('[data-id="test"]')).toExist();
+    });
+
     it('renders with a default padding correctly', () => {
       let wrapper = subject({ children: <Panel.Section>Section Content</Panel.Section> });
       expect(wrapper.find(Panel.Section)).toHaveStyleRule('padding', '1rem');


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed
- Fixes a bug that prevented empty `Panel.Section` from rendering

### How To Test or Verify
- Run storybook and visit a Panel story: http://localhost:9001/?path=/story/layout-panel--with-a-header
- Try rendering an empty panel section with no children
<!--
Describe any steps that may help reviewers verify changes.
Anything beyond basic unit testing, such as assistive tech usage, or special interactions.
-->

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
