### PR TITLE
UX-449 Allow any Drawer children

### DIFF
--- a/cypress/integration/Drawer.spec.js
+++ b/cypress/integration/Drawer.spec.js
@@ -21,18 +21,28 @@ describe('Drawer component', () => {
     cy.contains('Opened on the right').should('not.exist');
   });
 
+  it('closes when clicking the close button', () => {
+    cy.contains('Opened on the right').should('exist');
+    cy.findByRole('button', { name: 'Close' }).click();
+    cy.contains('Opened on the right').should('not.exist');
+  });
+
   it('traps focus', () => {
+    cy.wait(500); // waits for Drawer to enter
     cy.get('body').tab();
+    cy.focused().should('have.text', 'Close');
+    cy.focused().tab();
     cy.focused().should('have.text', 'Button 1');
     cy.focused().tab();
     cy.focused().should('have.text', 'Button 2');
     cy.focused().tab();
-    cy.focused().should('have.text', 'Button 1');
+    cy.focused().should('have.text', 'Close');
   });
 
   it('returns focus on close', () => {
+    cy.wait(500); // waits for Drawer to enter
     cy.get('body').tab();
-    cy.focused().should('have.text', 'Button 1');
+    cy.focused().should('have.text', 'Close');
     cy.get('body').type('{esc}');
     cy.focused().should('have.text', 'On the right');
   });

