### PR TITLE
UX-503 Adds new `align` prop to Cell and HeaderCell

### DIFF
--- a/libby/layout/Table.lib.js
+++ b/libby/layout/Table.lib.js
@@ -27,7 +27,7 @@ describe('Table', () => {
             <Table.HeaderCell>
               <Table.SortButton direction="asc">Heading 1</Table.SortButton>
             </Table.HeaderCell>
-            <Table.HeaderCell>
+            <Table.HeaderCell align="right">
               <Table.SortButton direction="desc">Heading 2</Table.SortButton>
             </Table.HeaderCell>
             <Table.HeaderCell>
@@ -41,7 +41,7 @@ describe('Table', () => {
         <tbody>
           <Table.Row>
             <Table.Cell>1</Table.Cell>
-            <Table.Cell>2</Table.Cell>
+            <Table.Cell align="right">2</Table.Cell>
             <Table.Cell>3</Table.Cell>
             <Table.Cell>4</Table.Cell>
           </Table.Row>

--- a/packages/matchbox/src/components/Table/SortButton.js
+++ b/packages/matchbox/src/components/Table/SortButton.js
@@ -82,7 +82,7 @@ function Unsorted() {
 }
 
 const SortButton = React.forwardRef(function SortButton(props, userRef) {
-  const { align, children, direction, onClick, onFocus, onBlur } = props;
+  const { children, direction, onClick, onFocus, onBlur } = props;
 
   const Icon = React.useMemo(() => {
     if (direction === 'asc') {
@@ -102,7 +102,6 @@ const SortButton = React.forwardRef(function SortButton(props, userRef) {
 
   return (
     <Button
-      align={align}
       onClick={onClick}
       onFocus={onFocus}
       onBlur={onBlur}
@@ -120,7 +119,6 @@ const SortButton = React.forwardRef(function SortButton(props, userRef) {
 
 SortButton.displayName = 'Table.SortButton';
 SortButton.propTypes = {
-  align: PropTypes.oneOf(['left', 'right', 'center', undefined]),
   children: PropTypes.node,
   direction: PropTypes.oneOf(['asc', 'desc', undefined]),
   onBlur: PropTypes.func,

--- a/packages/matchbox/src/components/Table/SortButton.js
+++ b/packages/matchbox/src/components/Table/SortButton.js
@@ -7,10 +7,7 @@ import { focusOutline, buttonReset } from '../../styles/helpers';
 const Button = styled.button`
   ${buttonReset}
   ${focusOutline()}
-  
-  display: flex;
-  align-items: flex-end;
-  text-align: left;
+  display: inline-block;
   cursor: pointer;
 
   ${({ theme }) => `
@@ -85,7 +82,7 @@ function Unsorted() {
 }
 
 const SortButton = React.forwardRef(function SortButton(props, userRef) {
-  const { children, direction, onClick, onFocus, onBlur } = props;
+  const { align, children, direction, onClick, onFocus, onBlur } = props;
 
   const Icon = React.useMemo(() => {
     if (direction === 'asc') {
@@ -105,6 +102,7 @@ const SortButton = React.forwardRef(function SortButton(props, userRef) {
 
   return (
     <Button
+      align={align}
       onClick={onClick}
       onFocus={onFocus}
       onBlur={onBlur}
@@ -122,8 +120,9 @@ const SortButton = React.forwardRef(function SortButton(props, userRef) {
 
 SortButton.displayName = 'Table.SortButton';
 SortButton.propTypes = {
+  align: PropTypes.oneOf(['left', 'right', 'center', undefined]),
   children: PropTypes.node,
-  direction: PropTypes.oneOf(['asc', 'desc', null, undefined]),
+  direction: PropTypes.oneOf(['asc', 'desc', undefined]),
   onBlur: PropTypes.func,
   onClick: PropTypes.func,
   onFocus: PropTypes.func,

--- a/packages/matchbox/src/components/Table/TableElements.js
+++ b/packages/matchbox/src/components/Table/TableElements.js
@@ -58,6 +58,7 @@ const Cell = React.forwardRef(function Cell(
 });
 
 Cell.propTypes = {
+  align: PropTypes.oneOf(['right', 'center', 'left', undefined]),
   value: PropTypes.node,
   className: PropTypes.string,
   children: PropTypes.node,
@@ -107,6 +108,7 @@ const HeaderCell = React.forwardRef(function HeaderCell(
 
 HeaderCell.propTypes = {
   'aria-sort': PropTypes.string,
+  align: PropTypes.oneOf(['right', 'center', 'left', undefined]),
   value: PropTypes.node,
   className: PropTypes.string,
   children: PropTypes.node,

--- a/packages/matchbox/src/components/Table/TableElements.js
+++ b/packages/matchbox/src/components/Table/TableElements.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { cell, row, headerCell, totalsRow, verticalAlignment } from './styles';
+import { cell, row, headerCell, totalsRow, verticalAlignment, horizontalAlignment } from './styles';
 import { TablePaddingContext } from './context';
 import { padding, fontSize, width, compose } from 'styled-system';
 import { createPropTypes } from '@styled-system/prop-types';
@@ -11,12 +11,14 @@ const cellSystem = compose(padding, fontSize, width);
 const StyledCell = styled('td')`
   ${cell}
   ${cellSystem}
+  ${horizontalAlignment}
 `;
 
 const headerSystem = compose(padding, width);
 const StyledHeaderCell = styled('th')`
   ${headerCell}
   ${headerSystem}
+  ${horizontalAlignment}
 `;
 
 const StyledRow = styled('tr')`
@@ -31,7 +33,7 @@ const StyledTotalsRow = styled('tr')`
 `;
 
 const Cell = React.forwardRef(function Cell(
-  { value, children, className, colSpan, role, rowSpan, style, width, ...rest },
+  { align, value, children, className, colSpan, role, rowSpan, style, width, ...rest },
   userRef,
 ) {
   const paddingContext = React.useContext(TablePaddingContext);
@@ -40,6 +42,7 @@ const Cell = React.forwardRef(function Cell(
     <StyledCell
       {...paddingContext}
       {...paddingProps}
+      align={align}
       className={className}
       fontSize={['200', null, '300']}
       colSpan={colSpan}
@@ -69,6 +72,7 @@ Cell.displayName = 'Table.Cell';
 
 const HeaderCell = React.forwardRef(function HeaderCell(
   {
+    align,
     'aria-sort': ariaSort,
     value,
     children,
@@ -85,6 +89,7 @@ const HeaderCell = React.forwardRef(function HeaderCell(
   return (
     <StyledHeaderCell
       p="450"
+      align={align}
       aria-sort={ariaSort}
       className={className}
       colSpan={colSpan}

--- a/packages/matchbox/src/components/Table/styles.js
+++ b/packages/matchbox/src/components/Table/styles.js
@@ -81,6 +81,17 @@ export const verticalAlignment = system({
   },
 });
 
+export const horizontalAlignment = system({
+  align: {
+    property: 'textAlign',
+    defaultScale: {
+      center: 'center',
+      left: 'left',
+      right: 'right',
+    },
+  },
+});
+
 export const wrapper = ({ freezeFirstColumn }) => `
    ${freezeFirstColumn ? 'overflow: auto;' : ''}
 `;


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed
- Removes the flex declaration that prevented SortButtons from being horizontally aligned
- Adds new `align` prop to Cell and HeaderCell (wrapper around textAlign)

### How To Test or Verify

- Run libby
- Visit http://localhost:9001/?path=Table__all-table-components&source=false
- Verify text align prop works

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
