### PR TITLE
Resolves #788 Support labelHidden on Select

### DIFF
--- a/cypress/integration/Select.spec.js
+++ b/cypress/integration/Select.spec.js
@@ -13,4 +13,10 @@ describe('The Select component', () => {
     cy.get('[data-id="error-message"]').should('exist');
     cy.findByText('You forgot to select').should('exist');
   });
+
+  it('renders with a hidden label correctly', () => {
+    cy.visit('/iframe.html?path=Select__hidden-label&source=false');
+    cy.get('#idLabel').should('have.text', 'Select an option');
+    cy.get('[for="id"]').should('exist');
+  });
 });

--- a/libby/form/Select.lib.js
+++ b/libby/form/Select.lib.js
@@ -51,6 +51,10 @@ describe('Select', () => {
     />
   ));
 
+  add('hidden label', () => (
+    <Select id="id" label="Select an option" labelHidden options={options} />
+  ));
+
   add('optional', () => <Select id="id" label="Select an option" options={options} optional />);
 
   add('disabled', () => <Select id="id" label="Select an option" disabled options={options} />);

--- a/packages/matchbox/src/components/Select/Select.js
+++ b/packages/matchbox/src/components/Select/Select.js
@@ -108,7 +108,7 @@ const Select = React.forwardRef(function Select(props, userRef) {
     error,
     errorInLabel,
     optional,
-    // labelHidden, TODO add this back in later after hibana cutover
+    labelHidden,
     ...rest
   } = props;
   const systemProps = pick(rest, system.propNames);
@@ -126,11 +126,7 @@ const Select = React.forwardRef(function Select(props, userRef) {
   ) : null;
 
   const labelMarkup = (
-    <Label
-      id={id}
-      label={label}
-      // labelHidden={labelHidden} TODO Add this back in after hibana cutover
-    >
+    <Label id={id} label={label} labelHidden={labelHidden}>
       {requiredIndicator}
       {error && errorInLabel && (
         <Box as={Error} id={errorId} wrapper="span" error={error} fontWeight="400" />
@@ -188,7 +184,7 @@ Select.propTypes = {
   disabled: PropTypes.bool,
   required: PropTypes.bool,
   label: PropTypes.string,
-  // labelHidden: PropTypes.bool, TODO Add this back in after hibana cutover
+  labelHidden: PropTypes.bool,
   helpText: PropTypes.node,
   error: PropTypes.string,
   errorInLabel: PropTypes.bool,

--- a/site/src/pages/components/select.mdx
+++ b/site/src/pages/components/select.mdx
@@ -119,6 +119,10 @@ export const optionsString = `[
   Label for the input
 </Prop>
 
+<Prop name="labelHidden" type="bool">
+  Hides the label visually, but still accessible to screen readers
+</Prop>
+
 <Prop name="helpText" type="node">
   Addition text to help the user that renders below the input
 </Prop>


### PR DESCRIPTION
Resolves #788 

### What Changed
- Adds `labelHidden` to Select

### How To Test or Verify
- Run libby, visit http://localhost:9001/?path=Select__hidden-label&source=false
- Verify the label is present to screen readers, but visually hidden

### PR Checklist

- [x] Add the correct `type` label
- [x] Pull request approval from #uxfe or #design-guild
