### PR TITLE
UX-479 Remove spreading of unknown Table component props, Forwards refs to all Table components

### DIFF
--- a/cypress/integration/Table.spec.js
+++ b/cypress/integration/Table.spec.js
@@ -28,6 +28,6 @@ describe('The Table component', () => {
   it('should set column width correctly', () => {
     cy.get('th')
       .eq(0)
-      .should('have.css', 'width', '20%');
+      .should('have.attr', 'width', '20%');
   });
 });

--- a/cypress/integration/Table.spec.js
+++ b/cypress/integration/Table.spec.js
@@ -1,0 +1,27 @@
+describe('The Table component', () => {
+  beforeEach(() => {
+    cy.visit('/iframe.html?path=Table__system-props&source=false');
+  });
+
+  it('should handle padding overrides correctly', () => {
+    cy.get('th').should('have.css', 'padding', '20px');
+    cy.get('td')
+      .eq(0)
+      .should('have.css', 'padding', '32px');
+    cy.get('td')
+      .eq(1)
+      .should('have.css', 'padding', '16px 20px');
+    cy.get('td')
+      .eq(2)
+      .should('have.css', 'padding', '8px');
+    cy.get('td')
+      .eq(3)
+      .should('have.css', 'padding', '16px 20px');
+  });
+
+  it('should pass colspan correctly', () => {
+    cy.get('td')
+      .eq(1)
+      .should('have.attr', 'colspan', '2');
+  });
+});

--- a/cypress/integration/Table.spec.js
+++ b/cypress/integration/Table.spec.js
@@ -24,4 +24,10 @@ describe('The Table component', () => {
       .eq(1)
       .should('have.attr', 'colspan', '2');
   });
+
+  it('should set column width correctly', () => {
+    cy.get('th')
+      .eq(0)
+      .should('have.css', 'width', '20%');
+  });
 });

