### PR TITLE
UX-530 Lower default tooltip sizing

### DIFF
--- a/packages/matchbox/src/components/Tooltip/Tooltip.js
+++ b/packages/matchbox/src/components/Tooltip/Tooltip.js
@@ -97,9 +97,9 @@ function Tooltip(props) {
           >
             <StyledContent
               position="relative"
-              fontSize="200"
-              lineHeight="200"
-              p="300"
+              fontSize="100"
+              lineHeight="100"
+              p="200"
               borderRadius="100"
               bg="gray.1000"
               color="white"

--- a/packages/matchbox/src/components/Tooltip/tests/Tooltip.test.js
+++ b/packages/matchbox/src/components/Tooltip/tests/Tooltip.test.js
@@ -26,7 +26,6 @@ describe('Tooltip', () => {
     expect(container(wrapper)).toHaveStyleRule('visibility', 'hidden');
     expect(container(wrapper)).toHaveStyleRule('opacity', '0');
 
-    expect(content(wrapper)).toHaveStyleRule('font-size', '200'); // Theme key not mocked in tests
     expect(content(wrapper)).toHaveStyleRule('width', '13rem');
     expect(content(wrapper)).toHaveStyleRule('background-color', 'gray.1000'); // Theme key not mocked in tests
   });


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed
- Lowers font-size and line height on tooltips to `100` from `200`
- Lowers padding on tooltips to `200` from `300`
### How To Test or Verify

<!--
Describe any steps that may help reviewers verify changes.
Anything beyond basic unit testing, such as assistive tech usage, or special interactions.
-->

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
