### PR TITLE
UX-533 Support popovers in frozen columns

### DIFF
--- a/cypress/integration/Table.spec.js
+++ b/cypress/integration/Table.spec.js
@@ -55,7 +55,7 @@ describe('The Table component', () => {
 
     it('should render overflowing popovers correctly', () => {
       cy.get('table')
-        .eq(1)
+        .eq(0)
         .within(() => {
           cy.contains('Content').should('not.exist');
           cy.get('button')
@@ -71,10 +71,12 @@ describe('The Table component', () => {
     it('should scroll correctly', () => {
       cy.contains('4').should('not.be.visible');
       cy.get('[data-id="matchbox-scroll-wrapper"]')
-        .eq(0)
+        .eq(1)
         .scrollTo(500, 0);
-
-      cy.contains('4').should('be.visible');
+      cy.wait(500);
+      cy.findAllByText('am i visible')
+        .eq(1)
+        .should('be.visible');
     });
   });
 });

--- a/cypress/integration/Table.spec.js
+++ b/cypress/integration/Table.spec.js
@@ -32,6 +32,7 @@ describe('The Table component', () => {
         .should('have.attr', 'width', '20%');
     });
   });
+
   describe('SortButton', () => {
     beforeEach(() => {
       cy.visit('/iframe.html?path=Table__all-table-components&source=false');
@@ -44,6 +45,36 @@ describe('The Table component', () => {
         name: 'Heading 3 with long title long title long title long title',
       }).should('exist');
       cy.contains('Heading 4').should('exist');
+    });
+  });
+
+  describe('frozen first column', () => {
+    beforeEach(() => {
+      cy.visit('/iframe.html?path=Table__frozen-first-column');
+    });
+
+    it('should render overflowing popovers correctly', () => {
+      cy.get('table')
+        .eq(1)
+        .within(() => {
+          cy.contains('Content').should('not.exist');
+          cy.get('button')
+            .eq(0)
+            .should('exist');
+          cy.get('button')
+            .eq(0)
+            .click({ force: true });
+          cy.contains('Content').should('be.visible');
+        });
+    });
+
+    it('should scroll correctly', () => {
+      cy.contains('4').should('not.be.visible');
+      cy.get('[data-id="matchbox-scroll-wrapper"]')
+        .eq(0)
+        .scrollTo(500, 0);
+
+      cy.contains('4').should('be.visible');
     });
   });
 });

--- a/libby/layout/Table.lib.js
+++ b/libby/layout/Table.lib.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import { describe, add } from '@sparkpost/libby-react';
-import { Table, Panel, Box, Popover, Button } from '@sparkpost/matchbox';
+import { Table, Panel, Box, Popover } from '@sparkpost/matchbox';
 
 const Node = ({ children = 'A react component' }) => <Box minWidth="900">{children}</Box>;
 const NodeLong = ({
   children = 'A really longgggggggggggggggggggggggggggggggggggggggg react component',
 }) => <Box minWidth="900">{children}</Box>;
 const PopoverNode = () => (
-  <Popover sectioned trigger={<Button>Click</Button>}>
+  <Popover sectioned trigger={<button>Click</button>}>
     Content
   </Popover>
 );