--- a/libby/overlays/Drawer.lib.js
+++ b/libby/overlays/Drawer.lib.js
@@ -28,6 +28,7 @@ describe('Drawer', () => {
         </Box>
 
         <Drawer {...getDrawerPropsA()} position="right">
+          <Drawer.Header>Header Title</Drawer.Header>
           <Drawer.Content>
             Opened on the right
             <Button variant="outline">Button 1</Button>

--- a/libby/overlays/Drawer.lib.js
+++ b/libby/overlays/Drawer.lib.js
@@ -16,12 +16,12 @@ describe('Drawer', () => {
       <>
         <Box display="flex">
           <Box flex="1">
-            <Button outline color="blue" {...getActivatorPropsA()}>
+            <Button variant="outline" color="blue" {...getActivatorPropsA()}>
               On the right
             </Button>
           </Box>
           <Box flex="0">
-            <Button outline color="blue" {...getActivatorPropsB()}>
+            <Button variant="outline" color="blue" {...getActivatorPropsB()}>
               On the Left
             </Button>
           </Box>
@@ -30,23 +30,25 @@ describe('Drawer', () => {
         <Drawer {...getDrawerPropsA()} position="right">
           <Drawer.Content>
             Opened on the right
-            <Button outline>Button 1</Button>
-            <Button outline>Button 2</Button>
+            <Button variant="outline">Button 1</Button>
+            <Button variant="outline">Button 2</Button>
           </Drawer.Content>
         </Drawer>
 
         <Drawer {...getDrawerPropsB()} position="left">
-          <Drawer.Header>Header Title</Drawer.Header>
-          <Drawer.Content>
-            Opened on the left
-            <Button outline>Button 1</Button>
-            <Button outline>Button 2</Button>
-            {Array.apply(null, Array(100)).map(() => (
-              <br />
-            ))}
-            Bottom
-          </Drawer.Content>
-          <Drawer.Footer>Footer Content</Drawer.Footer>
+          <div>
+            <Drawer.Header>Header Title</Drawer.Header>
+            <Drawer.Content>
+              Opened on the left
+              <Button variant="outline">Button 1</Button>
+              <Button variant="outline">Button 2</Button>
+              {Array.apply(null, Array(100)).map((n, i) => (
+                <br key={i} />
+              ))}
+              Bottom
+            </Drawer.Content>
+            <Drawer.Footer>Footer Content</Drawer.Footer>
+          </div>
         </Drawer>
       </>
     );
@@ -76,7 +78,7 @@ describe('Drawer', () => {
                 </Button>
               </Box>
               <Box flex="1" pl="100">
-                <Button width="100%" outline>
+                <Button width="100%" variant="outline">
                   Cancel
                 </Button>
               </Box>

--- a/libby/overlays/Drawer.lib.js
+++ b/libby/overlays/Drawer.lib.js
@@ -28,12 +28,14 @@ describe('Drawer', () => {
         </Box>
 
         <Drawer {...getDrawerPropsA()} position="right">
-          <Drawer.Header>Header Title</Drawer.Header>
-          <Drawer.Content>
-            Opened on the right
-            <Button variant="outline">Button 1</Button>
-            <Button variant="outline">Button 2</Button>
-          </Drawer.Content>
+          <div>
+            <Drawer.Header>Header Title</Drawer.Header>
+            <Drawer.Content>
+              Opened on the right
+              <Button variant="outline">Button 1</Button>
+              <Button variant="outline">Button 2</Button>
+            </Drawer.Content>
+          </div>
         </Drawer>
 
         <Drawer {...getDrawerPropsB()} position="left">

--- a/packages/matchbox/src/components/Drawer/Drawer.js
+++ b/packages/matchbox/src/components/Drawer/Drawer.js
@@ -13,8 +13,8 @@ import { useWindowEvent } from '../../hooks';
 import { onKey } from '../../helpers/keyEvents';
 import { secondsToMS } from '../../helpers/string';
 import { getRectFor } from '../../helpers/geometry';
-import { getChild } from '../../helpers/children';
 import { getWindow, isInIframe } from '../../helpers/window';
+import { DrawerContext } from './context';
 import { Overlay, Container } from './styles';
 
 const Drawer = React.forwardRef(function Drawer(props, userRef) {
@@ -160,9 +160,9 @@ const Drawer = React.forwardRef(function Drawer(props, userRef) {
                       position="relative"
                       height={`calc(100% - ${footerHeight})`}
                     >
-                      {getChild('Drawer.Header', children, { onClose })}
-                      {getChild('Drawer.Content', children)}
-                      {getChild('Drawer.Footer', children, { ref: footerRef })}
+                      <DrawerContext.Provider value={{ onClose, footerRef }}>
+                        {children}
+                      </DrawerContext.Provider>
                     </Box>
                   </TouchScrollable>
                 </Container>

--- a/packages/matchbox/src/components/Drawer/Footer.js
+++ b/packages/matchbox/src/components/Drawer/Footer.js
@@ -5,13 +5,16 @@ import { padding } from 'styled-system';
 import { createPropTypes } from '@styled-system/prop-types';
 import { pick } from '@styled-system/props';
 import { Box } from '../Box';
+import { DrawerContext } from './context';
 
 const Container = styled.div`
   ${padding}
 `;
 
-const Footer = React.forwardRef(function Footer({ children, ...rest }, ref) {
+const Footer = React.forwardRef(function Footer({ children, ...rest }, userRef) {
   const systemProps = pick(rest);
+  const context = React.useContext(DrawerContext);
+
   return (
     <Box
       data-id="drawer-footer"
@@ -21,9 +24,9 @@ const Footer = React.forwardRef(function Footer({ children, ...rest }, ref) {
       position="fixed"
       left="0"
       right="0"
-      ref={ref}
+      ref={context.footerRef}
     >
-      <Container p="500" {...systemProps}>
+      <Container p="500" {...systemProps} ref={userRef}>
         {children}
       </Container>
     </Box>

--- a/packages/matchbox/src/components/Drawer/Header.js
+++ b/packages/matchbox/src/components/Drawer/Header.js
@@ -6,9 +6,12 @@ import { ScreenReaderOnly } from '../ScreenReaderOnly';
 import { Box } from '../Box';
 import { Text } from '../Text';
 import { Button } from '../Button';
+import { DrawerContext } from './context';
 
 const Header = React.forwardRef(function Header(props, ref) {
-  const { children, onClose, showCloseButton } = props;
+  const { children, showCloseButton } = props;
+  const context = React.useContext(DrawerContext);
+
   return (
     <Box data-id="drawer-header" bg="white" p="500" ref={ref}>
       <Box display="flex">
@@ -18,7 +21,13 @@ const Header = React.forwardRef(function Header(props, ref) {
           </Text>
         </Box>
         {showCloseButton && (
-          <Button variant="text" size="small" width={tokens.spacing_600} px="0" onClick={onClose}>
+          <Button
+            variant="text"
+            size="small"
+            width={tokens.spacing_600}
+            px="0"
+            onClick={context.onClose}
+          >
             <ScreenReaderOnly>Close</ScreenReaderOnly>
             <Close size={25} />
           </Button>

--- a/packages/matchbox/src/components/Drawer/context.js
+++ b/packages/matchbox/src/components/Drawer/context.js
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export const DrawerContext = React.createContext({});

--- a/packages/matchbox/src/components/Drawer/tests/Drawer.test.js
+++ b/packages/matchbox/src/components/Drawer/tests/Drawer.test.js
@@ -4,7 +4,9 @@ import Drawer from '../Drawer';
 describe('Drawer', () => {
   const subject = props =>
     global.mountStyled(
-      <Drawer id="test-id" children={<Drawer.Content>test content</Drawer.Content>} {...props} />,
+      <Drawer id="test-id" {...props}>
+        <Drawer.Content>test content</Drawer.Content>
+      </Drawer>,
     );
 
   it('should not render when closed', () => {
@@ -27,9 +29,9 @@ describe('Drawer', () => {
     ).toEqual('test content');
   });
 
-  it('should not render invalid children', () => {
-    const wrapper = subject({ open: true, children: <div id="wrong">test children</div> });
-    expect(wrapper.find('#wrong')).not.toExist();
+  it('should render any children', () => {
+    const wrapper = subject({ open: true, children: <div id="test">test children</div> });
+    expect(wrapper.find('#test')).toExist();
   });
 
   it('should render on right by default', () => {

--- a/packages/matchbox/src/components/Drawer/tests/Drawer.test.js
+++ b/packages/matchbox/src/components/Drawer/tests/Drawer.test.js
@@ -5,7 +5,7 @@ describe('Drawer', () => {
   const subject = props =>
     global.mountStyled(
       <Drawer id="test-id" {...props}>
-        <Drawer.Content>test content</Drawer.Content>
+        {props.children || <Drawer.Content>test content</Drawer.Content>}
       </Drawer>,
     );
 

--- a/packages/matchbox/src/components/Drawer/tests/Header.test.js
+++ b/packages/matchbox/src/components/Drawer/tests/Header.test.js
@@ -9,13 +9,6 @@ describe('Drawer Header', () => {
     expect(wrapper.text()).toEqual('test titleClose');
   });
 
-  it('should handle clicking on close button', () => {
-    const onClose = jest.fn();
-    const wrapper = subject({ onClose });
-    wrapper.find('button').simulate('click');
-    expect(onClose).toHaveBeenCalledTimes(1);
-  });
-
   it('should be able to hide the close button', () => {
     const wrapper = subject({ showCloseButton: false });
     expect(wrapper.find('button')).not.toExist();


### PR DESCRIPTION
### What Changed
- Allows any React node to be a child of Drawer, to support more flexible component composition

### How To Test or Verify
- Run Libby - visit: http://localhost:9001/?path=Drawer__example-drawer&source=false
- Verify the first drawer renders and functions correctly

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
