### PR TITLE
UX-517 Fix wrapping and alignment on Slider ticks

### DIFF
--- a/libby/form/Slider.lib.js
+++ b/libby/form/Slider.lib.js
@@ -25,8 +25,8 @@ describe('Slider', () => {
         disabled
         value={33}
         ticks={{
-          50: '50',
-          25: 'Recommended',
+          0: '10 days',
+          100: '100000 days',
         }}
       />
     </>

--- a/packages/matchbox/src/components/Slider/Slider.js
+++ b/packages/matchbox/src/components/Slider/Slider.js
@@ -17,6 +17,7 @@ import {
   tick,
   tickHover,
   tickLabel,
+  tickLabelPosition,
   handle,
   handleShadow,
 } from './styles';
@@ -49,6 +50,7 @@ const StyledTick = styled('div')`
 
 const StyledTickLabel = styled('div')`
   ${tickLabel}
+  ${tickLabelPosition}
 `;
 
 const StyledHandle = styled('div')`
@@ -230,7 +232,7 @@ function Slider(props) {
         disabled={disabled}
         included={tick < sliderValue}
       >
-        <StyledTickLabel>{label}</StyledTickLabel>
+        <StyledTickLabel x={tick}>{label}</StyledTickLabel>
       </StyledTick>
     );
   });
@@ -260,6 +262,7 @@ function Slider(props) {
       <StyledHandle
         id={id}
         aria-controls={props['aria-controls']}
+        aria-labelledby={props['aria-labelledby']}
         aria-valuemin={min}
         aria-valuemax={max}
         aria-valuenow={sliderValue}
@@ -322,6 +325,7 @@ Slider.propTypes = {
    * Describes a side-effect relationship with another DOM element
    */
   'aria-controls': PropTypes.string,
+  'aria-labelledby': PropTypes.string,
   /**
    * Identifier passed to the handle for testing or tracking purposes
    */

--- a/packages/matchbox/src/components/Slider/styles.js
+++ b/packages/matchbox/src/components/Slider/styles.js
@@ -88,15 +88,12 @@ export const tickLabelPosition = ({ x }) => {
   if (x === '0') {
     return `
       left: 0;
-      transform: none;
    `;
   }
 
   if (x === '100') {
     return `
-      left: auto;
       right: 0;
-      transform: none;
    `;
   }
 

--- a/packages/matchbox/src/components/Slider/styles.js
+++ b/packages/matchbox/src/components/Slider/styles.js
@@ -68,6 +68,7 @@ export const tick = props => {
     transition: ${tokens.motionDuration_medium} background;
 
     user-select: none;
+    white-space: nowrap;
   `;
 };
 
@@ -78,12 +79,32 @@ export const tickHover = props => `
 export const tickLabel = () => `
   position: absolute;
   top: ${tokens.spacing_400};
-  left: 50%;
-  transform: translate(-50%, 0);
 
   color: ${tokens.color_gray_700};
   font-size: ${tokens.fontSize_100};
 `;
+
+export const tickLabelPosition = ({ x }) => {
+  if (x === '0') {
+    return `
+      left: 0;
+      transform: none;
+   `;
+  }
+
+  if (x === '100') {
+    return `
+      left: auto;
+      right: 0;
+      transform: none;
+   `;
+  }
+
+  return `
+    left: 50%;
+    transform: translate(-50%, 0);
+  `;
+};
 
 const sharedStyles = `
   position: absolute;


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

Closes #833 

### What Changed
- Slider ticks with spaces should no longer wrap
- Slider ticks and the beginning and end of the slider should no longer overflow
- Slider supports `aria-labelledby`

### How To Test or Verify
- Run libby
- Visit http://localhost:9001/?path=Slider__with-ticks&source=false
- Verify the tick labels dont wrap, and that the first and last tick labels don't overflow (they should be left and right aligned).

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