@@ -15,7 +15,7 @@ const data = [
   ['Foo', 'Bar', 'Baz', 'Foo'],
   [<Node />, <Node />, <NodeLong />, <Node />], // eslint-disable-line
   [1, 2, 3, 4],
-  [<PopoverNode />, <PopoverNode />, <PopoverNode />, <PopoverNode />], // eslint-disable-line
+  [<PopoverNode />, 'test', 'test', 'test'], // eslint-disable-line
 ];
 
 describe('Table', () => {
@@ -83,11 +83,81 @@ describe('Table', () => {
   ));
 
   add('frozen first column', () => (
-    <Box maxWidth="1100">
-      <Panel>
-        <Table p="200" data={data} freezeFirstColumn />
-      </Panel>
-    </Box>
+    <>
+      <Box maxWidth="1100">
+        <Panel>
+          <Table p="200" data={data} freezeFirstColumn />
+        </Panel>
+      </Box>
+      <Box height="500"></Box>
+      <Box maxWidth="1100">
+        <Panel>
+          <Table title="My Table" freezeFirstColumn>
+            <thead>
+              <Table.Row header>
+                <Table.HeaderCell>
+                  <Table.SortButton direction="asc">Heading 1</Table.SortButton>
+                </Table.HeaderCell>
+                <Table.HeaderCell align="right">
+                  <Table.SortButton direction="desc">Heading 2</Table.SortButton>
+                </Table.HeaderCell>
+                <Table.HeaderCell width="300px">
+                  <Table.SortButton direction={null}>Heading 3</Table.SortButton>
+                </Table.HeaderCell>
+                <Table.HeaderCell>Heading 4</Table.HeaderCell>
+                <Table.HeaderCell>Heading 5</Table.HeaderCell>
+              </Table.Row>
+            </thead>
+            <tbody>
+              <Table.Row>
+                <Table.Cell>1</Table.Cell>
+                <Table.Cell align="right">2</Table.Cell>
+                <Table.Cell>3</Table.Cell>
+                <Table.Cell>4</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+              </Table.Row>
+              <Table.Row>
+                <Table.Cell>1</Table.Cell>
+                <Table.Cell>2</Table.Cell>
+                <Table.Cell>3</Table.Cell>
+                <Table.Cell>4</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+              </Table.Row>
+              <Table.TotalsRow>
+                <Table.Cell>Total</Table.Cell>
+                <Table.Cell colSpan="4" align="right">
+                  100000
+                </Table.Cell>
+              </Table.TotalsRow>
+              <Table.Row>
+                <Table.Cell>
+                  <PopoverNode />
+                </Table.Cell>
+                <Table.Cell>2</Table.Cell>
+                <Table.Cell>3</Table.Cell>
+                <Table.Cell>4</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+              </Table.Row>
+              <Table.Row>
+                <Table.Cell>
+                  <PopoverNode />
+                </Table.Cell>
+                <Table.Cell>2</Table.Cell>
+                <Table.Cell>3</Table.Cell>
+                <Table.Cell>4</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+              </Table.Row>
+              <Table.TotalsRow>
+                <Table.Cell>Total</Table.Cell>
+                <Table.Cell colSpan="4" align="right">
+                  100000
+                </Table.Cell>
+              </Table.TotalsRow>
+            </tbody>
+          </Table>
+        </Panel>
+      </Box>
+    </>
   ));
 
   add('system props', () => (

--- a/libby/layout/Table.lib.js
+++ b/libby/layout/Table.lib.js
@@ -89,7 +89,7 @@ describe('Table', () => {
           <Table p="200" data={data} freezeFirstColumn />
         </Panel>
       </Box>
-      <Box height="500"></Box>
+      <Box height="800"></Box>
       <Box maxWidth="1100">
         <Panel>
           <Table title="My Table" freezeFirstColumn>
@@ -114,7 +114,7 @@ describe('Table', () => {
                 <Table.Cell align="right">2</Table.Cell>
                 <Table.Cell>3</Table.Cell>
                 <Table.Cell>4</Table.Cell>
-                <Table.Cell>5</Table.Cell>
+                <Table.Cell>am i visible</Table.Cell>
               </Table.Row>
               <Table.Row>
                 <Table.Cell>1</Table.Cell>

--- a/libby/layout/Table.lib.js
+++ b/libby/layout/Table.lib.js
@@ -90,7 +90,7 @@ describe('Table', () => {
         </Panel>
       </Box>
       <Box height="800"></Box>
-      <Box maxWidth="1100">
+      <Box>
         <Panel>
           <Table title="My Table" freezeFirstColumn>
             <thead>
@@ -122,6 +122,41 @@ describe('Table', () => {
                 <Table.Cell>3</Table.Cell>
                 <Table.Cell>4</Table.Cell>
                 <Table.Cell>5</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+                <Table.Cell>5</Table.Cell>
+                <Table.Cell>5</Table.Cell>
               </Table.Row>
               <Table.TotalsRow>
                 <Table.Cell>Total</Table.Cell>
@@ -147,12 +182,6 @@ describe('Table', () => {
                 <Table.Cell>4</Table.Cell>
                 <Table.Cell>5</Table.Cell>
               </Table.Row>
-              <Table.TotalsRow>
-                <Table.Cell>Total</Table.Cell>
-                <Table.Cell colSpan="4" align="right">
-                  100000
-                </Table.Cell>
-              </Table.TotalsRow>
             </tbody>
           </Table>
         </Panel>

--- a/packages/matchbox/package-lock.json
+++ b/packages/matchbox/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@sparkpost/matchbox",
-  "version": "5.1.5",
+  "version": "5.2.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/matchbox/package-lock.json
+++ b/packages/matchbox/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@sparkpost/matchbox",
-  "version": "5.2.0-beta.0",
+  "version": "5.2.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/matchbox/package.json
+++ b/packages/matchbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sparkpost/matchbox",
-  "version": "5.2.0-beta.0",
+  "version": "5.2.0-beta.1",
   "description": "A React UI component library",
   "main": "matchbox.js",
   "module": "matchbox.esm.js",

--- a/packages/matchbox/package.json
+++ b/packages/matchbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sparkpost/matchbox",
-  "version": "5.1.5",
+  "version": "5.2.0-beta.0",
   "description": "A React UI component library",
   "main": "matchbox.js",
   "module": "matchbox.esm.js",

--- a/packages/matchbox/src/components/Table/SortButton.js
+++ b/packages/matchbox/src/components/Table/SortButton.js
@@ -41,7 +41,7 @@ const Button = styled.button`
 
 const IconWrapper = styled.span`
   display: inline-block;
-  margin-left: ${({ theme }) => theme.space[200]};
+  margin-left: ${({ theme }) => theme.space[100]};
   color: ${({ theme }) => theme.colors.gray[700]};
   transition: ${({ theme }) => theme.motion.duration.fast};
 
@@ -112,7 +112,7 @@ const SortButton = React.forwardRef(function SortButton(props, userRef) {
     >
       <span>{children}</span>
       <IconWrapper sorted={sorted}>
-        <Icon size={18} />
+        <Icon size={16} />
       </IconWrapper>
     </Button>
   );

--- a/packages/matchbox/src/components/Table/Table.js
+++ b/packages/matchbox/src/components/Table/Table.js
@@ -83,10 +83,10 @@ function Table(props) {
       {freezeFirstColumn && (
         <DuplicatedTable
           data-id="matchbox-sticky-table"
-          aria-hidden="true"
           position="absolute"
           top="0"
-          left=" 0"
+          left="0"
+          right="0"
           isScrolled={isScrolled}
         >
           <StyledTable>{dataMarkup}</StyledTable>

--- a/packages/matchbox/src/components/Table/Table.js
+++ b/packages/matchbox/src/components/Table/Table.js
@@ -9,17 +9,38 @@ import { pick } from '../../helpers/props';
 import { Cell, HeaderCell, Row, TotalsRow } from './TableElements';
 import SortButton from './SortButton';
 import { TablePaddingContext } from './context';
-import { table, wrapper, sticky } from './styles';
+import { table, wrapper } from './styles';
 
 const StyledTable = styled('table')`
   ${table}
   ${padding}
-  ${sticky}
 `;
 
 const Wrapper = styled(Box)`
   ${wrapper}
   ${margin}
+`;
+
+const DuplicatedTable = styled(Box)`
+  pointer-events: none;
+
+  th:not(:first-child),
+  td:not(:first-child) {
+    opacity: 0;
+    pointer-events: none;
+    border-color: transparent !important;
+  }
+  tr {
+    background: none !important;
+  }
+  th:first-child,
+  td:first-child {
+    background: ${({ theme }) => theme.colors.white};
+    pointer-events: auto;
+    ${({ isScrolled, theme }) => (isScrolled ? `box-shadow: ${theme.shadows[200]};` : '')};
+    transition: ${({ theme }) =>
+      `box-shadow ${theme.motion.duration.medium} ${theme.motion.ease.inOut}`};
+  }
 `;
 
 function Table(props) {
@@ -57,29 +78,40 @@ function Table(props) {
   const marginProps = pick(rest, margin.propNames);
 
   return (
-    <Wrapper
-      freezeFirstColumn={freezeFirstColumn}
-      onScroll={freezeFirstColumn ? handleScroll : null}
-      {...marginProps}
-    >
-      <StyledTable
-        aria-readonly={readOnly}
-        data-id={dataId}
+    <TablePaddingContext.Provider value={{ px, py, ...paddingProps }}>
+      <Wrapper
+        data-id="matchbox-scroll-wrapper"
         freezeFirstColumn={freezeFirstColumn}
-        id={id}
-        isScrolled={isScrolled}
-        role={role}
+        onScroll={freezeFirstColumn ? handleScroll : null}
+        {...marginProps}
       >
-        <TablePaddingContext.Provider value={{ px, py, ...paddingProps }}>
+        <StyledTable
+          aria-readonly={readOnly}
+          data-id={dataId}
+          freezeFirstColumn={freezeFirstColumn}
+          id={id}
+          isScrolled={isScrolled}
+          role={role}
+        >
           {title && (
             <caption>
               <ScreenReaderOnly>{title}</ScreenReaderOnly>
             </caption>
           )}
           {dataMarkup}
-        </TablePaddingContext.Provider>
-      </StyledTable>
-    </Wrapper>
+        </StyledTable>
+      </Wrapper>
+      <DuplicatedTable
+        data-id="sticky-table"
+        aria-hidden="true"
+        position="absolute"
+        top="0"
+        left=" 0"
+        isScrolled={isScrolled}
+      >
+        <StyledTable>{dataMarkup}</StyledTable>
+      </DuplicatedTable>
+    </TablePaddingContext.Provider>
   );
 }
 

--- a/packages/matchbox/src/components/Table/Table.js
+++ b/packages/matchbox/src/components/Table/Table.js
@@ -23,10 +23,11 @@ const Wrapper = styled(Box)`
 
 const DuplicatedTable = styled(Box)`
   pointer-events: none;
+  z-index: ${({ theme }) => theme.zIndices.default};
 
   th:not(:first-child),
   td:not(:first-child) {
-    opacity: 0;
+    visibility: hidden;
     pointer-events: none;
     border-color: transparent !important;
   }
@@ -79,6 +80,18 @@ function Table(props) {
 
   return (
     <TablePaddingContext.Provider value={{ px, py, ...paddingProps }}>
+      {freezeFirstColumn && (
+        <DuplicatedTable
+          data-id="matchbox-sticky-table"
+          aria-hidden="true"
+          position="absolute"
+          top="0"
+          left=" 0"
+          isScrolled={isScrolled}
+        >
+          <StyledTable>{dataMarkup}</StyledTable>
+        </DuplicatedTable>
+      )}
       <Wrapper
         data-id="matchbox-scroll-wrapper"
         freezeFirstColumn={freezeFirstColumn}
@@ -101,16 +114,6 @@ function Table(props) {
           {dataMarkup}
         </StyledTable>
       </Wrapper>
-      <DuplicatedTable
-        data-id="sticky-table"
-        aria-hidden="true"
-        position="absolute"
-        top="0"
-        left=" 0"
-        isScrolled={isScrolled}
-      >
-        <StyledTable>{dataMarkup}</StyledTable>
-      </DuplicatedTable>
     </TablePaddingContext.Provider>
   );
 }

--- a/packages/matchbox/src/components/Table/Table.js
+++ b/packages/matchbox/src/components/Table/Table.js
@@ -79,42 +79,45 @@ function Table(props) {
   const marginProps = pick(rest, margin.propNames);
 
   return (
-    <TablePaddingContext.Provider value={{ px, py, ...paddingProps }}>
-      {freezeFirstColumn && (
-        <DuplicatedTable
-          data-id="matchbox-sticky-table"
-          position="absolute"
-          top="0"
-          left="0"
-          right="0"
-          isScrolled={isScrolled}
-        >
-          <StyledTable>{dataMarkup}</StyledTable>
-        </DuplicatedTable>
-      )}
-      <Wrapper
-        data-id="matchbox-scroll-wrapper"
-        freezeFirstColumn={freezeFirstColumn}
-        onScroll={freezeFirstColumn ? handleScroll : null}
-        {...marginProps}
-      >
-        <StyledTable
-          aria-readonly={readOnly}
-          data-id={dataId}
+    <Box position="relative">
+      <TablePaddingContext.Provider value={{ px, py, ...paddingProps }}>
+        {freezeFirstColumn && (
+          <DuplicatedTable
+            data-id="matchbox-sticky-table"
+            position="absolute"
+            top="0"
+            left="0"
+            right="0"
+            overflow="clip visible"
+            isScrolled={isScrolled}
+          >
+            <StyledTable>{dataMarkup}</StyledTable>
+          </DuplicatedTable>
+        )}
+        <Wrapper
+          data-id="matchbox-scroll-wrapper"
           freezeFirstColumn={freezeFirstColumn}
-          id={id}
-          isScrolled={isScrolled}
-          role={role}
+          onScroll={freezeFirstColumn ? handleScroll : null}
+          {...marginProps}
         >
-          {title && (
-            <caption>
-              <ScreenReaderOnly>{title}</ScreenReaderOnly>
-            </caption>
-          )}
-          {dataMarkup}
-        </StyledTable>
-      </Wrapper>
-    </TablePaddingContext.Provider>
+          <StyledTable
+            aria-readonly={readOnly}
+            data-id={dataId}
+            freezeFirstColumn={freezeFirstColumn}
+            id={id}
+            isScrolled={isScrolled}
+            role={role}
+          >
+            {title && (
+              <caption>
+                <ScreenReaderOnly>{title}</ScreenReaderOnly>
+              </caption>
+            )}
+            {dataMarkup}
+          </StyledTable>
+        </Wrapper>
+      </TablePaddingContext.Provider>
+    </Box>
   );
 }
 

--- a/packages/matchbox/src/components/Table/TableElements.js
+++ b/packages/matchbox/src/components/Table/TableElements.js
@@ -23,7 +23,10 @@ const StyledHeaderCell = styled('th')`
 
 const StyledRow = styled('tr')`
   ${row}
-  td, th {
+  thead & th {
+    vertical-align: bottom;
+  }
+  td {
     ${verticalAlignment}
   }
 `;

--- a/packages/matchbox/src/components/Table/styles.js
+++ b/packages/matchbox/src/components/Table/styles.js
@@ -1,11 +1,22 @@
 import { system } from 'styled-system';
 
-export const table = () => `
+export const table = ({ freezeFirstColumn }) => `
   position: relative;
   text-align: left;
   width: 100%;
   padding: 0;
   border-collapse: collapse;
+
+  ${
+    freezeFirstColumn
+      ? `
+        td:first-child, th:first-child {
+          visibility: hidden;
+        }
+  `
+      : ''
+  }
+  
 `;
 
 export const headerCell = ({ theme }) => `

--- a/packages/matchbox/src/components/Table/styles.js
+++ b/packages/matchbox/src/components/Table/styles.js
@@ -1,4 +1,3 @@
-import { tokens } from '@sparkpost/design-tokens';
 import { system } from 'styled-system';
 
 export const table = () => `
@@ -15,40 +14,23 @@ export const headerCell = ({ theme }) => `
   font-weight: ${theme.fontWeights.semibold};
 `;
 
-export const sticky = ({ isScrolled, freezeFirstColumn, theme }) => {
-  return `
-    td:first-child, th:first-child {
-      ${
-        freezeFirstColumn
-          ? `
-            transition: box-shadow ${tokens.motionDuration_medium} ${tokens.motionEase_in_out};
-            position: sticky;
-            left: 0;
-            background: inherit;
-            z-index: 1;
-          `
-          : ''
-      }
-      ${isScrolled ? `box-shadow: ${theme.shadows['400']};` : ''}
-    }
-  `;
-};
-
 export const cell = () => `
   word-break: break-all;
 `;
 
 const zebra = theme => `
-  tbody &:nth-of-type(odd) {
-    background: ${theme.colors.gray['100']};
+  tbody &:nth-of-type(odd) td {
+    background: ${theme.colors.gray[100]};
+  }
+  tbody &:nth-of-type(even) td, thead & th {
+    background: ${theme.colors.white};
   }
 `;
 
 export const row = ({ theme }) => `
-  background: ${theme.colors.white};
   border: none;
 
-  thead & {
+  thead & th {
     border-bottom:${theme.borders['300']};
   }
 
@@ -56,11 +38,11 @@ export const row = ({ theme }) => `
 `;
 
 export const totalsRow = ({ theme }) => `
-  &:not(:last-child) {
+  &:not(:last-child) td {
     border-bottom: ${theme.borders['500']};
   }
 
-  &:not(:first-child) {
+  &:not(:first-child) td {
     border-top: ${theme.borders['500']};
   }
 
@@ -93,5 +75,5 @@ export const horizontalAlignment = system({
 });
 
 export const wrapper = ({ freezeFirstColumn }) => `
-   ${freezeFirstColumn ? 'overflow: auto;' : ''}
+  ${freezeFirstColumn ? 'overflow: auto;' : ''}
 `;

--- a/packages/matchbox/src/components/Table/tests/Table.test.js
+++ b/packages/matchbox/src/components/Table/tests/Table.test.js
@@ -87,17 +87,6 @@ describe('Table', () => {
     ).toEqual('three');
   });
 
-  it('should freeze a column', () => {
-    wrapper = subject({ freezeFirstColumn: true });
-    wrapper.simulate('scroll', { target: { scrollLeft: 11 } });
-    expect(wrapper.find('table')).toHaveStyleRule('position', 'sticky', {
-      modifier: 'th:first-child',
-    });
-    expect(wrapper.find('table')).toHaveStyleRule('position', 'sticky', {
-      modifier: 'td:first-child',
-    });
-  });
-
   it('should render a caption', () => {
     wrapper = subject();
     expect(wrapper.find('caption').text()).toEqual('My Data Table');

--- a/packages/matchbox/src/components/Table/tests/Table.test.js
+++ b/packages/matchbox/src/components/Table/tests/Table.test.js
@@ -94,8 +94,8 @@ describe('Table', () => {
 
   it('should distribute system props correctly', () => {
     wrapper = subject({ p: '100', m: '100' });
-    expect(wrapper).toHaveStyleRule('margin', '100');
-    expect(wrapper).not.toHaveStyleRule('padding', '100');
+    expect(wrapper.find('div').at(1)).toHaveStyleRule('margin', '100');
+    expect(wrapper.find('div').at(1)).not.toHaveStyleRule('padding', '100');
     expect(wrapper.find('table')).not.toHaveStyleRule('margin', '100');
   });
 


### PR DESCRIPTION
### What Changed
- Popovers now work inside a tables first frozen column
- Renders a duplicate table to handle the overflow properties
- First column of the underlying table is hidden, and subsequent columns of the overlay table are hidden with CSS
- Also bottom aligns the table headers

### How To Test or Verify
- Run Libby
- Visit http://localhost:9001/?path=Table__frozen-first-column
- Verify popovers work in the first column

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
