### PR TITLE
Resolves #811 Support Label htmlFor

### DIFF
--- a/packages/matchbox/src/components/Label/Label.js
+++ b/packages/matchbox/src/components/Label/Label.js
@@ -53,7 +53,7 @@ Label.displayName = 'Label';
 Label.propTypes = {
   label: deprecate(PropTypes.string, 'Use the children instead'),
   children: PropTypes.node,
-  id: PropTypes.string.isRequired,
+  id: PropTypes.string,
   htmlFor: PropTypes.string,
 };
 

--- a/packages/matchbox/src/components/Label/Label.js
+++ b/packages/matchbox/src/components/Label/Label.js
@@ -9,6 +9,7 @@ function Label(props) {
   const {
     label,
     id,
+    htmlFor,
     className,
     children,
     labelHidden,
@@ -32,8 +33,8 @@ function Label(props) {
     <Box
       display="block"
       as={as}
-      id={id && `${id}Label`}
-      htmlFor={id}
+      id={id && !htmlFor ? `${id}Label` : id}
+      htmlFor={htmlFor ? htmlFor : id}
       fontWeight={fontWeight}
       className={className}
       mb={mb}
@@ -51,6 +52,9 @@ function Label(props) {
 Label.displayName = 'Label';
 Label.propTypes = {
   label: deprecate(PropTypes.string, 'Use the children instead'),
+  children: PropTypes.node,
+  id: PropTypes.string.isRequired,
+  htmlFor: PropTypes.string,
 };
 
 export default Label;

--- a/packages/matchbox/src/components/Label/tests/Label.test.js
+++ b/packages/matchbox/src/components/Label/tests/Label.test.js
@@ -19,9 +19,10 @@ describe('Label', () => {
       expect(subject.getByText('children text')).toBeTruthy();
     });
 
-    it('renders correctly with id', () => {
+    it('renders correctly with id without htmlFor', () => {
       render(<Label id="label1" label="Label text"></Label>);
       expect(within(document.querySelector('#label1Label')).getByText('Label text')).toBeTruthy();
+      expect(within(document.querySelector('[for="label1"]')).getByText('Label text')).toBeTruthy();
     });
 
     it('renders correctly with className', () => {
@@ -56,5 +57,11 @@ describe('Label', () => {
       </Label>,
     );
     expect(within(document.querySelector('#label1Label')).getByText('Label text')).toBeTruthy();
+  });
+
+  it('renders correctly id and htmlFor correctly when both are provided', () => {
+    render(<Label id="id" label="Label text" htmlFor="for"></Label>);
+    expect(within(document.querySelector('#id')).getByText('Label text')).toBeTruthy();
+    expect(within(document.querySelector('[for="for"]')).getByText('Label text')).toBeTruthy();
   });
 });


### PR DESCRIPTION
Closes #811 

### What Changed
- Passes through `htmlFor` and `id` if both is provided
- Defaults to old behavior if only `id` is provided

### How To Test or Verify
- Verify tests pass, we thoroughly test if ids are working properly through tests

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
