### PR TITLE
UX-448 Tabs should support component wrapper via as

### DIFF
--- a/cypress/integration/Tab.spec.js
+++ b/cypress/integration/Tab.spec.js
@@ -22,7 +22,7 @@ describe('The Tabs component', () => {
       // Setting viewport dimensions to avoid side effects
       cy.viewport(1400, 600);
       cy.get('button')
-        .first()
+        .eq(1)
         .click();
     });
 
@@ -34,20 +34,20 @@ describe('The Tabs component', () => {
       cy.get('body').type('{rightArrow}');
       cy.focused().should('have.text', 'Details');
       cy.get('body').type('{leftArrow}');
-      cy.focused().should('have.text', 'Example with a component wrapper');
-      cy.get(`[tabindex="0"]`).should('have.text', 'Example with a component wrapper');
+      cy.focused().should('have.text', 'Example with an `as` wrapper');
+      cy.get(`[tabindex="0"]`).should('have.text', 'Example with an `as` wrapper');
     });
 
     it('should handle home and end keys', () => {
       cy.get('body').type('{end}');
-      cy.focused().should('have.text', 'Example with a component wrapper');
+      cy.focused().should('have.text', 'Example with an `as` wrapper');
       cy.get('body').type('{home}');
       cy.focused().should('have.text', 'Details');
     });
 
     it('should handle page up and page down keys', () => {
       cy.get('body').type('{pageUp}');
-      cy.focused().should('have.text', 'Example with a component wrapper');
+      cy.focused().should('have.text', 'Example with an `as` wrapper');
       cy.get('body').type('{pageDown}');
       cy.focused().should('have.text', 'Details');
     });
@@ -62,7 +62,7 @@ describe('The Tabs component', () => {
       cy.focused().should('have.text', 'More Details');
       cy.tab();
       cy.focused().should('have.text', 'this is only here to test focus order');
-      cy.get(`[tabindex="0"]`).should('have.text', 'Details');
+      cy.get(`[tabindex="0"]`).should('have.text', 'More Details');
     });
   });
 

--- a/libby/navigation/Tabs.lib.js
+++ b/libby/navigation/Tabs.lib.js
@@ -13,8 +13,8 @@ const tabs = [
     content: 'Example with long text',
   },
   {
-    content: 'Example with a component wrapper',
-    Component: React.forwardRef((props, ref) => <a ref={ref} {...props} href="#" />),
+    content: 'Example with an `as` wrapper',
+    as: React.forwardRef((props, ref) => <a ref={ref} {...props} href="#" />),
   },
 ];
 

--- a/packages/matchbox/src/components/Tabs/Tab.js
+++ b/packages/matchbox/src/components/Tabs/Tab.js
@@ -1,7 +1,9 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { UnstyledLink } from '../UnstyledLink';
 import { tabStyles } from './styles';
+import { deprecate } from '../../helpers/propTypes';
 
 // TODO Replace this when styled-components supports shouldForwardProps
 // See: https://github.com/styled-components/styled-components/commit/e02109e626ed117b76f220d0b9b926129655262d
@@ -16,7 +18,18 @@ const StyledTab = styled(LinkWrapper)`
 `;
 
 const Tab = React.forwardRef(function Tab(props, ref) {
-  const { index, content, selected, fitted, component, Component, tabIndex, type, ...rest } = props;
+  const {
+    as,
+    index,
+    content,
+    selected,
+    fitted,
+    component,
+    Component,
+    tabIndex,
+    type,
+    ...rest
+  } = props;
 
   function handleClick(event) {
     const { index, onClick } = props;
@@ -25,8 +38,7 @@ const Tab = React.forwardRef(function Tab(props, ref) {
 
   // Buttons ensure focusability
   // Links will be focusable with an href
-  // TODO deprecate `Component`
-  const wrapper = component || Component || 'button';
+  const wrapper = as || component || Component || 'button';
 
   return (
     <StyledTab
@@ -49,5 +61,17 @@ const Tab = React.forwardRef(function Tab(props, ref) {
 });
 
 Tab.displayName = 'Tab';
+Tab.propTypes = {
+  index: PropTypes.number,
+  selected: PropTypes.number,
+  fitted: PropTypes.bool,
+  type: PropTypes.string,
+  onClick: PropTypes.func,
+  tabIndex: PropTypes.string,
+  children: PropTypes.node,
+  as: PropTypes.elementType,
+  component: deprecate(PropTypes.elementType, 'Use `as` instead'),
+  Component: deprecate(PropTypes.elementType, 'Use `as` instead'),
+};
 
 export default Tab;


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed

- Adds new `as` prop to `Tab` component
- Deprecate `component` and `Component` props on `Tab` component

### How To Test or Verify

- `npm run start:libby`
- Verify tabs stories http://localhost:9001/?path=Tabs__automatic-keyboard-activation&source=false

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
