### PR TITLE
UX-511 Correctly pass through props to Toggle input

### DIFF
--- a/packages/matchbox/src/components/Toggle/Toggle.js
+++ b/packages/matchbox/src/components/Toggle/Toggle.js
@@ -5,6 +5,7 @@ import { margin } from 'styled-system';
 import { pick } from '@styled-system/props';
 import { createPropTypes } from '@styled-system/prop-types';
 import { visuallyHidden } from '../../styles/helpers';
+import { omit } from '../../helpers/props';
 import { deprecate } from '../../helpers/propTypes';
 import { ScreenReaderOnly } from '../ScreenReaderOnly';
 import { toggle, input, StyledIndicator, StyledOutline } from './styles';
@@ -36,6 +37,7 @@ function Toggle(props) {
     ...rest
   } = props;
   const systemProps = pick(rest);
+  const componentProps = omit(rest, margin.propNames);
 
   return (
     <StyledToggle htmlFor={id} disabled={disabled} {...systemProps}>
@@ -53,6 +55,7 @@ function Toggle(props) {
         type="checkbox"
         aria-describedby={ariaDescribedBy}
         data-id={dataId}
+        {...componentProps}
       />
       <StyledOutline checked={checked} />
       <StyledIndicator checked={checked} />

--- a/packages/matchbox/src/components/Toggle/tests/Toggle.test.js
+++ b/packages/matchbox/src/components/Toggle/tests/Toggle.test.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import Toggle from '../Toggle';
+import { render, within } from 'test-utils';
 import { tokens } from '@sparkpost/design-tokens';
 import { StyledOutline } from '../styles';
 
 describe('Toggle', () => {
   let wrapper;
 
-  let subject = props => global.mountStyled(<Toggle data-id="toggle-input" id="id" {...props} />);
+  let subject = props => global.mountStyled(<Toggle id="id" {...props} />);
 
   it('renders base styles', () => {
     wrapper = subject();
@@ -45,5 +46,12 @@ describe('Toggle', () => {
   it('renders label', () => {
     wrapper = subject({ label: 'test label' });
     expect(wrapper.text()).toEqual('test label');
+  });
+
+  it('renders attributes on the input correctly', () => {
+    const { getByTestId } = render(<Toggle data-id="test" data-testattribute="test" id="id" />);
+    expect(getByTestId('test')).toBeTruthy();
+    expect(within(document.querySelector('input#id'))).toBeTruthy();
+    expect(within(document.querySelector('input[data-testattribute="test"]'))).toBeTruthy();
   });
 });


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed
- Passes through unknown props to Toggle's input element

### How To Test or Verify
- Visit http://localhost:9001/?path=Toggle__renders-correctly&source=false
- Verify unknown props, like data attributes, are passed through

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
