### PR TITLE
UX-461 Remove spreading of unknown ActionList props

### DIFF
--- a/cypress/integration/ActionList.spec.js
+++ b/cypress/integration/ActionList.spec.js
@@ -1,0 +1,37 @@
+describe('ActionList component', () => {
+  beforeEach(() => {
+    cy.visit('/iframe.html?path=ActionList__Actions-as-links-buttons-or-checkboxes&source=false');
+  });
+
+  it('should render correctly with data-id and class name', () => {
+    cy.get('.test-class').should('exist');
+    cy.get('[data-id="test-data-id"]').should('exist');
+  });
+
+  it('should render Actions correctly as buttons and links', () => {
+    cy.get('button').should('have.length', 2);
+    cy.get('a').should('have.length', 2);
+  });
+
+  it('should handle keyboard navigation correctly', () => {
+    cy.get('button')
+      .eq(0)
+      .click();
+    cy.focused().should('have.text', 'Button');
+    cy.tab();
+    cy.focused().should('have.text', 'External Link');
+  });
+
+  it('should handle disabled Actions correctly', () => {
+    cy.get('button')
+      .eq(1)
+      .should('be.disabled');
+
+    cy.get('a')
+      .eq(1)
+      .should('have.attr', 'tabindex', '-1');
+    cy.get('a')
+      .eq(1)
+      .should('have.css', 'pointer-events', 'none');
+  });
+});

--- a/libby/action/ActionList.lib.js
+++ b/libby/action/ActionList.lib.js
@@ -89,7 +89,7 @@ describe('ActionList', () => {
   add('Actions as links, buttons, or checkboxes', () => (
     <Box maxWidth="20rem">
       <Panel>
-        <ActionList>
+        <ActionList data-id="test-data-id" className="test-class">
           <ActionList.Action to="#" is="button">
             Button
           </ActionList.Action>

--- a/packages/matchbox/src/components/ActionList/ActionList.js
+++ b/packages/matchbox/src/components/ActionList/ActionList.js
@@ -5,6 +5,7 @@ import { createPropTypes } from '@styled-system/prop-types';
 import { margin, layout, compose } from 'styled-system';
 import { groupByValues } from '../../helpers/array';
 import { deprecate } from '../../helpers/propTypes';
+import { pick } from '../../helpers/props';
 import Section from './Section';
 import Action from './Action';
 
@@ -17,12 +18,16 @@ const Wrapper = styled('div')`
 const ActionList = React.forwardRef(function ActionList(props, userRef) {
   const {
     actions = [],
+    className,
+    children,
+    'data-id': dataId,
     sections = [],
     maxHeight = 'none',
+    onClick,
     groupByKey = 'section',
-    children,
     ...rest
   } = props;
+  const systemProps = pick(rest, system.propNames);
 
   let list = actions && actions.length ? groupByValues(actions, groupByKey) : [];
   if (sections && sections.length) {
@@ -33,10 +38,13 @@ const ActionList = React.forwardRef(function ActionList(props, userRef) {
 
   return (
     <Wrapper
+      className={className}
+      data-id={dataId}
       maxHeight={typeof maxHeight === 'number' ? `${maxHeight}px` : maxHeight}
+      onClick={onClick}
       ref={userRef}
       tabIndex="-1"
-      {...rest}
+      {...systemProps}
     >
       {listMarkup}
       {children}
@@ -56,6 +64,8 @@ ActionList.propTypes = {
     PropTypes.arrayOf(PropTypes.shape({ content: PropTypes.node.isRequired })),
     'Use the ActionList.Action component instead',
   ),
+  className: PropTypes.string,
+  'data-id': PropTypes.string,
   /**
    * Creates sections
    * e.g. [[{ content: 'action label', onClick: callback() }]]
@@ -69,6 +79,7 @@ ActionList.propTypes = {
    * Max height of list
    */
   maxHeight: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  onClick: PropTypes.func,
 
   /**
    * Group by key used to auto group actions into sections, defaults to "section"


### PR DESCRIPTION
### What Changed
- Removes spreading of unknown ActionList props

### How To Test or Verify
- Verify no additional props are used in app: https://proply-2web2ui.vercel.app/

### PR Checklist

- [x] Add the correct `type` label
- [x] Pull request approval from #uxfe or #design-guild
