### PR TITLE
UX-518 prevent form from submitting when ListBox value is changed

### DIFF
--- a/cypress/integration/ListBox.spec.js
+++ b/cypress/integration/ListBox.spec.js
@@ -118,4 +118,32 @@ describe('The ListBox component', () => {
       cy.findAllByText('You must select an option').should('exist');
     });
   });
+
+  describe('in a form', () => {
+    beforeEach(() => {
+      cy.visit('/iframe.html?path=ListBox__in-parent-form&source=false');
+    });
+
+    it('does not submit when value is changed', () => {
+      let submitted = false;
+      cy.get('#listbox-parent-form').invoke('submit', e => {
+        e.preventDefault();
+        submitted = true;
+      });
+
+      cy.get('#listbox-parent-form')
+        .within(() => {
+          cy.get('label').click();
+          cy.get('button')
+            .eq(3)
+            .click();
+          cy.wait(100);
+          cy.focused().should('have.text', 'Option 2');
+          cy.get('[name="listbox-form-test"]').should('have.value', 'option-2');
+        })
+        .then(() => {
+          expect(submitted, 'form submitted').to.be.false;
+        });
+    });
+  });
 });

--- a/libby/form/ListBox.lib.js
+++ b/libby/form/ListBox.lib.js
@@ -145,4 +145,21 @@ describe('ListBox', () => {
       </ListBox>
     </Inline>
   ));
+
+  add('in parent form', () => (
+    <form id="listbox-parent-form" onSubmit={() => console.log('submitted')}>
+      <ListBox
+        id="listbox-5"
+        label="Select an option"
+        placeholder="Select One"
+        onChange={e => console.log(e)}
+        name="listbox-form-test"
+      >
+        <ListBox.Option value="option-1">Option 1</ListBox.Option>
+        <ListBox.Option value="option-2">Option 2</ListBox.Option>
+        <ListBox.Option value="option-3">Option 3</ListBox.Option>
+        <ListBox.Option value="option-4">Option 4</ListBox.Option>
+      </ListBox>
+    </form>
+  ));
 });

--- a/packages/matchbox/src/components/ListBox/Option.js
+++ b/packages/matchbox/src/components/ListBox/Option.js
@@ -12,6 +12,11 @@ const Option = React.forwardRef(function Option(props, ref) {
     return selected === value;
   }, [selected, value]);
 
+  const handleClick = event => {
+    event.preventDefault();
+    onSelect && onSelect(value);
+  };
+
   return (
     <Box
       as="li"
@@ -21,7 +26,7 @@ const Option = React.forwardRef(function Option(props, ref) {
       aria-posinset={index}
       aria-selected={isActive}
       disabled={disabled}
-      onClick={() => onSelect(value)}
+      onClick={handleClick}
     >
       <StyledLink active={isActive} as="button" disabled={disabled} tabIndex="-1" ref={ref}>
         {children}
@@ -38,6 +43,7 @@ Option.propTypes = {
   index: PropTypes.number,
   setSize: PropTypes.number,
   onSelect: PropTypes.func,
+  children: PropTypes.node,
 };
 
 export default Option;

--- a/packages/matchbox/src/components/ListBox/Option.js
+++ b/packages/matchbox/src/components/ListBox/Option.js
@@ -12,11 +12,6 @@ const Option = React.forwardRef(function Option(props, ref) {
     return selected === value;
   }, [selected, value]);
 
-  const handleClick = event => {
-    event.preventDefault();
-    onSelect && onSelect(value);
-  };
-
   return (
     <Box
       as="li"
@@ -26,9 +21,16 @@ const Option = React.forwardRef(function Option(props, ref) {
       aria-posinset={index}
       aria-selected={isActive}
       disabled={disabled}
-      onClick={handleClick}
+      onClick={() => onSelect(value)}
     >
-      <StyledLink active={isActive} as="button" disabled={disabled} tabIndex="-1" ref={ref}>
+      <StyledLink
+        active={isActive}
+        as="button"
+        type="button"
+        disabled={disabled}
+        tabIndex="-1"
+        ref={ref}
+      >
         {children}
       </StyledLink>
     </Box>


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed

- Prevent form from submitting when choosing a `ListBox` option
- New test to verify form is not being submitted

### How To Test or Verify

- Verify new example in libby http://localhost:9001/?path=ListBox__in-parent-form&source=false
- Verify cypress tests pass and form is not submitted

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
