### PR TITLE
UX-491 Pass through data-id to all Skeletons, Prevent rendering children

### DIFF
--- a/config/test-utils.js
+++ b/config/test-utils.js
@@ -1,6 +1,6 @@
 // // react-testing-library setup
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, configure } from '@testing-library/react';
 import ThemeProvider from '../packages/matchbox/src/components/ThemeProvider/ThemeProvider';
 
 function Wrapper({ children }) {
@@ -10,6 +10,11 @@ function Wrapper({ children }) {
 function customRender(ui, options) {
   return render(ui, { wrapper: Wrapper, ...options });
 }
+
+// React testing library configuration
+configure({
+  testIdAttribute: 'data-id', // Overriding the default test ID used by `getByTestId` matcher
+});
 
 // re-export everything
 export * from '@testing-library/react';

--- a/libby/feedback/Skeleton.lib.js
+++ b/libby/feedback/Skeleton.lib.js
@@ -5,7 +5,7 @@ import { Skeleton, Stack, Panel } from '@sparkpost/matchbox';
 describe('Skeleton', () => {
   add('heading', () => (
     <Stack>
-      <Skeleton.Header looksLike="h1" />
+      <Skeleton.Header looksLike="h1" data-id="test-id" />
       <Skeleton.Header looksLike="h2" />
       <Skeleton.Header looksLike="h3" />
       <Skeleton.Header looksLike="h4" />
@@ -16,13 +16,13 @@ describe('Skeleton', () => {
 
   add('box', () => (
     <Stack>
-      <Skeleton.Box size="5rem" />
+      <Skeleton.Box size="5rem" data-id="test-id" />
       <Skeleton.Box width="20rem" height="8rem" />
       <Skeleton.Box size="7rem" borderRadius="circle" />
     </Stack>
   ));
 
-  add('body', () => <Skeleton.Body />);
+  add('body', () => <Skeleton.Body data-id="test-id" />);
 
   add('all together', () => (
     <div id="test">

--- a/packages/matchbox/src/components/Skeleton/Skeleton.js
+++ b/packages/matchbox/src/components/Skeleton/Skeleton.js
@@ -30,7 +30,7 @@ export const Animator = styled(Box)`
 `;
 
 const SkeletonHeader = React.forwardRef(function SkeletonHeader(props, ref) {
-  const { looksLike, width } = props;
+  const { 'data-id': dataId, looksLike, width } = props;
   const delay = React.useMemo(() => `${Math.random() / 2}s`, []);
 
   const size = React.useMemo(() => {
@@ -53,7 +53,7 @@ const SkeletonHeader = React.forwardRef(function SkeletonHeader(props, ref) {
   }, [looksLike]);
 
   return (
-    <Box ref={ref} tabIndex="-1" aria-hidden="true">
+    <Box ref={ref} tabIndex="-1" aria-hidden="true" data-id={dataId}>
       <Animator
         borderRadius="200"
         delay={delay}
@@ -66,6 +66,7 @@ const SkeletonHeader = React.forwardRef(function SkeletonHeader(props, ref) {
 
 SkeletonHeader.displayName = 'Skeleton.Header';
 SkeletonHeader.propTypes = {
+  'data-id': Proptypes.string,
   looksLike: Proptypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']),
   width: Proptypes.string,
 };
@@ -75,7 +76,7 @@ SkeletonHeader.defaultProps = {
 };
 
 const SkeletonBody = React.forwardRef(function SkeletonBody(props, ref) {
-  const { lines } = props;
+  const { 'data-id': dataId, lines } = props;
 
   const body = React.useMemo(() => {
     const arr = [];
@@ -94,7 +95,7 @@ const SkeletonBody = React.forwardRef(function SkeletonBody(props, ref) {
   }, [lines]);
 
   return (
-    <Box ref={ref} mt="100" tabIndex="-1" aria-hidden="true">
+    <Box ref={ref} mt="100" tabIndex="-1" aria-hidden="true" data-id={dataId}>
       <Stack space="300">{body}</Stack>
     </Box>
   );
@@ -102,6 +103,7 @@ const SkeletonBody = React.forwardRef(function SkeletonBody(props, ref) {
 
 SkeletonBody.displayName = 'Skeleton.Body';
 SkeletonBody.propTypes = {
+  'data-id': Proptypes.string,
   lines: Proptypes.number,
 };
 SkeletonBody.defaultProps = {
@@ -109,16 +111,19 @@ SkeletonBody.defaultProps = {
 };
 
 const SkeletonBox = React.forwardRef(function SkeletonBox(props, ref) {
+  const { 'data-id': dataId, children, ...rest } = props;
+
   const delay = React.useMemo(() => `${Math.random() / 2}s`, []);
   return (
-    <Box ref={ref} tabIndex="-1" aria-hidden="true">
-      <Animator borderRadius="200" delay={delay} {...props} />
+    <Box ref={ref} tabIndex="-1" aria-hidden="true" data-id={dataId}>
+      <Animator borderRadius="200" delay={delay} {...rest} />
     </Box>
   );
 });
 
 SkeletonBox.displayName = 'Skeleton.Box';
 SkeletonBox.propTypes = {
+  'data-id': Proptypes.string,
   ...Box.propTypes,
 };
 

--- a/packages/matchbox/src/components/Skeleton/tests/Skeleton.test.js
+++ b/packages/matchbox/src/components/Skeleton/tests/Skeleton.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import cases from 'jest-in-case';
 import Skeleton, { Animator } from '../Skeleton';
+import { render } from 'test-utils';
 
 describe('Skeleton', () => {
   const Header = props => global.mountStyled(<Skeleton.Header {...props} />);
@@ -37,6 +38,16 @@ describe('Skeleton', () => {
       },
       sizes,
     );
+
+    it('should render with data-id', () => {
+      const { getByTestId } = render(<Skeleton.Header data-id="test-id" />);
+      expect(getByTestId('test-id')).toBeTruthy();
+    });
+
+    it('should not render children', () => {
+      const { queryByText } = render(<Skeleton.Header>test</Skeleton.Header>);
+      expect(queryByText('test')).toBeFalsy();
+    });
   });
 
   describe('Base Skeleton', () => {
@@ -44,6 +55,16 @@ describe('Skeleton', () => {
       const wrapper = Box({ size: '20px' });
       expect(wrapper.find('div').at(1)).toHaveStyleRule('width', '20px');
       expect(wrapper.find('div').at(1)).toHaveStyleRule('height', '20px');
+    });
+
+    it('should render with data-id', () => {
+      const { getByTestId } = render(<Skeleton.Box data-id="test-id" />);
+      expect(getByTestId('test-id')).toBeTruthy();
+    });
+
+    it('should not render children', () => {
+      const { queryByText } = render(<Skeleton.Box>test</Skeleton.Box>);
+      expect(queryByText('test')).toBeFalsy();
     });
   });
 
@@ -57,6 +78,16 @@ describe('Skeleton', () => {
       const wrapper = Body({ lines: 5 });
       expect(wrapper.find(Animator)).toHaveLength(5);
       expect(wrapper.find(Animator).last()).toHaveStyleRule('width', '70%');
+    });
+
+    it('should render with data-id', () => {
+      const { getByTestId } = render(<Skeleton.Body data-id="test-id" />);
+      expect(getByTestId('test-id')).toBeTruthy();
+    });
+
+    it('should not render children', () => {
+      const { queryByText } = render(<Skeleton.Body>test</Skeleton.Body>);
+      expect(queryByText('test')).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
### What Changed
- Passes through `data-id` to all Skeleton components
- Prevents `children` from being passed down to Skeleton.Box

### How To Test or Verify
- Run libby
- Visit the skeleton stories: http://localhost:9001/?path=Skeleton__body&source=false
- Verify `data-id` is passed along to the DOM

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
