### PR TITLE
UX-492 Focus on activator when Popovers close

### DIFF
--- a/cypress/integration/Popover.spec.js
+++ b/cypress/integration/Popover.spec.js
@@ -51,11 +51,6 @@ describe('Uncontrolled Popover with Actionlist', () => {
     cy.get('[data-id="popover-content"]').should('be.visible');
   });
 
-  it('should toggle open with enter key', () => {
-    cy.contains('More Actions').type('{enter}');
-    cy.get('[data-id="popover-content"]').should('be.visible');
-  });
-
   it('should tab through actionlist buttons', () => {
     cy.contains('More Actions').click();
     cy.get('[data-id="popover-content"]').should('be.visible');

--- a/cypress/integration/Popover.spec.js
+++ b/cypress/integration/Popover.spec.js
@@ -21,18 +21,21 @@ describe('Controlled Popover component', () => {
       cy.get('[data-id="popover-content"]').should('be.visible');
       cy.get('html').click(100, 300);
       cy.get('[data-id="popover-content"]').should('not.exist');
+      cy.focused().should('have.text', 'Open Me');
     });
 
     it('should close when pressing the escape key', () => {
       cy.get('[data-id="popover-content"]').should('be.visible');
       cy.get('body').type('{esc}');
       cy.get('[data-id="popover-content"]').should('not.exist');
+      cy.focused().should('have.text', 'Open Me');
     });
 
     it('should close when pressing a close button', () => {
       cy.get('[data-id="popover-content"]').should('be.visible');
       cy.get('[data-id="close-button"]').click();
       cy.get('[data-id="popover-content"]').should('not.exist');
+      cy.focused().should('have.text', 'Open Me');
     });
   });
 });
@@ -71,6 +74,7 @@ describe('Uncontrolled Popover with Actionlist', () => {
     cy.get('[data-id="popover-content"]').should('be.visible');
     cy.get('html').click(100, 600);
     cy.get('[data-id="popover-content"]').should('not.exist');
+    cy.focused().should('have.text', 'More Actions');
   });
 
   it('should close when pressing the escape key', () => {
@@ -78,5 +82,6 @@ describe('Uncontrolled Popover with Actionlist', () => {
     cy.get('[data-id="popover-content"]').should('be.visible');
     cy.get('body').type('{esc}');
     cy.get('[data-id="popover-content"]').should('not.exist');
+    cy.focused().should('have.text', 'More Actions');
   });
 });

--- a/cypress/integration/Popover.spec.js
+++ b/cypress/integration/Popover.spec.js
@@ -51,6 +51,11 @@ describe('Uncontrolled Popover with Actionlist', () => {
     cy.get('[data-id="popover-content"]').should('be.visible');
   });
 
