### PR TITLE
UX-474 Allow any Modal children

### DIFF
--- a/libby/overlays/Modal.lib.js
+++ b/libby/overlays/Modal.lib.js
@@ -97,13 +97,15 @@ describe('Modal', () => {
         </Button>
 
         <Modal {...modal.getModalProps()}>
-          <Modal.Header showCloseButton>Modal Title</Modal.Header>
-          <Modal.Content>Modal Content</Modal.Content>
-          <Modal.Footer>
-            <Button>Primary Button</Button>
-            <Button>Secondary Button</Button>
-            <Button>Tertiary Button</Button>
-          </Modal.Footer>
+          <div id="this-is-here-to-test-composition">
+            <Modal.Header showCloseButton>Modal Title</Modal.Header>
+            <Modal.Content>Modal Content</Modal.Content>
+            <Modal.Footer>
+              <Button>Primary Button</Button>
+              <Button>Secondary Button</Button>
+              <Button>Tertiary Button</Button>
+            </Modal.Footer>
+          </div>
         </Modal>
       </>
     );

--- a/packages/matchbox/src/components/Modal/Content.js
+++ b/packages/matchbox/src/components/Modal/Content.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { padding } from 'styled-system';
 import { createPropTypes } from '@styled-system/prop-types';
 import { pick } from '../../helpers/props';
-
 import { Box } from '../Box';
 
 const Content = React.forwardRef(function Content(props, ref) {

--- a/packages/matchbox/src/components/Modal/Header.js
+++ b/packages/matchbox/src/components/Modal/Header.js
@@ -7,13 +7,16 @@ import { ScreenReaderOnly } from '../ScreenReaderOnly';
 import { Box } from '../Box';
 import { Text } from '../Text';
 import { Button } from '../Button';
+import { ModalContext } from './context';
 
 const StyledButton = styled(Button)`
   color: ${tokens.color_gray_700};
 `;
 
 const Header = React.forwardRef(function Header(props, ref) {
-  const { children, onClose, showCloseButton } = props;
+  const { children, showCloseButton } = props;
+  const { onClose } = React.useContext(ModalContext);
+
   return (
     <Box data-id="modal-header" bg="white" pl="500" pr="500" pt="500" ref={ref}>
       <Box display="flex" alignItems="center">

--- a/packages/matchbox/src/components/Modal/Modal.js
+++ b/packages/matchbox/src/components/Modal/Modal.js
@@ -12,8 +12,8 @@ import { Portal } from '../Portal';
 import { useWindowEvent } from '../../hooks';
 import { onKey } from '../../helpers/keyEvents';
 import { secondsToMS } from '../../helpers/string';
-import { getChild } from '../../helpers/children';
 import { isInIframe } from '../../helpers/window';
+import { ModalContext } from './context';
 import { base, focusLock, wrapper, content, contentAnimation } from './styles';
 
 import Header from './Header';
@@ -135,9 +135,9 @@ const Modal = React.forwardRef(function Modal(props, userRef) {
                             tabIndex="-1"
                             data-id="modal-content-panel"
                           >
-                            {getChild('Modal.Header', children, { onClose })}
-                            {getChild('Modal.Content', children, { open })}
-                            {getChild('Modal.Footer', children)}
+                            <ModalContext.Provider value={{ onClose, open }}>
+                              {children}
+                            </ModalContext.Provider>
                           </Box>
                         </StyledContent>
                       </div>

--- a/packages/matchbox/src/components/Modal/context.js
+++ b/packages/matchbox/src/components/Modal/context.js
@@ -1,0 +1,6 @@
+import React from 'react';
+
+/**
+ * Context is created here to pass modal onClose and open state to composed Modal components
+ */
+export const ModalContext = React.createContext({});


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed
- Replaces the unnecessary `getChild` or cloning with React context to allow for more flexible component composition

### How To Test or Verify
- Visit http://localhost:9001/?path=Modal__toggle-example&source=false
- Verify clicking on the close button in the header works

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
