### PR TITLE
UX-457 Remove spreading of unknown Pager props

### DIFF
--- a/packages/matchbox/src/components/Pager/Pager.js
+++ b/packages/matchbox/src/components/Pager/Pager.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { margin } from 'styled-system';
 import { createPropTypes } from '@styled-system/prop-types';
+import { pick } from '../../helpers/props';
 import styled from 'styled-components';
 
 import Next from './Next';
@@ -13,9 +14,14 @@ const StyledPager = styled('div')`
 `;
 
 function Pager(props) {
-  const { children, ...rest } = props;
+  const { children, id, 'data-id': dataId, ...rest } = props;
+  const systemProps = pick(rest, margin.propNames);
 
-  return <StyledPager {...rest}>{children}</StyledPager>;
+  return (
+    <StyledPager id={id} data-id={dataId} {...systemProps}>
+      {children}
+    </StyledPager>
+  );
 }
 
 Pager.propTypes = {

--- a/packages/matchbox/src/components/Pager/tests/Pager.test.js
+++ b/packages/matchbox/src/components/Pager/tests/Pager.test.js
@@ -5,7 +5,7 @@ import Pager from '../Pager';
 describe('Pager', () => {
   const subject = () =>
     global.mountStyled(
-      <Pager mb="400">
+      <Pager mb="400" id="test-id" data-id="data-test-id">
         <Pager.Previous />
         <Pager.Next />
       </Pager>,
@@ -14,6 +14,8 @@ describe('Pager', () => {
   it('renders pager with buttons', () => {
     expect(subject().find(Pager.Previous)).toExist();
     expect(subject().find(Pager.Next)).toExist();
+    expect(subject().find('#test-id')).toExist();
+    expect(subject().find('[data-id="data-test-id"]')).toExist();
   });
 
   it('renders pager styles', () => {


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed
- Removes spreading of unknown Pager props
- Pager.Next and Pager.Previous are wrappers around Button, so no need to touch those
- Passes through id and data-id
<!--
What changes does this PR propose?
Provide screenshots or [screen recordings](https://getkap.co/) for any visual changes.
-->

### How To Test or Verify
- Verify no additional props are used in app: https://proply-2web2ui.vercel.app/
- Verify margin props, id, data-id are passed through correctly
- 
### PR Checklist

- [x] Add the correct `type` label
- [x] Pull request approval from #uxfe or #design-guild
