### PR TITLE
UX-483 Skeletons are hidden from screen readers

### DIFF
--- a/cypress/integration/Skeleton.spec.js
+++ b/cypress/integration/Skeleton.spec.js
@@ -1,0 +1,10 @@
+describe('The Skeleton component', () => {
+  beforeEach(() => {
+    cy.visit('/iframe.html?path=Skeleton__all-together&source=false');
+  });
+
+  it('not render anything visible to screen readers', () => {
+    cy.get('#test').should('have.text', '');
+    cy.get('[aria-hidden="true"]').should('have.length', 6);
+  });
+});

--- a/libby/feedback/Skeleton.lib.js
+++ b/libby/feedback/Skeleton.lib.js
@@ -25,25 +25,27 @@ describe('Skeleton', () => {
   add('body', () => <Skeleton.Body />);
 
   add('all together', () => (
-    <Stack>
-      <Skeleton.Header looksLike="h1" />
-      <Skeleton.Header looksLike="h6" width="800" />
-      <Panel>
-        <Panel.Section>
-          <Stack>
-            <Skeleton.Header looksLike="h5" />
-            <Skeleton.Body lines={2} />
-          </Stack>
-        </Panel.Section>
-      </Panel>
-      <Panel>
-        <Panel.Section>
-          <Stack>
-            <Skeleton.Box size="3.5rem" borderRadius="circle" />
-            <Skeleton.Body lines={8} />
-          </Stack>
-        </Panel.Section>
-      </Panel>
-    </Stack>
+    <div id="test">
+      <Stack>
+        <Skeleton.Header looksLike="h1" />
+        <Skeleton.Header looksLike="h6" width="800" />
+        <Panel>
+          <Panel.Section>
+            <Stack>
+              <Skeleton.Header looksLike="h5" />
+              <Skeleton.Body lines={2} />
+            </Stack>
+          </Panel.Section>
+        </Panel>
+        <Panel>
+          <Panel.Section>
+            <Stack>
+              <Skeleton.Box size="3.5rem" borderRadius="circle" />
+              <Skeleton.Body lines={8} />
+            </Stack>
+          </Panel.Section>
+        </Panel>
+      </Stack>
+    </div>
   ));
 });

--- a/packages/matchbox/src/components/Skeleton/Skeleton.js
+++ b/packages/matchbox/src/components/Skeleton/Skeleton.js
@@ -53,7 +53,7 @@ const SkeletonHeader = React.forwardRef(function SkeletonHeader(props, ref) {
   }, [looksLike]);
 
   return (
-    <Box ref={ref} tabIndex="-1">
+    <Box ref={ref} tabIndex="-1" aria-hidden="true">
       <Animator
         borderRadius="200"
         delay={delay}
@@ -94,7 +94,7 @@ const SkeletonBody = React.forwardRef(function SkeletonBody(props, ref) {
   }, [lines]);
 
   return (
-    <Box ref={ref} mt="100" tabIndex="-1">
+    <Box ref={ref} mt="100" tabIndex="-1" aria-hidden="true">
       <Stack space="300">{body}</Stack>
     </Box>
   );
@@ -111,7 +111,7 @@ SkeletonBody.defaultProps = {
 const SkeletonBox = React.forwardRef(function SkeletonBox(props, ref) {
   const delay = React.useMemo(() => `${Math.random() / 2}s`, []);
   return (
-    <Box ref={ref} tabIndex="-1">
+    <Box ref={ref} tabIndex="-1" aria-hidden="true">
       <Animator borderRadius="200" delay={delay} {...props} />
     </Box>
   );


### PR DESCRIPTION
### What Changed
- Adds `aria-hidden` to Skeleton components

### How To Test or Verify
- Run libby with `npm run start:libby`
- Visit: http://localhost:9001/?path=Skeleton__all-together&source=false
- Verify the skeleton elements are not tabbable and have `aria-hidden` set

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
