### PR TITLE
UX-467 Disabled checkboxes should ignore hover event

### DIFF
--- a/packages/matchbox/src/components/Checkbox/styles.js
+++ b/packages/matchbox/src/components/Checkbox/styles.js
@@ -42,13 +42,6 @@ export const StyledBox = styled(Box)`
 
   ${focusOutline({ modifier: 'input:focus ~ span &' })}
 
-  ${StyledLabel}:hover & {
-    ${props =>
-      !props.disabled && !props.indeterminate && !props.error
-        ? `border: 2px solid ${tokens.color_gray_800};`
-        : ''}
-  }
-
   input:checked ~ span & {
     border: 2px solid ${props => (props.error ? tokens.color_red_700 : tokens.color_blue_700)};
     background: ${props => (props.error ? tokens.color_red_700 : tokens.color_blue_700)};
@@ -62,6 +55,13 @@ export const StyledBox = styled(Box)`
   input:disabled:checked ~ span & {
     background: ${tokens.color_gray_600};
     border: 2px solid ${tokens.color_gray_600};
+  }
+
+  ${StyledLabel}:hover input:not(:disabled) ~ span & {
+    ${props =>
+      !props.disabled && !props.indeterminate && !props.error
+        ? `border: 2px solid ${tokens.color_gray_800};`
+        : ''}
   }
 
   ${StyledLabel}:hover input:checked:not(:disabled) ~ span & {


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed

- bugfix: prevent hover styles from applying to disabled checkboxes

### How To Test or Verify

- `npm run start:libby`
- Verify disabled checkbox story http://localhost:9001/?path=Checkbox__disabled&source=false

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
