### PR TITLE
UX-508 Remove visual indicator for required fields

### DIFF
--- a/packages/matchbox/src/components/Checkbox/Checkbox.js
+++ b/packages/matchbox/src/components/Checkbox/Checkbox.js
@@ -109,14 +109,7 @@ const Checkbox = React.forwardRef(function Checkbox(props, userRef) {
               fontWeight="400"
               mb="0" // TODO Remove once margin 0 is baked into Label
             >
-              <Box as="span" pr="200">
-                {label}
-              </Box>
-              {required && (
-                <Box as="span" pr="200" aria-hidden="true">
-                  *
-                </Box>
-              )}
+              {label}
             </Label>
           )}
         </Box>

--- a/packages/matchbox/src/components/Checkbox/tests/Checkbox.test.js
+++ b/packages/matchbox/src/components/Checkbox/tests/Checkbox.test.js
@@ -45,7 +45,7 @@ describe('Checkbox', () => {
 
   it('renders required', () => {
     const wrapper = subject({ required: true, label: 'test-label' });
-    expect(wrapper.text()).toEqual('test-label*');
+    expect(wrapper.text()).toEqual('test-label');
     expect(wrapper.find('input')).toHaveAttributeValue('required', '');
   });
 

--- a/packages/matchbox/src/components/ListBox/ListBox.js
+++ b/packages/matchbox/src/components/ListBox/ListBox.js
@@ -241,6 +241,7 @@ const ListBox = React.forwardRef(function ListBox(props, userRef) {
         value={currentValue}
         data-id={dataId}
         data-sensitive={dataSensitive}
+        required={required}
       />
     </StyledWrapper>
   );

--- a/packages/matchbox/src/components/ListBox/ListBox.js
+++ b/packages/matchbox/src/components/ListBox/ListBox.js
@@ -100,12 +100,6 @@ const ListBox = React.forwardRef(function ListBox(props, userRef) {
     hasError: !!error,
   });
 
-  const requiredIndicator = required ? (
-    <Box as="span" pr="200" aria-hidden="true">
-      *
-    </Box>
-  ) : null;
-
   function togglePopover(event) {
     event.stopPropagation();
     setOpen(!open);
@@ -152,7 +146,6 @@ const ListBox = React.forwardRef(function ListBox(props, userRef) {
       <Box as="span" pr="200">
         {label}
       </Box>
-      {requiredIndicator}
       {error && errorInLabel && (
         <Box as={Error} id={errorId} wrapper="span" error={error} fontWeight="400" />
       )}

--- a/packages/matchbox/src/components/ListBox/tests/ListBox.test.js
+++ b/packages/matchbox/src/components/ListBox/tests/ListBox.test.js
@@ -17,7 +17,8 @@ describe('Select', () => {
 
   it('should render with required label', () => {
     const wrapper = subject({ required: true, label: 'test-label' });
-    expect(wrapper.find('label').text()).toEqual('test-label*');
+    expect(wrapper.find('label').text()).toEqual('test-label');
+    expect(wrapper.find('input')).toHaveAttributeValue('required', '');
   });
 
   it('should render with optional label', () => {

--- a/packages/matchbox/src/components/Radio/Group.js
+++ b/packages/matchbox/src/components/Radio/Group.js
@@ -16,7 +16,7 @@ const StyledGroup = styled('fieldset')`
 `;
 
 function Group(props) {
-  const { children, label, labelHidden, required, optional, ...rest } = props;
+  const { children, label, labelHidden, optional, ...rest } = props;
   const systemProps = pick(rest);
 
   return (
@@ -27,11 +27,6 @@ function Group(props) {
             <Box as="span" pr="200">
               {label}
             </Box>
-            {required && (
-              <Box as="span" pr="200" aria-hidden="true">
-                *
-              </Box>
-            )}
             {optional && <OptionalLabel />}
           </Label>
         </Box>
@@ -45,7 +40,6 @@ Group.propTypes = {
   children: PropTypes.node.isRequired,
   label: PropTypes.node.isRequired,
   labelHidden: PropTypes.bool,
-  required: PropTypes.bool,
   optional: PropTypes.bool,
   ...createPropTypes(margin.propNames),
 };

--- a/packages/matchbox/src/components/Radio/Group.js
+++ b/packages/matchbox/src/components/Radio/Group.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Box } from '../Box';
 import { Label } from '../Label';
+import { ScreenReaderOnly } from '../ScreenReaderOnly';
 import { OptionalLabel } from '../OptionalLabel';
 import { Stack } from '../Stack';
 import { createPropTypes } from '@styled-system/prop-types';
@@ -16,16 +17,17 @@ const StyledGroup = styled('fieldset')`
 `;
 
 function Group(props) {
-  const { children, label, labelHidden, optional, ...rest } = props;
+  const { children, label, labelHidden, required, optional, ...rest } = props;
   const systemProps = pick(rest);
 
   return (
-    <StyledGroup {...systemProps}>
+    <StyledGroup {...systemProps} aria-required={required}>
       {label && (
         <Box width="100%">
           <Label as="legend" labelHidden={labelHidden}>
             <Box as="span" pr="200">
               {label}
+              {required && <ScreenReaderOnly>Required</ScreenReaderOnly>}
             </Box>
             {optional && <OptionalLabel />}
           </Label>
@@ -41,6 +43,7 @@ Group.propTypes = {
   label: PropTypes.node.isRequired,
   labelHidden: PropTypes.bool,
   optional: PropTypes.bool,
+  required: PropTypes.bool,
   ...createPropTypes(margin.propNames),
 };
 

--- a/packages/matchbox/src/components/Radio/tests/Group.test.js
+++ b/packages/matchbox/src/components/Radio/tests/Group.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Group from '../Group';
+import { render } from 'test-utils';
 
 describe('Checkbox Group', () => {
   const subject = props => global.mountStyled(<Group {...props}>children</Group>);
@@ -34,5 +35,15 @@ describe('Checkbox Group', () => {
   it('renders with system props', () => {
     const wrapper = subject({ label: 'label', mb: '500' });
     expect(wrapper).toHaveStyleRule('margin-bottom', '1.5rem');
+  });
+
+  it('renders with a required label', () => {
+    const { getByText } = render(
+      <Group required label="test label">
+        children
+      </Group>,
+    );
+    expect(getByText('test label')).toBeTruthy();
+    expect(getByText('Required')).toBeTruthy();
   });
 });

--- a/packages/matchbox/src/components/Select/Select.js
+++ b/packages/matchbox/src/components/Select/Select.js
@@ -119,18 +119,11 @@ const Select = React.forwardRef(function Select(props, userRef) {
     hasError: !!error,
   });
 
-  const requiredIndicator = required ? (
-    <Box as="span" pr="200" aria-hidden="true">
-      *
-    </Box>
-  ) : null;
-
   const labelMarkup = label && (
     <Label id={id} labelHidden={labelHidden}>
       <Box as="span" pr="200">
         {label}
       </Box>
-      {requiredIndicator}
       {error && errorInLabel && (
         <Box as={Error} id={errorId} wrapper="span" error={error} fontWeight="400" />
       )}

--- a/packages/matchbox/src/components/Select/tests/Select.test.js
+++ b/packages/matchbox/src/components/Select/tests/Select.test.js
@@ -12,7 +12,8 @@ describe('Select', () => {
 
   it('should render with required label', () => {
     const wrapper = subject({ required: true, label: 'test-label' });
-    expect(wrapper.find('label').text()).toEqual('test-label*');
+    expect(wrapper.find('label').text()).toEqual('test-label');
+    expect(wrapper.find('select')).toHaveAttributeValue('required', '');
   });
 
   it('should render with optional label', () => {

--- a/packages/matchbox/src/components/TextField/TextField.js
+++ b/packages/matchbox/src/components/TextField/TextField.js
@@ -171,11 +171,6 @@ const TextField = React.forwardRef(function TextField(props, userRef) {
           <Box as="span" pr="200">
             {label}
           </Box>
-          {required && (
-            <Box as="span" pr="200" aria-hidden="true">
-              *
-            </Box>
-          )}
           {error && errorInLabel && (
             <Box as={Error} id={errorId} wrapper="span" error={error} fontWeight="400" />
           )}

--- a/packages/matchbox/src/components/TextField/tests/TextField.test.js
+++ b/packages/matchbox/src/components/TextField/tests/TextField.test.js
@@ -27,7 +27,8 @@ describe('TextField', () => {
 
   it('renders label with required correctly', () => {
     const wrapper = subject({ required: true, label: 'test label' });
-    expect(label(wrapper).text()).toEqual('test label*');
+    expect(label(wrapper).text()).toEqual('test label');
+    expect(input(wrapper)).toHaveAttributeValue('required', '');
   });
 
   it('renders label without required correctly', () => {


### PR DESCRIPTION
### What Changed
- Removes the visual `*` required indicator from all fields

### How To Test or Verify
- Run libby
- Visit the following stories:
  - Select
  - Textfield
  - Checkbox
  - Radio.Group 
  - ListBox
- Verify that when they are required, they apply the `required` HTML attribute but do not render anything visually
- Verify that no other input components are missing this change

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