--- a/libby/layout/Table.lib.js
+++ b/libby/layout/Table.lib.js
@@ -24,7 +24,7 @@ describe('Table', () => {
       <Table title="My Table">
         <thead>
           <Table.Row header>
-            <Table.HeaderCell width="20%">Heading 1</Table.HeaderCell>
+            <Table.HeaderCell>Heading 1</Table.HeaderCell>
             <Table.HeaderCell>Heading 2</Table.HeaderCell>
             <Table.HeaderCell>Heading 3</Table.HeaderCell>
           </Table.Row>
@@ -84,7 +84,7 @@ describe('Table', () => {
       <Table>
         <thead>
           <Table.Row header>
-            <Table.HeaderCell>Padding 300</Table.HeaderCell>
+            <Table.HeaderCell width="20%">Padding 300</Table.HeaderCell>
             <Table.HeaderCell>Padding 300</Table.HeaderCell>
             <Table.HeaderCell>Padding 300</Table.HeaderCell>
           </Table.Row>

--- a/libby/layout/Table.lib.js
+++ b/libby/layout/Table.lib.js
@@ -24,7 +24,7 @@ describe('Table', () => {
       <Table title="My Table">
         <thead>
           <Table.Row header>
-            <Table.HeaderCell>Heading 1</Table.HeaderCell>
+            <Table.HeaderCell width="20%">Heading 1</Table.HeaderCell>
             <Table.HeaderCell>Heading 2</Table.HeaderCell>
             <Table.HeaderCell>Heading 3</Table.HeaderCell>
           </Table.Row>

--- a/libby/layout/Table.lib.js
+++ b/libby/layout/Table.lib.js
@@ -97,8 +97,7 @@ describe('Table', () => {
         <tbody>
           <Table.Row>
             <Table.Cell p="600">Padding 600</Table.Cell>
-            <Table.Cell>Padding 800</Table.Cell>
-            <Table.Cell>Padding 800</Table.Cell>
+            <Table.Cell colSpan="2">Padding 800 colspan 2</Table.Cell>
           </Table.Row>
           <Table.Row>
             <Table.Cell p="200">Padding 200</Table.Cell>

--- a/libby/layout/Table.lib.js
+++ b/libby/layout/Table.lib.js
@@ -13,9 +13,14 @@ const PopoverNode = () => (
 );
 const data = [
   ['Foo', 'Bar', 'Baz', 'Foo'],
-  [<Node />, <Node />, <NodeLong />, <Node />],
+  [<Node key="1" />, <Node key="2" />, <NodeLong key="3" />, <Node key="4" />],
   [1, 2, 3, 4],
-  [<PopoverNode />, <PopoverNode />, <PopoverNode />, <PopoverNode />],
+  [
+    <PopoverNode key="1" />,
+    <PopoverNode key="2" />,
+    <PopoverNode key="3" />,
+    <PopoverNode key="4" />,
+  ],
 ];
 
 describe('Table', () => {
@@ -90,15 +95,15 @@ describe('Table', () => {
           </Table.Row>
         </thead>
         <tbody>
-          <Table.Row p="800">
-            <Table.Cell p="800">Padding 800</Table.Cell>
+          <Table.Row>
+            <Table.Cell p="600">Padding 600</Table.Cell>
             <Table.Cell>Padding 800</Table.Cell>
             <Table.Cell>Padding 800</Table.Cell>
           </Table.Row>
           <Table.Row>
-            <Table.Cell p="400">Padding 400</Table.Cell>
-            <Table.Cell>Padding 400</Table.Cell>
-            <Table.Cell>Padding 400</Table.Cell>
+            <Table.Cell p="200">Padding 200</Table.Cell>
+            <Table.Cell>Default Padding</Table.Cell>
+            <Table.Cell>Default Padding</Table.Cell>
           </Table.Row>
           <Table.Row>
             <Table.Cell>Default Padding</Table.Cell>

--- a/libby/layout/Table.lib.js
+++ b/libby/layout/Table.lib.js
@@ -13,14 +13,9 @@ const PopoverNode = () => (
 );
 const data = [
   ['Foo', 'Bar', 'Baz', 'Foo'],
-  [<Node key="1" />, <Node key="2" />, <NodeLong key="3" />, <Node key="4" />],
+  [<Node />, <Node />, <NodeLong />, <Node />], // eslint-disable-line
   [1, 2, 3, 4],
-  [
-    <PopoverNode key="1" />,
-    <PopoverNode key="2" />,
-    <PopoverNode key="3" />,
-    <PopoverNode key="4" />,
-  ],
+  [<PopoverNode />, <PopoverNode />, <PopoverNode />, <PopoverNode />], // eslint-disable-line
 ];
 
 describe('Table', () => {

--- a/packages/matchbox/src/components/Table/Table.js
+++ b/packages/matchbox/src/components/Table/Table.js
@@ -22,7 +22,17 @@ const Wrapper = styled(Box)`
 `;
 
 function Table(props) {
-  const { children, data, 'data-id': dataId, freezeFirstColumn, id, title, ...rest } = props;
+  const {
+    'aria-readonly': readOnly,
+    children,
+    data,
+    'data-id': dataId,
+    freezeFirstColumn,
+    id,
+    role,
+    title,
+    ...rest
+  } = props;
   const [isScrolled, setIsScrolled] = React.useState(false);
 
   const handleScroll = React.useCallback(
@@ -52,10 +62,12 @@ function Table(props) {
       {...marginProps}
     >
       <StyledTable
+        aria-readonly={readOnly}
         data-id={dataId}
         freezeFirstColumn={freezeFirstColumn}
         id={id}
         isScrolled={isScrolled}
+        role={role}
       >
         <TablePaddingContext.Provider value={{ px, py, ...paddingProps }}>
           {title && (
@@ -77,11 +89,13 @@ Table.TotalsRow = TotalsRow;
 
 Table.displayName = 'Table';
 Table.propTypes = {
+  'aria-readonly': PropTypes.string,
   children: PropTypes.node,
   data: PropTypes.array,
   'data-id': PropTypes.string,
   freezeFirstColumn: PropTypes.bool,
   id: PropTypes.string,
+  role: PropTypes.string,
   title: PropTypes.string,
   ...createPropTypes(margin.propNames),
   ...createPropTypes(padding.propNames),

--- a/packages/matchbox/src/components/Table/Table.js
+++ b/packages/matchbox/src/components/Table/Table.js
@@ -22,7 +22,7 @@ const Wrapper = styled(Box)`
 `;
 
 function Table(props) {
-  const { children, data, freezeFirstColumn, title, ...rest } = props;
+  const { children, data, 'data-id': dataId, freezeFirstColumn, id, title, ...rest } = props;
   const [isScrolled, setIsScrolled] = React.useState(false);
 
   const handleScroll = React.useCallback(
@@ -51,7 +51,12 @@ function Table(props) {
       onScroll={freezeFirstColumn ? handleScroll : null}
       {...marginProps}
     >
-      <StyledTable freezeFirstColumn={freezeFirstColumn} isScrolled={isScrolled} {...rest}>
+      <StyledTable
+        data-id={dataId}
+        freezeFirstColumn={freezeFirstColumn}
+        id={id}
+        isScrolled={isScrolled}
+      >
         <TablePaddingContext.Provider value={{ px, py, ...paddingProps }}>
           {title && (
             <caption>
@@ -72,12 +77,11 @@ Table.TotalsRow = TotalsRow;
 
 Table.displayName = 'Table';
 Table.propTypes = {
-  freezeFirstColumn: PropTypes.bool,
-  data: PropTypes.array,
-  /**
-   * React node(s)
-   */
   children: PropTypes.node,
+  data: PropTypes.array,
+  'data-id': PropTypes.string,
+  freezeFirstColumn: PropTypes.bool,
+  id: PropTypes.string,
   title: PropTypes.string,
   ...createPropTypes(margin.propNames),
   ...createPropTypes(padding.propNames),

--- a/packages/matchbox/src/components/Table/TableElements.js
+++ b/packages/matchbox/src/components/Table/TableElements.js
@@ -5,6 +5,7 @@ import { cell, row, headerCell, totalsRow, verticalAlignment } from './styles';
 import { TablePaddingContext } from './context';
 import { padding, fontSize, compose } from 'styled-system';
 import { createPropTypes } from '@styled-system/prop-types';
+import { pick } from '../../helpers/props';
 
 const paddingAndFontSize = compose(padding, fontSize);
 const StyledCell = styled('td')`
@@ -29,14 +30,15 @@ const StyledTotalsRow = styled('tr')`
 `;
 
 const Cell = React.forwardRef(function Cell(
-  { value, children, className, colSpan, style, width },
+  { value, children, className, colSpan, style, width, ...rest },
   userRef,
 ) {
   const paddingContext = React.useContext(TablePaddingContext);
-
+  const paddingProps = pick(rest, padding.propNames);
   return (
     <StyledCell
       {...paddingContext}
+      {...paddingProps}
       className={className}
       fontSize={['200', null, '300']}
       colSpan={colSpan}

--- a/packages/matchbox/src/components/Table/TableElements.js
+++ b/packages/matchbox/src/components/Table/TableElements.js
@@ -5,7 +5,6 @@ import { cell, row, headerCell, totalsRow, verticalAlignment } from './styles';
 import { TablePaddingContext } from './context';
 import { padding, fontSize, compose } from 'styled-system';
 import { createPropTypes } from '@styled-system/prop-types';
-import { pick } from '../../helpers/props';
 
 const paddingAndFontSize = compose(padding, fontSize);
 const StyledCell = styled('td')`
@@ -20,7 +19,6 @@ const StyledHeaderCell = styled('th')`
 
 const StyledRow = styled('tr')`
   ${row}
-  ${padding}
   td, th {
     ${verticalAlignment}
   }
@@ -28,39 +26,65 @@ const StyledRow = styled('tr')`
 
 const StyledTotalsRow = styled('tr')`
   ${totalsRow}
-  ${padding}
 `;
 
-const Cell = ({ value, children, className, ...rest }) => {
+const Cell = React.forwardRef(function Cell(
+  { value, children, className, colSpan, style, width },
+  userRef,
+) {
   const paddingContext = React.useContext(TablePaddingContext);
 
   return (
-    <StyledCell {...paddingContext} className={className} fontSize={['200', null, '300']} {...rest}>
+    <StyledCell
+      {...paddingContext}
+      className={className}
+      fontSize={['200', null, '300']}
+      colSpan={colSpan}
+      ref={userRef}
+      style={style}
+      width={width}
+    >
       {value || children}
     </StyledCell>
   );
-};
+});
 
 Cell.propTypes = {
   value: PropTypes.node,
   className: PropTypes.string,
   children: PropTypes.node,
+  colSpan: PropTypes.string,
+  style: PropTypes.object,
+  width: PropTypes.string,
   ...createPropTypes(padding.propNames),
 };
 Cell.displayName = 'Table.Cell';
 
-const HeaderCell = ({ value, children, className, ...rest }) => {
+const HeaderCell = React.forwardRef(function HeaderCell(
+  { value, children, className, colSpan, style, width },
+  userRef,
+) {
   return (
-    <StyledHeaderCell p="450" className={className} {...rest}>
+    <StyledHeaderCell
+      p="450"
+      className={className}
+      colSpan={colSpan}
+      ref={userRef}
+      style={style}
+      width={width}
+    >
       {value || children}
     </StyledHeaderCell>
   );
-};
+});
 
 HeaderCell.propTypes = {
   value: PropTypes.node,
   className: PropTypes.string,
   children: PropTypes.node,
+  colSpan: PropTypes.string,
+  style: PropTypes.object,
+  width: PropTypes.string,
 };
 HeaderCell.displayName = 'Table.HeaderCell';
 
@@ -91,15 +115,8 @@ const TotalsRow = React.forwardRef(function TotalsRow(
   { rowData, children, className, onClick },
   userRef,
 ) {
-  const paddingProps = pick(rest, padding.propNames);
   return (
-    <StyledTotalsRow
-      className={className}
-      {...paddingProps}
-      ref={userRef}
-      tabIndex="-1"
-      onClick={onClick}
-    >
+    <StyledTotalsRow className={className} ref={userRef} tabIndex="-1" onClick={onClick}>
       {rowData ? rowData.map((value, i) => <Cell value={value} key={`Cell-${i}`} />) : children}
     </StyledTotalsRow>
   );

--- a/packages/matchbox/src/components/Table/TableElements.js
+++ b/packages/matchbox/src/components/Table/TableElements.js
@@ -3,19 +3,20 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { cell, row, headerCell, totalsRow, verticalAlignment } from './styles';
 import { TablePaddingContext } from './context';
-import { padding, fontSize, compose } from 'styled-system';
+import { padding, fontSize, width, compose } from 'styled-system';
 import { createPropTypes } from '@styled-system/prop-types';
 import { pick } from '../../helpers/props';
 
-const paddingAndFontSize = compose(padding, fontSize);
+const cellSystem = compose(padding, fontSize, width);
 const StyledCell = styled('td')`
   ${cell}
-  ${paddingAndFontSize}
+  ${cellSystem}
 `;
 
+const headerSystem = compose(padding, width);
 const StyledHeaderCell = styled('th')`
   ${headerCell}
-  ${padding}
+  ${headerSystem}
 `;
 
 const StyledRow = styled('tr')`
@@ -61,8 +62,8 @@ Cell.propTypes = {
   role: PropTypes.string,
   rowSpan: PropTypes.string,
   style: PropTypes.object,
-  width: PropTypes.string,
   ...createPropTypes(padding.propNames),
+  ...createPropTypes(width.propNames),
 };
 Cell.displayName = 'Table.Cell';
 
@@ -109,7 +110,7 @@ HeaderCell.propTypes = {
   rowSpan: PropTypes.string,
   scope: PropTypes.string,
   style: PropTypes.object,
-  width: PropTypes.string,
+  ...createPropTypes(width.propNames),
 };
 HeaderCell.displayName = 'Table.HeaderCell';
 

--- a/packages/matchbox/src/components/Table/TableElements.js
+++ b/packages/matchbox/src/components/Table/TableElements.js
@@ -64,19 +64,23 @@ HeaderCell.propTypes = {
 };
 HeaderCell.displayName = 'Table.HeaderCell';
 
-const Row = ({ alignY, rowData, children, className, ...rest }) => {
+const Row = React.forwardRef(function Row(
+  { alignY, rowData, children, className, onClick },
+  userRef,
+) {
   return (
-    <StyledRow alignY={alignY} className={className} {...rest}>
+    <StyledRow alignY={alignY} className={className} onClick={onClick} ref={userRef}>
       {rowData ? rowData.map((value, i) => <Cell value={value} key={`Cell-${i}`} />) : children}
     </StyledRow>
   );
-};
+});
 
 Row.propTypes = {
   alignY: PropTypes.oneOf(['top', 'bottom', 'center']),
   rowData: PropTypes.array,
   className: PropTypes.string,
   children: PropTypes.node,
+  onClick: PropTypes.func,
 };
 Row.defaultProps = {
   alignY: 'center',
@@ -84,12 +88,18 @@ Row.defaultProps = {
 Row.displayName = 'Table.Row';
 
 const TotalsRow = React.forwardRef(function TotalsRow(
-  { rowData, children, className, ...rest },
-  ref,
+  { rowData, children, className, onClick },
+  userRef,
 ) {
   const paddingProps = pick(rest, padding.propNames);
   return (
-    <StyledTotalsRow className={className} {...paddingProps} ref={ref} tabIndex="-1">
+    <StyledTotalsRow
+      className={className}
+      {...paddingProps}
+      ref={userRef}
+      tabIndex="-1"
+      onClick={onClick}
+    >
       {rowData ? rowData.map((value, i) => <Cell value={value} key={`Cell-${i}`} />) : children}
     </StyledTotalsRow>
   );
@@ -99,6 +109,7 @@ TotalsRow.propTypes = {
   rowData: PropTypes.array,
   className: PropTypes.string,
   children: PropTypes.node,
+  onClick: PropTypes.func,
 };
 TotalsRow.displayName = 'Table.TotalsRow';
 

--- a/packages/matchbox/src/components/Table/TableElements.js
+++ b/packages/matchbox/src/components/Table/TableElements.js
@@ -30,7 +30,7 @@ const StyledTotalsRow = styled('tr')`
 `;
 
 const Cell = React.forwardRef(function Cell(
-  { value, children, className, colSpan, style, width, ...rest },
+  { value, children, className, colSpan, role, rowSpan, style, width, ...rest },
   userRef,
 ) {
   const paddingContext = React.useContext(TablePaddingContext);
@@ -43,6 +43,8 @@ const Cell = React.forwardRef(function Cell(
       fontSize={['200', null, '300']}
       colSpan={colSpan}
       ref={userRef}
+      role={role}
+      rowSpan={rowSpan}
       style={style}
       width={width}
     >
@@ -56,6 +58,8 @@ Cell.propTypes = {
   className: PropTypes.string,
   children: PropTypes.node,
   colSpan: PropTypes.string,
+  role: PropTypes.string,
+  rowSpan: PropTypes.string,
   style: PropTypes.object,
   width: PropTypes.string,
   ...createPropTypes(padding.propNames),
@@ -63,15 +67,30 @@ Cell.propTypes = {
 Cell.displayName = 'Table.Cell';
 
 const HeaderCell = React.forwardRef(function HeaderCell(
-  { value, children, className, colSpan, style, width },
+  {
+    'aria-sort': ariaSort,
+    value,
+    children,
+    className,
+    colSpan,
+    role,
+    rowSpan,
+    scope,
+    style,
+    width,
+  },
   userRef,
 ) {
   return (
     <StyledHeaderCell
       p="450"
+      aria-sort={ariaSort}
       className={className}
       colSpan={colSpan}
       ref={userRef}
+      role={role}
+      rowSpan={rowSpan}
+      scope={scope}
       style={style}
       width={width}
     >
@@ -81,10 +100,14 @@ const HeaderCell = React.forwardRef(function HeaderCell(
 });
 
 HeaderCell.propTypes = {
+  'aria-sort': PropTypes.string,
   value: PropTypes.node,
   className: PropTypes.string,
   children: PropTypes.node,
   colSpan: PropTypes.string,
+  role: PropTypes.string,
+  rowSpan: PropTypes.string,
+  scope: PropTypes.string,
   style: PropTypes.object,
   width: PropTypes.string,
 };

--- a/packages/matchbox/src/components/Table/tests/Table.test.js
+++ b/packages/matchbox/src/components/Table/tests/Table.test.js
@@ -108,7 +108,6 @@ describe('Table', () => {
     expect(wrapper).toHaveStyleRule('margin', '100');
     expect(wrapper).not.toHaveStyleRule('padding', '100');
     expect(wrapper.find('table')).not.toHaveStyleRule('margin', '100');
-    expect(wrapper.find('table')).toHaveStyleRule('padding', '100');
   });
 
   describe('Cell', () => {
@@ -145,7 +144,7 @@ describe('Table', () => {
       wrapper = global.mountStyled(
         <Table>
           <tbody>
-            <Table.Row rowData={[1, '2', <span>3</span>]} className="test" />
+            <Table.Row rowData={[1, '2', <span key="test">3</span>]} className="test" />
           </tbody>
         </Table>,
       );
@@ -183,7 +182,7 @@ describe('Table', () => {
       wrapper = global.mountStyled(
         <Table>
           <tbody>
-            <Table.TotalsRow rowData={[1, '2', <span>3</span>]} className="test" />
+            <Table.TotalsRow rowData={[1, '2', <span key="test">3</span>]} className="test" />
           </tbody>
         </Table>,
       );


### PR DESCRIPTION
### What Changed
- Removes spreading of unknown Table component props
- Supports new HTML attributes for accessibility

### How To Test or Verify
- Run libby, verify the table works as expected http://localhost:9001/?path=Table__all-table-components&source=false
- Verify 2web2ui does not use any attributes that aren't defined 


### PR Checklist

- [x] Add the correct `type` label
- [x] Pull request approval from #uxfe or #design-guild
