### PR TITLE
Resolves #810 – Support Label children over label prop

### DIFF
--- a/config/test-utils.js
+++ b/config/test-utils.js
@@ -1,0 +1,18 @@
+// // react-testing-library setup
+import React from 'react';
+import { render } from '@testing-library/react';
+import ThemeProvider from '../packages/matchbox/src/components/ThemeProvider/ThemeProvider';
+
+function Wrapper({ children }) {
+  return <ThemeProvider>{children}</ThemeProvider>;
+}
+
+function customRender(ui, options) {
+  return render(ui, { wrapper: Wrapper, ...options });
+}
+
+// re-export everything
+export * from '@testing-library/react';
+
+// override render method
+export { customRender as render };

--- a/jest.config.json
+++ b/jest.config.json
@@ -31,6 +31,8 @@
     "\\.(css|scss)$": "identity-obj-proxy",
     "@sparkpost/matchbox-icons(.*)": "<rootDir>/packages/matchbox-icons/src",
     "@sparkpost/matchbox(.*)": "<rootDir>/packages/matchbox/src",
-    "^styled-components": "<rootDir>/node_modules/styled-components"
+    "@sparkpost/design-tokens(.*)": "<rootDir>/packages/design-tokens",
+    "^styled-components": "<rootDir>/node_modules/styled-components",
+    "^test-utils$": "<rootDir>/config/test-utils.js"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6228,6 +6228,16 @@
         }
       }
     },
+    "@testing-library/react": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.2.6.tgz",
+      "integrity": "sha512-TXMCg0jT8xmuU8BkKMtp8l7Z50Ykew5WNX8UoIKTaLFwKkP2+1YDhOLA2Ga3wY4x29jyntk7EWfum0kjlYiSjQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^7.28.1"
+      }
+    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@babel/preset-react": "^7.12.5",
     "@sparkpost/libby-react": "0.0.29",
     "@testing-library/cypress": "^7.0.4",
+    "@testing-library/react": "^11.2.6",
     "@wojtekmaj/enzyme-adapter-react-17": "^0.3.1",
     "autoprefixer": "^8.4.1",
     "babel-eslint": "^10.1.0",

