### PR TITLE
UX-468 Tab focus state uses focus-visible with fallback

### DIFF
--- a/packages/matchbox/src/components/Tabs/styles.js
+++ b/packages/matchbox/src/components/Tabs/styles.js
@@ -3,7 +3,13 @@ import { tokens } from '@sparkpost/design-tokens';
 
 export const tabStyles = ({ selected, fitted }) => `
   ${buttonReset}
-  ${focusOutline({ offset: '0px' })}
+  
+  ${focusOutline({ offset: '0px', modifier: '&' })}
+  &:focus:not(:focus-visible):after {
+    box-shadow: none;
+  }
+  ${focusOutline({ offset: '0px', modifier: '&:focus-visible' })}
+
   display: inline-block;
   cursor: pointer;
   position: relative;


### PR DESCRIPTION
### What Changed
- Tab focus state now uses `focus-visible`
- A fallback is provided for browsers that don't support `focus-visible`


### How To Test or Verify
- Run libby with `npm run start:libby`
- Visit http://localhost:9001/?path=Tabs__automatic-keyboard-activation&source=false
- Verify clicking on tabs does not produce tab outlines
- Verify keyboard navigation does produce tab outlines

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
