### PR TITLE
UX-510 Fix Popover activators being focused by default

### DIFF
--- a/cypress/integration/Popover.spec.js
+++ b/cypress/integration/Popover.spec.js
@@ -22,7 +22,6 @@ describe('Controlled Popover component', () => {
       cy.get('[data-id="popover-content"]').should('be.visible');
       cy.get('html').click(100, 300);
       cy.get('[data-id="popover-content"]').should('not.exist');
-      cy.focused().should('have.text', 'Open Me');
     });
 
     it('should close when pressing the escape key', () => {
@@ -36,7 +35,7 @@ describe('Controlled Popover component', () => {
       cy.get('[data-id="popover-content"]').should('be.visible');
       cy.get('[data-id="close-button"]').click();
       cy.get('[data-id="popover-content"]').should('not.exist');
-      cy.focused().should('have.text', 'Open Me');
+      // cy.focused().should('have.text', 'Open Me');
     });
   });
 });
@@ -76,7 +75,6 @@ describe('Uncontrolled Popover with Actionlist', () => {
     cy.get('[data-id="popover-content"]').should('be.visible');
     cy.get('html').click(100, 600);
     cy.get('[data-id="popover-content"]').should('not.exist');
-    cy.focused().should('have.text', 'More Actions');
   });
 
   it('should close when pressing the escape key', () => {

--- a/cypress/integration/Popover.spec.js
+++ b/cypress/integration/Popover.spec.js
@@ -4,6 +4,7 @@ describe('Controlled Popover component', () => {
   });
 
   it('should open when clicking the trigger', () => {
+    cy.focused().should('not.exist');
     cy.get('button')
       .first()
       .click();
@@ -47,6 +48,7 @@ describe('Uncontrolled Popover with Actionlist', () => {
   });
 
   it('should open when clicking the trigger', () => {
+    cy.focused().should('not.exist');
     cy.contains('More Actions').click();
     cy.get('[data-id="popover-content"]').should('be.visible');
   });

--- a/cypress/integration/Popover.spec.js
+++ b/cypress/integration/Popover.spec.js
@@ -35,7 +35,6 @@ describe('Controlled Popover component', () => {
       cy.get('[data-id="popover-content"]').should('be.visible');
       cy.get('[data-id="close-button"]').click();
       cy.get('[data-id="popover-content"]').should('not.exist');
-      // cy.focused().should('have.text', 'Open Me');
     });
   });
 });

--- a/packages/matchbox/src/components/Popover/Popover.js
+++ b/packages/matchbox/src/components/Popover/Popover.js
@@ -10,14 +10,6 @@ import useWindowEvent from '../../hooks/useWindowEvent';
 import { deprecate } from '../../helpers/propTypes';
 import { findFocusableChild } from '../../helpers/focus';
 
-function usePrevious(value) {
-  const ref = React.useRef();
-  React.useEffect(() => {
-    ref.current = value;
-  });
-  return ref.current;
-}
-
 const Popover = React.forwardRef(function Popover(props, ref) {
   const { as, id, open: controlledOpen, onClose, children, trigger, wrapper, ...rest } = props;
   const [open, setOpen] = React.useState(null);
@@ -25,7 +17,6 @@ const Popover = React.forwardRef(function Popover(props, ref) {
   const activatorRef = React.useRef();
 
   const shouldBeOpen = controlledOpen || open;
-  const previousShouldBeOpen = usePrevious(shouldBeOpen);
   const Wrapper = as || wrapper || 'span';
 
   useWindowEvent('click', handleOutsideClick);
@@ -51,20 +42,14 @@ const Popover = React.forwardRef(function Popover(props, ref) {
     setOpen(!open);
   }
 
-  // Focus on activator element when closing
+  // Focus on activator element
+  // This is only called for when closing via keyboard
   function focusOnActivator() {
     if (activatorRef && activatorRef.current) {
       const activatorToFocus = findFocusableChild(activatorRef.current) || activatorRef.current;
       activatorToFocus.focus();
     }
   }
-
-  // Focuses on activator when open state closes
-  React.useLayoutEffect(() => {
-    if (!shouldBeOpen && !!previousShouldBeOpen) {
-      focusOnActivator();
-    }
-  }, [shouldBeOpen]);
 
   // Toggles uncontrolled popovers on clicking outside, and calls `onClose` for controlled popovers
   function handleOutsideClick(e) {
@@ -90,12 +75,14 @@ const Popover = React.forwardRef(function Popover(props, ref) {
     if (onClose && shouldBeOpen) {
       onKey('escape', () => {
         onClose(e);
+        focusOnActivator();
       })(e);
     }
 
     if (open) {
       onKey('escape', () => {
         handleUncontrolledToggle();
+        focusOnActivator();
       })(e);
     }
   }

--- a/packages/matchbox/src/components/Popover/Popover.js
+++ b/packages/matchbox/src/components/Popover/Popover.js
@@ -10,11 +10,20 @@ import useWindowEvent from '../../hooks/useWindowEvent';
 import { deprecate } from '../../helpers/propTypes';
 import { findFocusableChild } from '../../helpers/focus';
 
+export const useIsFirstRender = () => {
+  const isFirstRef = React.useRef(true);
+  React.useEffect(() => {
+    isFirstRef.current = false;
+  }, []);
+  return isFirstRef.current;
+};
+
 const Popover = React.forwardRef(function Popover(props, ref) {
   const { as, id, open: controlledOpen, onClose, children, trigger, wrapper, ...rest } = props;
   const [open, setOpen] = React.useState(null);
   const popoverRef = React.useRef();
   const activatorRef = React.useRef();
+  const isFirstRender = useIsFirstRender();
 
   const shouldBeOpen = controlledOpen || open;
   const Wrapper = as || wrapper || 'span';
@@ -53,10 +62,10 @@ const Popover = React.forwardRef(function Popover(props, ref) {
   // Focuses on activator when controlled open state closes ONLY
   React.useLayoutEffect(() => {
     // explicit false check to rule out uncontrolled open state
-    if (controlledOpen === false) {
+    if (controlledOpen === false && !isFirstRender) {
       focusOnActivator();
     }
-  }, [controlledOpen]);
+  }, [controlledOpen, isFirstRender]);
 
   // Toggles uncontrolled popovers on clicking outside, and calls `onClose` for controlled popovers
   function handleOutsideClick(e) {


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed
- Adjusts the initial incorrect implementation – activators shouldn't be focused when clicking outside

### How To Test or Verify
- Visit http://localhost:9001/?path=Popover__controlled&source=false
- The activator button should not be focused by default
- The activator button should only focus when pressing escape when open

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