--- a/packages/matchbox/src/components/Checkbox/Checkbox.js
+++ b/packages/matchbox/src/components/Checkbox/Checkbox.js
@@ -104,11 +104,13 @@ const Checkbox = React.forwardRef(function Checkbox(props, userRef) {
           <Label
             as="span" // Outer wrapper already includes a label
             id={id}
-            label={label}
             labelHidden={labelHidden}
             fontWeight="400"
             mb="0" // TODO Remove once margin 0 is baked into Label
           >
+            <Box as="span" pr="200">
+              {label}
+            </Box>
             {required && (
               <Box as="span" pr="200" aria-hidden="true">
                 *

--- a/packages/matchbox/src/components/Checkbox/Checkbox.js
+++ b/packages/matchbox/src/components/Checkbox/Checkbox.js
@@ -101,22 +101,24 @@ const Checkbox = React.forwardRef(function Checkbox(props, userRef) {
           />
         </Box>
         <Box flex="1" pl="200">
-          <Label
-            as="span" // Outer wrapper already includes a label
-            id={id}
-            labelHidden={labelHidden}
-            fontWeight="400"
-            mb="0" // TODO Remove once margin 0 is baked into Label
-          >
-            <Box as="span" pr="200">
-              {label}
-            </Box>
-            {required && (
-              <Box as="span" pr="200" aria-hidden="true">
-                *
+          {label && (
+            <Label
+              as="span" // Outer wrapper already includes a label
+              id={id}
+              labelHidden={labelHidden}
+              fontWeight="400"
+              mb="0" // TODO Remove once margin 0 is baked into Label
+            >
+              <Box as="span" pr="200">
+                {label}
               </Box>
-            )}
-          </Label>
+              {required && (
+                <Box as="span" pr="200" aria-hidden="true">
+                  *
+                </Box>
+              )}
+            </Label>
+          )}
         </Box>
       </StyledLabel>
       {helpText && (

--- a/packages/matchbox/src/components/Checkbox/Group.js
+++ b/packages/matchbox/src/components/Checkbox/Group.js
@@ -23,7 +23,10 @@ function Group(props) {
     <StyledGroup {...systemProps}>
       {label && (
         <Box width="100%">
-          <Label as="legend" label={label} labelHidden={labelHidden}>
+          <Label as="legend" labelHidden={labelHidden}>
+            <Box as="span" pr="200">
+              {label}
+            </Box>
             {required && (
               <Box as="span" pr="200" aria-hidden="true">
                 *

--- a/packages/matchbox/src/components/ComboBox/ComboBoxTextField.js
+++ b/packages/matchbox/src/components/ComboBox/ComboBoxTextField.js
@@ -72,19 +72,21 @@ function ComboBoxTextField(props) {
 
   return (
     <StyledWrapper {...systemProps}>
-      <Label id={id} labelHidden={labelHidden}>
-        <Box as="span" pr="200">
-          {label}
-        </Box>
-        {required && (
-          <Box as="span" pr="200" aria-hidden="true">
-            *
+      {label && (
+        <Label id={id} labelHidden={labelHidden}>
+          <Box as="span" pr="200">
+            {label}
           </Box>
-        )}
-        {error && errorInLabel && (
-          <Box as={Error} id={errorId} wrapper="span" error={error} fontWeight="400" />
-        )}
-      </Label>
+          {required && (
+            <Box as="span" pr="200" aria-hidden="true">
+              *
+            </Box>
+          )}
+          {error && errorInLabel && (
+            <Box as={Error} id={errorId} wrapper="span" error={error} fontWeight="400" />
+          )}
+        </Label>
+      )}
       <StyledInputWrapper hasError={!!error} isDisabled={disabled}>
         {selectedItems.length > 0 && (
           <Box display="flex" pl="200" pt="0.375rem">

--- a/packages/matchbox/src/components/ComboBox/ComboBoxTextField.js
+++ b/packages/matchbox/src/components/ComboBox/ComboBoxTextField.js
@@ -72,7 +72,10 @@ function ComboBoxTextField(props) {
 
   return (
     <StyledWrapper {...systemProps}>
-      <Label id={id} label={label} labelHidden={labelHidden}>
+      <Label id={id} labelHidden={labelHidden}>
+        <Box as="span" pr="200">
+          {label}
+        </Box>
         {required && (
           <Box as="span" pr="200" aria-hidden="true">
             *

--- a/packages/matchbox/src/components/ComboBox/tests/ComboBox.test.js
+++ b/packages/matchbox/src/components/ComboBox/tests/ComboBox.test.js
@@ -2,10 +2,11 @@ import React from 'react';
 import ComboBox from '../ComboBox';
 import ComboBoxMenu from '../ComboBoxMenu';
 import ComboBoxTextField from '../ComboBoxTextField';
+import { render } from 'test-utils';
 
 describe('ComboBox Wrapper', () => {
   const subject = (props = {}) =>
-    global.mountStyled(
+    render(
       <ComboBox {...props}>
         <ComboBoxTextField id="test-id" helpText="test help" />
         <ComboBoxMenu isOpen items={[{ content: 'foo', is: 'button' }]} />
@@ -13,13 +14,9 @@ describe('ComboBox Wrapper', () => {
     );
 
   it('should menu correctly inside textfield', () => {
-    const wrapper = subject();
-    const children = wrapper
-      .find('div')
-      .at(1)
-      .children();
-    expect(children.at(1).find('input')).toExist();
-    expect(children.at(2).text()).toEqual('foo');
-    expect(children.last().text()).toEqual('test help');
+    const { getByRole, getByText } = subject();
+    expect(getByRole('textbox')).toBeTruthy();
+    expect(getByRole('button', { name: 'foo' })).toBeTruthy();
+    expect(getByText(/test help/g)).toBeTruthy();
   });
 });

--- a/packages/matchbox/src/components/Label/Label.js
+++ b/packages/matchbox/src/components/Label/Label.js
@@ -1,6 +1,9 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Box } from '../Box';
 import { ScreenReaderOnly } from '../ScreenReaderOnly';
+import { Inline } from '../Inline';
+import { deprecate } from '../../helpers/propTypes';
 
 function Label(props) {
   const {
@@ -13,10 +16,6 @@ function Label(props) {
     fontWeight = '500',
     mb = '100',
   } = props;
-
-  if (!label) {
-    return null;
-  }
 
   if (labelHidden) {
     return (
@@ -39,14 +38,19 @@ function Label(props) {
       className={className}
       mb={mb}
     >
-      <Box as="span" pr="200" lineHeight="200" fontSize="200">
-        {label}
+      <Box as="span" lineHeight="200" fontSize="200">
+        <Inline space="200">
+          {label ? <span>{label}</span> : null}
+          {children ? <span>{children}</span> : null}
+        </Inline>
       </Box>
-      {/* Certain form components append <Error /> or requred indicators here */}
-      <span>{children}</span>
     </Box>
   );
 }
 
 Label.displayName = 'Label';
+Label.propTypes = {
+  label: deprecate(PropTypes.string, 'Use the children instead'),
+};
+
 export default Label;

--- a/packages/matchbox/src/components/Label/tests/Label.test.js
+++ b/packages/matchbox/src/components/Label/tests/Label.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Label from '../Label';
 import { ScreenReaderOnly } from '../../ScreenReaderOnly';
 
-describe('Label', () => {
+describe('Label - deprecated use', () => {
   it('renders correctly', () => {
     const wrapper = global.mountStyled(
       <Label id="label1" label="Label text" className="test-class">
@@ -22,10 +22,27 @@ describe('Label', () => {
     expect(wrapper.find('label')).toHaveAttributeValue('id', 'label1Label');
     expect(wrapper.find('label')).toHaveAttributeValue('for', 'label1');
   });
+});
 
-  it('renders null when no "label" prop is provided', () => {
-    const wrapper = global.mountStyled(<Label />);
+describe('Label', () => {
+  it('renders correctly', () => {
+    const wrapper = global.mountStyled(
+      <Label id="label1" className="test-class">
+        Label text
+        <span>Select one!</span>
+      </Label>,
+    );
+    expect(wrapper).toHaveAttributeValue('id', 'label1Label');
+    expect(wrapper).toHaveAttributeValue('for', 'label1');
+    expect(wrapper.text()).toEqual('Label textSelect one!');
+    expect(wrapper.find('label').prop('className')).toContain('test-class');
+  });
 
-    expect(wrapper.find('label')).not.toExist();
+  it('renders hidden correctly', () => {
+    const wrapper = global.mountStyled(<Label id="label1" label="Label text" labelHidden></Label>);
+    // TODO switch to a style assertion when screen reader component switches to styled-components
+    expect(wrapper.find(ScreenReaderOnly)).toExist();
+    expect(wrapper.find('label')).toHaveAttributeValue('id', 'label1Label');
+    expect(wrapper.find('label')).toHaveAttributeValue('for', 'label1');
   });
 });

--- a/packages/matchbox/src/components/Label/tests/Label.test.js
+++ b/packages/matchbox/src/components/Label/tests/Label.test.js
@@ -1,48 +1,60 @@
 import React from 'react';
 import Label from '../Label';
-import { ScreenReaderOnly } from '../../ScreenReaderOnly';
-
-describe('Label - deprecated use', () => {
-  it('renders correctly', () => {
-    const wrapper = global.mountStyled(
-      <Label id="label1" label="Label text" className="test-class">
-        <span>Select one!</span>
-      </Label>,
-    );
-    expect(wrapper).toHaveAttributeValue('id', 'label1Label');
-    expect(wrapper).toHaveAttributeValue('for', 'label1');
-    expect(wrapper.text()).toEqual('Label textSelect one!');
-    expect(wrapper.find('label').prop('className')).toContain('test-class');
-  });
-
-  it('renders hidden correctly', () => {
-    const wrapper = global.mountStyled(<Label id="label1" label="Label text" labelHidden></Label>);
-    // TODO switch to a style assertion when screen reader component switches to styled-components
-    expect(wrapper.find(ScreenReaderOnly)).toExist();
-    expect(wrapper.find('label')).toHaveAttributeValue('id', 'label1Label');
-    expect(wrapper.find('label')).toHaveAttributeValue('for', 'label1');
-  });
-});
+import { render, within } from 'test-utils';
 
 describe('Label', () => {
-  it('renders correctly', () => {
-    const wrapper = global.mountStyled(
-      <Label id="label1" className="test-class">
-        Label text
-        <span>Select one!</span>
-      </Label>,
-    );
-    expect(wrapper).toHaveAttributeValue('id', 'label1Label');
-    expect(wrapper).toHaveAttributeValue('for', 'label1');
-    expect(wrapper.text()).toEqual('Label textSelect one!');
-    expect(wrapper.find('label').prop('className')).toContain('test-class');
+  describe('deprecated use', () => {
+    it('renders correctly with label prop', () => {
+      const subject = render(<Label id="label1" label="Label text"></Label>);
+      expect(subject.getByText('Label text')).toBeTruthy();
+    });
+
+    it('renders correctly with label prop and children', () => {
+      const subject = render(
+        <Label id="label1" label="Label text">
+          children text
+        </Label>,
+      );
+      expect(subject.getByText('Label text')).toBeTruthy();
+      expect(subject.getByText('children text')).toBeTruthy();
+    });
+
+    it('renders correctly with id', () => {
+      render(<Label id="label1" label="Label text"></Label>);
+      expect(within(document.querySelector('#label1Label')).getByText('Label text')).toBeTruthy();
+    });
+
+    it('renders correctly with className', () => {
+      render(<Label id="label1" label="Label text" className="test-class"></Label>);
+      expect(within(document.querySelector('.test-class')).getByText('Label text')).toBeTruthy();
+    });
+
+    it('renders hidden correctly', () => {
+      const subject = render(<Label id="label1" label="Label text" labelHidden></Label>);
+      expect(subject.getByText('Label text')).toBeTruthy();
+    });
   });
 
-  it('renders hidden correctly', () => {
-    const wrapper = global.mountStyled(<Label id="label1" label="Label text" labelHidden></Label>);
-    // TODO switch to a style assertion when screen reader component switches to styled-components
-    expect(wrapper.find(ScreenReaderOnly)).toExist();
-    expect(wrapper.find('label')).toHaveAttributeValue('id', 'label1Label');
-    expect(wrapper.find('label')).toHaveAttributeValue('for', 'label1');
+  it('renders children correctly', () => {
+    const subject = render(<Label id="label1">Label text</Label>);
+    expect(subject.getByText('Label text')).toBeTruthy();
+  });
+
+  it('renders children correctly with id', () => {
+    render(
+      <Label id="label1" className="test-class">
+        Label text
+      </Label>,
+    );
+    expect(within(document.querySelector('.test-class')).getByText('Label text')).toBeTruthy();
+  });
+
+  it('renders children correctly with className', () => {
+    render(
+      <Label id="label1" className="test-class">
+        Label text
+      </Label>,
+    );
+    expect(within(document.querySelector('#label1Label')).getByText('Label text')).toBeTruthy();
   });
 });

--- a/packages/matchbox/src/components/ListBox/ListBox.js
+++ b/packages/matchbox/src/components/ListBox/ListBox.js
@@ -139,7 +139,10 @@ const ListBox = React.forwardRef(function ListBox(props, userRef) {
   }, [currentValue]);
 
   const labelMarkup = (
-    <Label id={id} label={label} labelHidden={labelHidden}>
+    <Label id={id} labelHidden={labelHidden}>
+      <Box as="span" pr="200">
+        {label}
+      </Box>
       {requiredIndicator}
       {error && errorInLabel && (
         <Box as={Error} id={errorId} wrapper="span" error={error} fontWeight="400" />

--- a/packages/matchbox/src/components/Radio/Group.js
+++ b/packages/matchbox/src/components/Radio/Group.js
@@ -23,7 +23,10 @@ function Group(props) {
     <StyledGroup {...systemProps}>
       {label && (
         <Box width="100%">
-          <Label as="legend" label={label} labelHidden={labelHidden}>
+          <Label as="legend" labelHidden={labelHidden}>
+            <Box as="span" pr="200">
+              {label}
+            </Box>
             {required && (
               <Box as="span" pr="200" aria-hidden="true">
                 *

--- a/packages/matchbox/src/components/Radio/Radio.js
+++ b/packages/matchbox/src/components/Radio/Radio.js
@@ -69,14 +69,16 @@ const Radio = React.forwardRef(function Radio(props, userRef) {
           <StyledChecked error={error} size="1rem" as={RadioButtonChecked} />
         </Box>
         <Box flex="1" pl="200">
-          <Label
-            as="span" // Outer wrapper already includes a label
-            id={id}
-            label={label}
-            labelHidden={labelHidden}
-            fontWeight="400"
-            mb="0" // TODO Remove once margin 0 is baked into Label
-          />
+          {label && (
+            <Label
+              as="span" // Outer wrapper already includes a label
+              id={id}
+              label={label}
+              labelHidden={labelHidden}
+              fontWeight="400"
+              mb="0" // TODO Remove once margin 0 is baked into Label
+            />
+          )}
         </Box>
       </StyledLabel>
       {helpText && (

--- a/packages/matchbox/src/components/Radio/tests/Group.test.js
+++ b/packages/matchbox/src/components/Radio/tests/Group.test.js
@@ -22,10 +22,8 @@ describe('Checkbox Group', () => {
         .find('legend')
         .find('span')
         .at(1)
-        .find('span')
-        .at(0)
         .text(),
-    ).toEqual('Optional');
+    ).toEqual('test-labelOptional');
   });
 
   it('renders a legend while hidden correctly', () => {

--- a/packages/matchbox/src/components/RadioCard/Group.js
+++ b/packages/matchbox/src/components/RadioCard/Group.js
@@ -28,7 +28,10 @@ const Group = React.forwardRef(function Group(props, userRef) {
 
   return (
     <Fieldset data-id={rest['data-id']} id={id} ref={userRef} {...systemProps}>
-      <Label as="legend" label={label} labelHidden={labelHidden}>
+      <Label as="legend" labelHidden={labelHidden}>
+        <Box as="span" pr="200">
+          {label}
+        </Box>
         {optional && <OptionalLabel />}
       </Label>
 

--- a/packages/matchbox/src/components/Select/Select.js
+++ b/packages/matchbox/src/components/Select/Select.js
@@ -126,7 +126,10 @@ const Select = React.forwardRef(function Select(props, userRef) {
   ) : null;
 
   const labelMarkup = (
-    <Label id={id} label={label} labelHidden={labelHidden}>
+    <Label id={id} labelHidden={labelHidden}>
+      <Box as="span" pr="200">
+        {label}
+      </Box>
       {requiredIndicator}
       {error && errorInLabel && (
         <Box as={Error} id={errorId} wrapper="span" error={error} fontWeight="400" />

--- a/packages/matchbox/src/components/Select/Select.js
+++ b/packages/matchbox/src/components/Select/Select.js
@@ -125,7 +125,7 @@ const Select = React.forwardRef(function Select(props, userRef) {
     </Box>
   ) : null;
 
-  const labelMarkup = (
+  const labelMarkup = label && (
     <Label id={id} labelHidden={labelHidden}>
       <Box as="span" pr="200">
         {label}

--- a/packages/matchbox/src/components/Select/tests/Select.test.js
+++ b/packages/matchbox/src/components/Select/tests/Select.test.js
@@ -42,12 +42,15 @@ describe('Select', () => {
     const wrapper = subject({ id: 'test-id', error: 'test-error' });
     expect(
       wrapper
-        .find('div')
-        .at(3)
+        .find('[data-id="error-message"]')
+        .last()
         .text(),
     ).toEqual('test-error');
     expect(wrapper.find('select')).toHaveAttributeValue('aria-describedby', 'test-id-error');
-    expect(wrapper.find('div').at(3)).toHaveAttributeValue('id', 'test-id-error');
+    expect(wrapper.find('[data-id="error-message"]').last()).toHaveAttributeValue(
+      'id',
+      'test-id-error',
+    );
   });
 
   it('should render with error and helptext describedby', () => {

--- a/packages/matchbox/src/components/TextField/TextField.js
+++ b/packages/matchbox/src/components/TextField/TextField.js
@@ -166,7 +166,10 @@ const TextField = React.forwardRef(function TextField(props, userRef) {
 
   return (
     <StyledWrapper {...systemProps}>
-      <Label id={id} label={label} labelHidden={labelHidden}>
+      <Label id={id} labelHidden={labelHidden}>
+        <Box as="span" pr="200">
+          {label}
+        </Box>
         {required && (
           <Box as="span" pr="200" aria-hidden="true">
             *

--- a/packages/matchbox/src/components/TextField/TextField.js
+++ b/packages/matchbox/src/components/TextField/TextField.js
@@ -166,7 +166,7 @@ const TextField = React.forwardRef(function TextField(props, userRef) {
 
   return (
     <StyledWrapper {...systemProps}>
-      {label ? (
+      {label && (
         <Label id={id} labelHidden={labelHidden}>
           <Box as="span" pr="200">
             {label}
@@ -181,7 +181,7 @@ const TextField = React.forwardRef(function TextField(props, userRef) {
           )}
           {optional && <OptionalLabel float />}
         </Label>
-      ) : null}
+      )}
       <Connect left={connectLeft} right={connectRight}>
         <Box position="relative">
           <PrefixOrSuffix content={prefix} className={prefixClassname} ref={prefixRef} left="300" />

--- a/packages/matchbox/src/components/TextField/TextField.js
+++ b/packages/matchbox/src/components/TextField/TextField.js
@@ -166,20 +166,22 @@ const TextField = React.forwardRef(function TextField(props, userRef) {
 
   return (
     <StyledWrapper {...systemProps}>
-      <Label id={id} labelHidden={labelHidden}>
-        <Box as="span" pr="200">
-          {label}
-        </Box>
-        {required && (
-          <Box as="span" pr="200" aria-hidden="true">
-            *
+      {label ? (
+        <Label id={id} labelHidden={labelHidden}>
+          <Box as="span" pr="200">
+            {label}
           </Box>
-        )}
-        {error && errorInLabel && (
-          <Box as={Error} id={errorId} wrapper="span" error={error} fontWeight="400" />
-        )}
-        {optional && <OptionalLabel float />}
-      </Label>
+          {required && (
+            <Box as="span" pr="200" aria-hidden="true">
+              *
+            </Box>
+          )}
+          {error && errorInLabel && (
+            <Box as={Error} id={errorId} wrapper="span" error={error} fontWeight="400" />
+          )}
+          {optional && <OptionalLabel float />}
+        </Label>
+      ) : null}
       <Connect left={connectLeft} right={connectRight}>
         <Box position="relative">
           <PrefixOrSuffix content={prefix} className={prefixClassname} ref={prefixRef} left="300" />


### PR DESCRIPTION
Closes #810

### What Changed
- Removes the check in the Label component that returns `null` if no `label` is provided
- Deprecates `label`
- Updates components that use `Label`
- Installs react-testing-library
- Refactor a few tests

### How To Test or Verify
- Run libby, and visit the following component pages to verify Label works as expected:
- TextField
- Select
- Checkbox
- Radio
- ListBox
- ComboBox

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
