### PR TITLE
UX-489 Remove indent on RadioCard component

### DIFF
--- a/packages/matchbox/src/components/RadioCard/RadioCard.js
+++ b/packages/matchbox/src/components/RadioCard/RadioCard.js
@@ -57,13 +57,13 @@ const RadioCard = React.forwardRef(function RadioCard(props, userRef) {
             >
               {label}
             </StyledHeader>
-            {children && (
-              <Box data-id="radio-card-content" pt="200">
-                {children}
-              </Box>
-            )}
           </Box>
         </Box>
+        {children && (
+          <Box data-id="radio-card-content" pt="200">
+            {children}
+          </Box>
+        )}
       </StyledLabel>
     </Box>
   );

--- a/packages/matchbox/src/components/RadioCard/styles.js
+++ b/packages/matchbox/src/components/RadioCard/styles.js
@@ -6,6 +6,7 @@ import { Box } from '../Box';
 export const StyledLabel = styled(Box)`
   display: block;
   position: relative;
+  background: ${props => props.theme.colors.white};
   padding: ${props => props.theme.space['500']};
   border: ${props => props.theme.borders['400']};
   border-radius: ${props => props.theme.radii['200']};


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed
- Removes the indent
- Adds white background color (this was missing from original implementation)

### How To Test or Verify
- Run libby and visit http://localhost:9001/?path=RadioCard__grid&source=false
- Verify support text is not indented

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