+  it('should toggle open with enter key', () => {
+    cy.contains('More Actions').type('{enter}');
+    cy.get('[data-id="popover-content"]').should('be.visible');
+  });
+
   it('should tab through actionlist buttons', () => {
     cy.contains('More Actions').click();
     cy.get('[data-id="popover-content"]').should('be.visible');

--- a/packages/matchbox/src/components/Popover/Popover.js
+++ b/packages/matchbox/src/components/Popover/Popover.js
@@ -30,13 +30,6 @@ const Popover = React.forwardRef(function Popover(props, ref) {
     }
   }, []);
 
-  // Automatically focuses on activator content when closing
-  React.useLayoutEffect(() => {
-    if (!shouldBeOpen) {
-      focusOnActivator();
-    }
-  }, [shouldBeOpen]);
-
   // Automatically focuses on content when opening
   React.useLayoutEffect(() => {
     if (shouldBeOpen && popoverRef && popoverRef.current) {
@@ -57,6 +50,14 @@ const Popover = React.forwardRef(function Popover(props, ref) {
     }
   }
 
+  // Focuses on activator when controlled open state closes ONLY
+  React.useLayoutEffect(() => {
+    // explicit false check to rule out uncontrolled open state
+    if (controlledOpen === false) {
+      focusOnActivator();
+    }
+  }, [controlledOpen]);
+
   // Toggles uncontrolled popovers on clicking outside, and calls `onClose` for controlled popovers
   function handleOutsideClick(e) {
     const isOutside =
@@ -73,17 +74,25 @@ const Popover = React.forwardRef(function Popover(props, ref) {
       if (open) {
         handleUncontrolledToggle();
       }
+
+      focusOnActivator();
     }
   }
 
   // Toggles uncontrolled popovers on escape keydown, and calls `onClose` for controlled popovers
   function handleEsc(e) {
     if (onClose && shouldBeOpen) {
-      onKey('escape', onClose)(e);
+      onKey('escape', () => {
+        onClose(e);
+        focusOnActivator();
+      })(e);
     }
 
     if (open) {
-      onKey('escape', handleUncontrolledToggle)(e);
+      onKey('escape', () => {
+        handleUncontrolledToggle();
+        focusOnActivator();
+      })(e);
     }
   }
 
@@ -91,6 +100,9 @@ const Popover = React.forwardRef(function Popover(props, ref) {
   function handleTrigger() {
     if (open !== null) {
       handleUncontrolledToggle();
+      if (open === false) {
+        focusOnActivator();
+      }
     }
   }
 

--- a/packages/matchbox/src/components/Popover/Popover.js
+++ b/packages/matchbox/src/components/Popover/Popover.js
@@ -8,6 +8,7 @@ import PopoverContent from './PopoverContent';
 import { onKey } from '../../helpers/keyEvents';
 import useWindowEvent from '../../hooks/useWindowEvent';
 import { deprecate } from '../../helpers/propTypes';
+import { findFocusableChild } from '../../helpers/focus';
 
 const Popover = React.forwardRef(function Popover(props, ref) {
   const { as, id, open: controlledOpen, onClose, children, trigger, wrapper, ...rest } = props;
@@ -29,6 +30,13 @@ const Popover = React.forwardRef(function Popover(props, ref) {
     }
   }, []);
 
+  // Automatically focuses on activator content when closing
+  React.useLayoutEffect(() => {
+    if (!shouldBeOpen) {
+      focusOnActivator();
+    }
+  }, [shouldBeOpen]);
+
   // Automatically focuses on content when opening
   React.useLayoutEffect(() => {
     if (shouldBeOpen && popoverRef && popoverRef.current) {
@@ -41,7 +49,15 @@ const Popover = React.forwardRef(function Popover(props, ref) {
     setOpen(!open);
   }
 
-  // Toggles uncontrolled popovers, and calls `onClose` for controlled popovers
+  // Focus on activator element when closing
+  function focusOnActivator() {
+    if (activatorRef && activatorRef.current) {
+      const activatorToFocus = findFocusableChild(activatorRef.current) || activatorRef.current;
+      activatorToFocus.focus();
+    }
+  }
+
+  // Toggles uncontrolled popovers on clicking outside, and calls `onClose` for controlled popovers
   function handleOutsideClick(e) {
     const isOutside =
       popoverRef.current &&
@@ -60,7 +76,7 @@ const Popover = React.forwardRef(function Popover(props, ref) {
     }
   }
 
-  // Toggles uncontrolled popovers, and calls `onClose` for controlled popovers
+  // Toggles uncontrolled popovers on escape keydown, and calls `onClose` for controlled popovers
   function handleEsc(e) {
     if (onClose && shouldBeOpen) {
       onKey('escape', onClose)(e);

--- a/packages/matchbox/src/helpers/focus.js
+++ b/packages/matchbox/src/helpers/focus.js
@@ -1,0 +1,6 @@
+const FOCUSABLE_SELECTOR =
+  'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled),*[tabindex]';
+
+export function findFocusableChild(element) {
+  return element.querySelector(FOCUSABLE_SELECTOR);
+}

--- a/packages/matchbox/src/helpers/tests/focus.test.js
+++ b/packages/matchbox/src/helpers/tests/focus.test.js
@@ -1,0 +1,49 @@
+import { findFocusableChild } from '../focus';
+
+function setup({ wrapper = 'div', activator = 'button' } = {}) {
+  const wrapperElem = document.createElement(wrapper);
+  const activatorElem = document.createElement(activator);
+
+  wrapperElem.appendChild(activatorElem);
+  document.body.appendChild(wrapperElem);
+
+  return { wrapper: wrapperElem, activator: activatorElem };
+}
+
+describe('findFocusableChild', () => {
+  it('does not return self', () => {
+    const { wrapper } = setup({ wrapper: 'button' });
+    const focusable = findFocusableChild(wrapper);
+    expect(focusable).not.toBe(wrapper);
+  });
+
+  it('returns descendant button', () => {
+    const { wrapper, activator } = setup();
+    const focusable = findFocusableChild(wrapper);
+    expect(focusable).toBe(activator);
+  });
+
+  it('returns descendant link', () => {
+    const { wrapper, activator } = setup({ activator: 'a' });
+    const focusable = findFocusableChild(wrapper);
+    expect(focusable).toBe(activator);
+  });
+
+  it('returns descendant input', () => {
+    const { wrapper, activator } = setup({ activator: 'input' });
+    const focusable = findFocusableChild(wrapper);
+    expect(focusable).toBe(activator);
+  });
+
+  it('returns descendant select', () => {
+    const { wrapper, activator } = setup({ activator: 'select' });
+    const focusable = findFocusableChild(wrapper);
+    expect(focusable).toBe(activator);
+  });
+
+  it('returns nothing if nothing is focusable', () => {
+    const { wrapper } = setup({ activator: 'div' });
+    const focusable = findFocusableChild(wrapper);
+    expect(focusable).toBeNull();
+  });
+});


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed
- Focuses on the popover activator's focusable child when closing the popover
<!--
What changes does this PR propose?
Provide screenshots or [screen recordings](https://getkap.co/) for any visual changes.
-->

### How To Test or Verify
- Run libby
- Visit the stories for both controlled and uncontrolled popovers 
  - http://localhost:9001/?path=Popover__controlled&source=false
  - http://localhost:9001/?path=Popover__uncontrolled&source=false
- Verify focus is returned when
  - closing via clicking outside
  - closing via pressing escape
  - closing via close button (for controlled popover)

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
