### PR TITLE
UX-482 Remove is="checkbox" option from ActionList.Action

### DIFF
--- a/libby/action/ActionList.lib.js
+++ b/libby/action/ActionList.lib.js
@@ -90,12 +90,6 @@ describe('ActionList', () => {
     <Box maxWidth="20rem">
       <Panel>
         <ActionList>
-          <ActionList.Action to="#" selected={true} is="checkbox">
-            Checkbox
-          </ActionList.Action>
-          <ActionList.Action to="#" selected={false} is="checkbox">
-            Checkbox
-          </ActionList.Action>
           <ActionList.Action to="#" is="button">
             Button
           </ActionList.Action>

--- a/packages/matchbox/src/components/ActionList/Action.js
+++ b/packages/matchbox/src/components/ActionList/Action.js
@@ -25,9 +25,6 @@ const Action = React.forwardRef(function Action(props, userRef) {
     );
   }, [content, selected, helpText]);
 
-  const isAttributes =
-    is === 'checkbox' ? { role: 'checkbox', 'aria-checked': !!selected, tabIndex: '0' } : {};
-
   return (
     <StyledLink
       as={is === 'button' ? 'button' : null}
@@ -35,7 +32,6 @@ const Action = React.forwardRef(function Action(props, userRef) {
       disabled={disabled}
       isType={is}
       ref={userRef}
-      {...isAttributes}
       {...action}
     >
       {linkContent}
@@ -53,7 +49,7 @@ Action.propTypes = {
    * Can be used for wrappers that manage focus within the menu, eg downshift
    */
   highlighted: PropTypes.bool,
-  is: PropTypes.oneOf(['link', 'button', 'checkbox']),
+  is: PropTypes.oneOf(['link', 'button']),
   selected: deprecate(PropTypes.bool, 'Use the checkbox component instead'),
   helpText: PropTypes.string,
 };

--- a/packages/matchbox/src/components/ActionList/tests/ActionList.test.js
+++ b/packages/matchbox/src/components/ActionList/tests/ActionList.test.js
@@ -170,18 +170,6 @@ describe('Legacy ActionList', () => {
     expect(wrapper.find('div').at(0)).toHaveStyleRule('max-height', '10rem');
   });
 
-  it('renders a selected action as a checkbox', () => {
-    const wrapper = subject({
-      actions: [
-        { content: 'Action', is: 'checkbox' },
-        { content: 'Action 2', selected: true, is: 'checkbox' },
-      ],
-    });
-    expect(wrapper.find('a').at(1)).toHaveAttributeValue('role', 'checkbox');
-    expect(wrapper.find('a').at(1)).toHaveAttributeValue('aria-checked', 'true');
-    expect(wrapper.find('a').at(0)).toHaveAttributeValue('aria-checked', 'false');
-  });
-
   it('renders an action button', () => {
     const wrapper = subject({
       actions: [{ content: 'Action', is: 'button' }],


### PR DESCRIPTION
### What Changed
- Removes the `is="checkbox"` option from `ActionList.Action`

### How To Test or Verify
- Verify mdx docs are up to date (they never included the option)
- Verify 2web2ui does not use the option

### PR Checklist

- [x] Add the correct `type` label
- [x] Pull request approval from #uxfe or #design-guild
