### PR TITLE
UX-469 Fix Tabs on Safari

### DIFF
--- a/packages/matchbox/src/components/Tabs/Tab.js
+++ b/packages/matchbox/src/components/Tabs/Tab.js
@@ -16,7 +16,7 @@ const StyledTab = styled(LinkWrapper)`
 `;
 
 const Tab = React.forwardRef(function Tab(props, ref) {
-  const { index, content, selected, fitted, component, Component, tabIndex, ...rest } = props;
+  const { index, content, selected, fitted, component, Component, tabIndex, type, ...rest } = props;
 
   function handleClick(event) {
     const { index, onClick } = props;
@@ -39,7 +39,9 @@ const Tab = React.forwardRef(function Tab(props, ref) {
       onClick={handleClick}
       role="tab"
       tabIndex={tabIndex}
-      type="button"
+      // Safari overwrites the button reset styles
+      // if the element is an 'a' with this attribute
+      type={wrapper === 'button' ? 'button' : type}
     >
       {content}
     </StyledTab>

--- a/packages/matchbox/src/components/Tabs/tests/Tabs.test.js
+++ b/packages/matchbox/src/components/Tabs/tests/Tabs.test.js
@@ -14,6 +14,7 @@ describe('Tabs', () => {
     const wrapper = subject();
     expect(wrapper.find('button').at(0)).toHaveStyleRule('flex', '0');
     expect(wrapper.find('button').at(0)).toHaveStyleRule('margin', '0 1.25rem');
+    expect(wrapper.find('[type="button]')).toExist();
   });
 
   it('renders fitted styles', () => {
@@ -56,6 +57,7 @@ describe('Tabs', () => {
       ],
     });
     expect(wrapper.find('a').text()).toEqual('Tab 4');
+    expect(wrapper.find('[type="button]')).not.toExist();
   });
 
   it('renders with with a ref', () => {

--- a/packages/matchbox/src/components/Tabs/tests/Tabs.test.js
+++ b/packages/matchbox/src/components/Tabs/tests/Tabs.test.js
@@ -10,11 +10,20 @@ describe('Tabs', () => {
   };
   const subject = props => global.mountStyled(<Tabs {...defaultprops} {...props} />);
 
+  it('renders button type correctly', () => {
+    const wrapper = subject();
+    expect(
+      wrapper
+        .find('button')
+        .first()
+        .props().type,
+    ).toEqual('button');
+  });
+
   it('renders non-fitted styles', () => {
     const wrapper = subject();
     expect(wrapper.find('button').at(0)).toHaveStyleRule('flex', '0');
     expect(wrapper.find('button').at(0)).toHaveStyleRule('margin', '0 1.25rem');
-    expect(wrapper.find('[type="button]')).toExist();
   });
 
   it('renders fitted styles', () => {
@@ -57,7 +66,7 @@ describe('Tabs', () => {
       ],
     });
     expect(wrapper.find('a').text()).toEqual('Tab 4');
-    expect(wrapper.find('[type="button]')).not.toExist();
+    expect(wrapper.find('a').props().type).toBeUndefined();
   });
 
   it('renders with with a ref', () => {


### PR DESCRIPTION
This PR isn't pointed to `main` because we want to publish a patch on top of `4.8.1`. The main branch contains changes that would need a minor release.


<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed
- Fixes tab styling on Safari

### How To Test or Verify

- Open Safari and run storybook
- Visit: http://localhost:9001/?path=/story/navigation-tabs--example-tabs
- Verify the first 3 tabs have `type=button`, and the last one does not
- Verify styles are correct

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
