### PR TITLE
Resolves #820 Fix button loader colors

### DIFF
--- a/libby/action/Button.lib.js
+++ b/libby/action/Button.lib.js
@@ -97,13 +97,13 @@ describe('Button', () => {
       <Box display="flex" justifyContent="space-between">
         <Stack>
           <Button loading>Button</Button>
-          <Button loading flat>
+          <Button loading variant="text">
             Flat
           </Button>
-          <Button loading outlineBorder>
+          <Button loading variant="outline">
             Outline Border
           </Button>
-          <Button loading outline>
+          <Button loading variant="mutedOutline">
             Outline
           </Button>
         </Stack>
@@ -112,13 +112,13 @@ describe('Button', () => {
           <Button loading color="red">
             Button
           </Button>
-          <Button loading color="red" flat>
+          <Button loading color="red" variant="text">
             Flat
           </Button>
-          <Button loading color="red" outlineBorder>
+          <Button loading color="red" variant="outline">
             Outline Border
           </Button>
-          <Button loading color="red" outline>
+          <Button loading color="red" variant="mutedOutline">
             Outline
           </Button>
         </Stack>
@@ -127,13 +127,13 @@ describe('Button', () => {
           <Button loading color="blue">
             Button
           </Button>
-          <Button loading color="blue" flat>
+          <Button loading color="blue" variant="text">
             Flat
           </Button>
-          <Button loading color="blue" outlineBorder>
+          <Button loading color="blue" variant="outline">
             Outline Border
           </Button>
-          <Button loading color="blue" outline>
+          <Button loading color="blue" variant="mutedOutline">
             Outline
           </Button>
         </Stack>
@@ -143,13 +143,13 @@ describe('Button', () => {
             <Button loading color="white">
               Button
             </Button>
-            <Button loading color="white" flat>
+            <Button loading color="white" variant="text">
               Flat
             </Button>
-            <Button loading color="white" outlineBorder>
+            <Button loading color="white" variant="outline">
               Outline Border
             </Button>
-            <Button loading color="white" outline>
+            <Button loading color="white" variant="mutedOutline">
               Outline
             </Button>
           </Stack>

--- a/packages/matchbox/src/components/Button/Button.js
+++ b/packages/matchbox/src/components/Button/Button.js
@@ -7,6 +7,7 @@ import { margin, width, padding, compose } from 'styled-system';
 import { createPropTypes } from '@styled-system/prop-types';
 import { omit } from '@styled-system/props';
 import { pick, clean } from '../../helpers/props';
+import { getLoaderColor } from './utils';
 import { Box } from '../Box';
 import { Spinner } from '../Spinner';
 import Icon from './Icon';
@@ -44,7 +45,7 @@ const ChildWrapper = styled.span.withConfig(clean(['loading']))`
 `;
 
 // Handles deprecated button variant props
-// TODO Remove in 5.0
+// TODO Remove in 6.0
 function getVariant({ outline, outlineBorder, plain, flat, variant }) {
   if (variant) {
     return variant;
@@ -122,25 +123,16 @@ const Button = React.forwardRef(function Button(props, ref) {
     return getVariant({ variant, outline, outlineBorder, plain, flat });
   }, [variant, outline, outlineBorder, plain, flat, getVariant]);
 
-  const isSolid = !outline && !outlineBorder && !plain && !flat;
+  const loaderColor = React.useMemo(() => {
+    return getLoaderColor({ variant: buttonVariant, color });
+  }, [buttonVariant, color]);
 
   const loadingIndicator = React.useMemo(() => {
     return (
       <Transition mountOnEnter unmountOnExit in={loading} timeout={0} nodeRef={transitionRef}>
         {state => (
           <StyledLoader state={state} ref={transitionRef}>
-            <Spinner
-              color={
-                isSolid && color === 'white'
-                  ? 'gray'
-                  : isSolid || color === 'white'
-                  ? 'white'
-                  : 'gray'
-              }
-              size="small"
-              label={loadingLabel}
-              rotationOnly
-            />
+            <Spinner color={loaderColor} size="small" label={loadingLabel} rotationOnly />
           </StyledLoader>
         )}
       </Transition>

--- a/packages/matchbox/src/components/Button/tests/utils.test.js
+++ b/packages/matchbox/src/components/Button/tests/utils.test.js
@@ -1,23 +1,26 @@
 import React from 'react';
-import { buttonFrom, buttonsFrom } from '../utils';
+import { buttonFrom, buttonsFrom, getLoaderColor } from '../utils';
 
 describe('Button Utils', () => {
-
   describe('buttonFrom', () => {
     it('renders correctly', () => {
-      expect(buttonFrom({ content: <span>button content</span>, disabled: false })).toMatchSnapshot();
+      expect(
+        buttonFrom({ content: <span>button content</span>, disabled: false }),
+      ).toMatchSnapshot();
     });
 
     it('passes any custom overrides', () => {
-      expect(buttonFrom({ content: <span>button content</span> }, { foo: 'bar', type: 'submit' })).toMatchSnapshot();
+      expect(
+        buttonFrom({ content: <span>button content</span> }, { foo: 'bar', type: 'submit' }),
+      ).toMatchSnapshot();
     });
   });
 
   describe('buttonsFrom', () => {
     it('renders correctly', () => {
       const actions = [
-        { content: <span>button 1 content</span>, action: { content: <span>foo</span> }},
-        { content: <span>button 2 content</span>, action: {}}
+        { content: <span>button 1 content</span>, action: { content: <span>foo</span> } },
+        { content: <span>button 2 content</span>, action: {} },
       ];
 
       expect(buttonsFrom(actions)).toMatchSnapshot();
@@ -26,6 +29,47 @@ describe('Button Utils', () => {
     it('returns nothing without actions', () => {
       const actions = [];
       expect(buttonsFrom(actions)).toBe(undefined);
+    });
+  });
+
+  describe('getLoaderColor', () => {
+    it('returns gray for a default button', () => {
+      expect(getLoaderColor()).toEqual('white');
+    });
+
+    it('returns white if variant is filled', () => {
+      expect(getLoaderColor({ variant: 'filled' })).toEqual('white');
+      expect(getLoaderColor({ variant: 'filled', color: 'blue' })).toEqual('white');
+      expect(getLoaderColor({ variant: 'filled', color: 'gray' })).toEqual('white');
+      expect(getLoaderColor({ variant: 'filled', color: 'red' })).toEqual('white');
+    });
+
+    it('returns white if variant is not filled and color is white', () => {
+      expect(getLoaderColor({ variant: 'outline', color: 'white' })).toEqual('white');
+      expect(getLoaderColor({ variant: 'mutedOutline', color: 'white' })).toEqual('white');
+      expect(getLoaderColor({ variant: 'text', color: 'white' })).toEqual('white');
+    });
+
+    it('returns gray if variant is filled but color is white', () => {
+      expect(getLoaderColor({ variant: 'filled', color: 'white' })).toEqual('gray');
+    });
+
+    it('returns blue if variant is outline, mutedOutline, or text for a blue button', () => {
+      expect(getLoaderColor({ variant: 'outline', color: 'blue' })).toEqual('blue');
+      expect(getLoaderColor({ variant: 'mutedOutline', color: 'blue' })).toEqual('blue');
+      expect(getLoaderColor({ variant: 'text', color: 'blue' })).toEqual('blue');
+    });
+
+    it('returns gray if variant is outline, mutedOutline, or text for a red and gray buttons', () => {
+      expect(getLoaderColor({ variant: 'outline', color: 'red' })).toEqual('gray');
+      expect(getLoaderColor({ variant: 'mutedOutline', color: 'red' })).toEqual('gray');
+      expect(getLoaderColor({ variant: 'text', color: 'red' })).toEqual('gray');
+      expect(getLoaderColor({ variant: 'outline', color: 'gray' })).toEqual('gray');
+      expect(getLoaderColor({ variant: 'mutedOutline', color: 'gray' })).toEqual('gray');
+      expect(getLoaderColor({ variant: 'text', color: 'gray' })).toEqual('gray');
+      expect(getLoaderColor({ variant: 'outline' })).toEqual('gray');
+      expect(getLoaderColor({ variant: 'mutedOutline' })).toEqual('gray');
+      expect(getLoaderColor({ variant: 'text' })).toEqual('gray');
     });
   });
 });

--- a/packages/matchbox/src/components/Button/utils.js
+++ b/packages/matchbox/src/components/Button/utils.js
@@ -15,11 +15,7 @@ export function buttonsFrom(actions, overrides) {
 }
 
 export function buttonFrom({ content, ...action }, overrides, key) {
-  return (
-    <Button key={key} {...action} {...overrides}>
-      {content}
-    </Button>
-  );
+  return <Button key={key} children={content} {...action} {...overrides} />; // eslint-disable-line
 }
 
 export function getLoaderColor({ variant = 'filled', color = 'gray' } = {}) {

--- a/packages/matchbox/src/components/Button/utils.js
+++ b/packages/matchbox/src/components/Button/utils.js
@@ -6,17 +6,38 @@ export function buttonsFrom(actions, overrides) {
   const filteredActions = filterByVisible(actions);
 
   if (filteredActions.length) {
-    return <Button.Group>{filteredActions.map((action, key) => buttonFrom(action, overrides, key))}</Button.Group>;
+    return (
+      <Button.Group>
+        {filteredActions.map((action, key) => buttonFrom(action, overrides, key))}
+      </Button.Group>
+    );
   }
 }
 
 export function buttonFrom({ content, ...action }, overrides, key) {
   return (
-    <Button
-      key={key}
-      children={content}
-      {...action}
-      {...overrides}
-    />
+    <Button key={key} {...action} {...overrides}>
+      {content}
+    </Button>
   );
+}
+
+export function getLoaderColor({ variant = 'filled', color = 'gray' } = {}) {
+  if (variant === 'filled') {
+    if (color === 'white') {
+      return 'gray';
+    }
+
+    return 'white';
+  }
+
+  if (color === 'white') {
+    return 'white';
+  }
+
+  if (color === 'blue') {
+    return 'blue';
+  }
+
+  return 'gray';
 }


### PR DESCRIPTION
Closes #820

### What Changed
- Fixes Button loader colors for non-filled buttons

### How To Test or Verify
- Run libby, visit http://localhost:9001/?path=Button__loading&source=false
- Verify the loading `Spinner`s are visible and use the right colors

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
