### PR TITLE
UX-470 Fix bug that caused excessive horizontal scroll on Tabs

### DIFF
--- a/packages/matchbox/src/components/Tabs/styles.js
+++ b/packages/matchbox/src/components/Tabs/styles.js
@@ -58,6 +58,7 @@ export const overflowTabs = ({ isOverflowing }) => `
   display: flex;
   visibility: ${isOverflowing ? 'hidden' : 'visible'};
   pointer-events: ${isOverflowing ? 'none' : 'auto'};
+  overflow: ${isOverflowing ? 'hidden' : 'unset'};
 `;
 
 export const containerStyles = () => `

--- a/stories/navigation/Tabs.stories.js
+++ b/stories/navigation/Tabs.stories.js
@@ -47,7 +47,7 @@ export default {
   title: 'Navigation|Tabs',
 };
 
-export const ExampleTabs = withInfo({ source: false, propTables: [Tabs] })(() => {
+export const ExampleTabs = () => {
   const { getTabsProps } = useTabs({ tabs });
   return (
     <>
@@ -55,7 +55,7 @@ export const ExampleTabs = withInfo({ source: false, propTables: [Tabs] })(() =>
       <button>this is only here to test focus order</button>
     </>
   );
-});
+};
 
 export const AutomaticKeyboardActivation = withInfo()(() => {
   const { getTabsProps } = useTabs({ tabs });


### PR DESCRIPTION


### What Changed
- Fixes a bug that caused excessive horizontal scroll on the viewport when tabs are overflowing

### How To Test or Verify
- Run storybook and visit: http://localhost:9001/iframe.html?id=navigation-tabs--example-tabs
- Down size the browser, attempt to scroll horizontally with a trackpad on the window
- Verify the browser does **not** scroll horizontally

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
