### PR TITLE
issue-836 Sliders should no longer trap focus

### DIFF
--- a/cypress/integration/Slider.spec.js
+++ b/cypress/integration/Slider.spec.js
@@ -57,6 +57,13 @@ describe('The Slider component', () => {
 
       cy.get('[data-id="slider-test"]').should('have.attr', 'aria-valuenow', '123');
     });
+
+    it('shoud be focusable through keyboard controls', () => {
+      cy.get('body').tab();
+      cy.focused().should('have.attr', 'role', 'slider');
+      cy.focused().tab();
+      cy.focused().should('have.text', 'end focus test');
+    });
   });
 
   describe('when disabled', () => {

--- a/libby/form/Slider.lib.js
+++ b/libby/form/Slider.lib.js
@@ -4,7 +4,16 @@ import { Slider, TextField } from '@sparkpost/matchbox';
 
 describe('Slider', () => {
   add('basic usage', () => (
-    <Slider aria-controls="test-id" data-id="slider-test" defaultValue={125} min={100} max={150} />
+    <>
+      <Slider
+        aria-controls="test-id"
+        data-id="slider-test"
+        defaultValue={125}
+        min={100}
+        max={150}
+      />
+      <button>end focus test</button>
+    </>
   ));
 
   add('disabled', () => <Slider data-id="slider-test" disabled value={75} />);

--- a/packages/matchbox/src/components/Slider/Slider.js
+++ b/packages/matchbox/src/components/Slider/Slider.js
@@ -176,13 +176,28 @@ function Slider(props) {
   }
 
   function handleKeyDown(e) {
-    e.stopPropagation();
-    e.preventDefault();
+    // preventDefault here prevents the parent window
+    // from scrolling when interacting with the slider
 
-    onKeys(['arrowLeft', 'arrowDown'], () => setValue(sliderValue - interval))(e);
-    onKeys(['arrowRight', 'arrowUp'], () => setValue(sliderValue + interval))(e);
-    onKey('home', () => setValue(min))(e);
-    onKey('end', () => setValue(max))(e);
+    onKeys(['arrowLeft', 'arrowDown'], () => {
+      e.preventDefault();
+      setValue(sliderValue - interval);
+    })(e);
+
+    onKeys(['arrowRight', 'arrowUp'], () => {
+      e.preventDefault();
+      setValue(sliderValue + interval);
+    })(e);
+
+    onKey('home', () => {
+      e.preventDefault();
+      setValue(min);
+    })(e);
+
+    onKey('end', () => {
+      e.preventDefault();
+      setValue(max);
+    })(e);
   }
 
   // Sets slider value based on an x position
@@ -281,6 +296,8 @@ function Slider(props) {
     </StyledSlider>
   );
 }
+
+Slider.displayName = 'Slider';
 
 Slider.defaultProps = {
   min: 0,


### PR DESCRIPTION
Closes #836 

### What Changed
- No longer prevents events from bubbling up unless they are hitting keys associated with controlling the slider

### How To Test or Verify
- Run libby
- Visit the Slider story
- Verify that focus is not trapped when pressing Tab. Up and down arrow keys should still prevent window scrolling.

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
