### PR TITLE
UX-502 Add name id and data attributes to hidden field in Listbox

### DIFF
--- a/cypress/integration/ListBox.spec.js
+++ b/cypress/integration/ListBox.spec.js
@@ -70,7 +70,7 @@ describe('The ListBox component', () => {
     it('tabs through properly without opening', () => {
       cy.wait(100);
       cy.get('body').tab();
-      cy.focused().should('have.attr', 'id', 'listbox-1');
+      cy.focused().should('have.attr', 'id', 'listbox-1LabelButton');
       cy.focused().tab();
       cy.focused().should('have.text', 'end focus test');
     });

--- a/libby/form/ListBox.lib.js
+++ b/libby/form/ListBox.lib.js
@@ -10,6 +10,8 @@ describe('ListBox', () => {
       defaultValue="option-1"
       label="Select an option"
       onChange={e => console.log(e)}
+      onFocus={() => console.log('focus')}
+      onBlur={() => console.log('blur')}
     >
       <ListBox.Option value="option-1">Option 1</ListBox.Option>
       <ListBox.Option value="option-2">Option 2</ListBox.Option>

--- a/packages/matchbox/src/components/ListBox/ListBox.js
+++ b/packages/matchbox/src/components/ListBox/ListBox.js
@@ -41,7 +41,7 @@ const StyledButton = styled(Button)`
   border: ${props =>
     props.hasError ? `1px solid ${props.theme.colors.red[700]}` : `${props.theme.borders[400]}`};
   &:hover {
-    background: ${props => (props.disabled ? props.theme.colors.gray['200'] : 'white')};
+    background: ${props => (props.disabled ? props.theme.colors.gray['200'] : 'transparent')};
   }
   ${focusOutline()}
 `;

--- a/packages/matchbox/src/components/ListBox/ListBox.js
+++ b/packages/matchbox/src/components/ListBox/ListBox.js
@@ -41,7 +41,7 @@ const StyledButton = styled(Button)`
   border: ${props =>
     props.hasError ? `1px solid ${props.theme.colors.red[700]}` : `${props.theme.borders[400]}`};
   &:hover {
-    background: ${props => (props.disabled ? props.theme.colors.gray['200'] : 'transparent')};
+    background: ${props => (props.disabled ? props.theme.colors.gray['200'] : 'white')};
   }
   ${focusOutline()}
 `;
@@ -65,6 +65,7 @@ const ListBox = React.forwardRef(function ListBox(props, userRef) {
   const {
     children,
     'data-id': dataId,
+    'data-sensitive': dataSensitive,
     placeholder,
     disabled,
     id,
@@ -78,6 +79,8 @@ const ListBox = React.forwardRef(function ListBox(props, userRef) {
     defaultValue,
     value,
     onChange,
+    onFocus,
+    onBlur,
     name,
     ...rest
   } = props;
@@ -115,6 +118,7 @@ const ListBox = React.forwardRef(function ListBox(props, userRef) {
   function onSelect(value) {
     if (onChange) {
       // This is a fake event, because buttons do not inherently have a change event
+      // onChange does not work on hidden inputs
       onChange({
         currentTarget: {
           value,
@@ -127,6 +131,11 @@ const ListBox = React.forwardRef(function ListBox(props, userRef) {
 
     // Returns focus to the button when closing the popover
     buttonRef.current.focus();
+
+    // Calls user's blur method
+    if (onBlur) {
+      onBlur();
+    }
   }
 
   const contentFromValue = React.useMemo(() => {
@@ -139,7 +148,7 @@ const ListBox = React.forwardRef(function ListBox(props, userRef) {
   }, [currentValue]);
 
   const labelMarkup = (
-    <Label id={id} labelHidden={labelHidden}>
+    <Label id={`${id}Label`} htmlFor={`${id}LabelButton`} labelHidden={labelHidden}>
       <Box as="span" pr="200">
         {label}
       </Box>
@@ -183,7 +192,7 @@ const ListBox = React.forwardRef(function ListBox(props, userRef) {
   }
 
   return (
-    <StyledWrapper data-id={dataId} tabIndex="-1" {...systemProps} {...focusContainerProps}>
+    <StyledWrapper tabIndex="-1" {...systemProps} {...focusContainerProps}>
       {labelMarkup}
       <Popover
         id="listbox-popover"
@@ -195,7 +204,7 @@ const ListBox = React.forwardRef(function ListBox(props, userRef) {
         trigger={
           <Box position="relative">
             <ListBoxButton
-              id={id}
+              id={`${id}LabelButton`}
               data-id="open-listbox"
               textAlign="left"
               fullWidth
@@ -205,6 +214,7 @@ const ListBox = React.forwardRef(function ListBox(props, userRef) {
               aria-pressed={open}
               aria-expanded={open}
               onClick={togglePopover}
+              onFocus={onFocus}
               onKeyDown={activatorKeyDown}
               disabled={disabled}
               hasError={!!error}
@@ -231,7 +241,14 @@ const ListBox = React.forwardRef(function ListBox(props, userRef) {
       </Popover>
       {helpMarkup}
       {error && !errorInLabel && <Error id={errorId} error={error} />}
-      <input type="hidden" name={name} value={currentValue} />
+      <input
+        id={id}
+        type="hidden"
+        name={name}
+        value={currentValue}
+        data-id={dataId}
+        data-sensitive={dataSensitive}
+      />
     </StyledWrapper>
   );
 });
@@ -239,6 +256,7 @@ const ListBox = React.forwardRef(function ListBox(props, userRef) {
 ListBox.displayName = 'ListBox';
 ListBox.propTypes = {
   'data-id': PropTypes.string,
+  'data-sensitive': PropTypes.string,
   placeholder: PropTypes.string,
   id: PropTypes.string,
   label: PropTypes.string,

--- a/packages/matchbox/src/components/ListBox/tests/ListBox.test.js
+++ b/packages/matchbox/src/components/ListBox/tests/ListBox.test.js
@@ -27,8 +27,14 @@ describe('Select', () => {
 
   it('should render with id', () => {
     const wrapper = subject({ id: 'test-id', label: 'test-label' });
-    expect(wrapper.find('label')).toHaveAttributeValue('for', 'test-id');
-    expect(wrapper.find('button')).toHaveAttributeValue('id', 'test-id');
+    expect(wrapper.find('label')).toHaveAttributeValue('for', 'test-idLabelButton');
+    expect(wrapper.find('button')).toHaveAttributeValue('id', 'test-idLabelButton');
+    expect(wrapper.find('input')).toHaveAttributeValue('id', 'test-id');
+  });
+
+  it('should render with name', () => {
+    const wrapper = subject({ name: 'test-name' });
+    expect(wrapper.find('input')).toHaveAttributeValue('name', 'test-name');
   });
 
   it('should render with help text', () => {


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed
- Passes through `id` `name` `data-id` and `data-sensitive` to Listbox's hidden input
- Fixes the `onFocus` and `onBlur` events

### How To Test or Verify

<!--
Describe any steps that may help reviewers verify changes.
Anything beyond basic unit testing, such as assistive tech usage, or special interactions.
-->

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
