### PR TITLE
UX-485 Prevent system prop HTML attributes for Box

### DIFF
--- a/packages/matchbox/src/components/Box/Box.js
+++ b/packages/matchbox/src/components/Box/Box.js
@@ -1,9 +1,5 @@
 import styled from 'styled-components';
-import { border, color, flexbox, grid, layout, position, shadow, space, typography, compose } from 'styled-system';
-import propTypes from '@styled-system/prop-types';
-import PropTypes from 'prop-types';
-
-const system = compose(
+import {
   border,
   color,
   flexbox,
@@ -12,20 +8,26 @@ const system = compose(
   position,
   shadow,
   space,
-  typography
-);
+  typography,
+  compose,
+} from 'styled-system';
+import propTypes from '@styled-system/prop-types';
+import PropTypes from 'prop-types';
+import { clean } from '../../helpers/props';
 
-const truncate = (props) => {
+const system = compose(border, color, flexbox, grid, layout, position, shadow, space, typography);
+
+const truncate = props => {
   if (props.truncate) {
     return {
       overflow: 'hidden',
       textOverflow: 'ellipsis',
-      whiteSpace: 'nowrap'
+      whiteSpace: 'nowrap',
     };
   }
 };
 
-const Box = styled('div')`
+const Box = styled('div').withConfig(clean(system.propNames))`
   ${system}
   ${truncate}
 `;
@@ -40,7 +42,7 @@ Box.propTypes = {
   ...propTypes.shadow,
   ...propTypes.space,
   ...propTypes.typography,
-  truncate: PropTypes.bool
+  truncate: PropTypes.bool,
 };
 
 Box.displayName = 'Box';

--- a/packages/matchbox/src/components/Box/Box.js
+++ b/packages/matchbox/src/components/Box/Box.js
@@ -27,7 +27,7 @@ const truncate = props => {
   }
 };
 
-const Box = styled('div').withConfig(clean(system.propNames))`
+const Box = styled.div.withConfig(clean(system.propNames))`
   ${system}
   ${truncate}
 `;

--- a/packages/matchbox/src/helpers/props.js
+++ b/packages/matchbox/src/helpers/props.js
@@ -51,7 +51,9 @@ export function pick(props, names) {
  */
 export function clean(arr = [], config = {}) {
   return {
-    shouldForwardProp: (prop, defaultFn) => !arr.includes(prop) && defaultFn(prop),
+    shouldForwardProp: prop => {
+      return !arr.includes(prop);
+    },
     ...config,
   };
 }


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed
- Cleans system props from `Box`

### How To Test or Verify
- Run libby with `npm run start:libby`
- Verify no HTML attributes are forwarded from the Box component http://localhost:9001/?path=Box__styled&source=false

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
