### PR TITLE
UX-565 Massively change ActionList and Popover interactions

### DIFF
--- a/cypress/integration/ActionList.spec.js
+++ b/cypress/integration/ActionList.spec.js
@@ -13,15 +13,6 @@ describe('ActionList component', () => {
     cy.get('a').should('have.length', 2);
   });
 
-  it('should handle keyboard navigation correctly', () => {
-    cy.get('button')
-      .eq(0)
-      .click();
-    cy.focused().should('have.text', 'Button');
-    cy.tab();
-    cy.focused().should('have.text', 'External Link');
-  });
-
   it('should handle disabled Actions correctly', () => {
     cy.get('button')
       .eq(1)

--- a/cypress/integration/ListBox.spec.js
+++ b/cypress/integration/ListBox.spec.js
@@ -97,7 +97,7 @@ describe('The ListBox component', () => {
     it('selects item on click and returns focus to button', () => {
       cy.get('label').click();
       cy.get('button')
-        .eq(3)
+        .eq(4)
         .click();
       cy.wait(100);
       cy.focused().should('have.text', 'Charlie');
@@ -131,19 +131,15 @@ describe('The ListBox component', () => {
         submitted = true;
       });
 
-      cy.get('#listbox-parent-form')
-        .within(() => {
-          cy.get('label').click();
-          cy.get('button')
-            .eq(3)
-            .click();
-          cy.wait(100);
-          cy.focused().should('have.text', 'Option 2');
-          cy.get('[name="listbox-form-test"]').should('have.value', 'option-2');
-        })
-        .then(() => {
-          expect(submitted, 'form submitted').to.be.false;
-        });
+      cy.get('label').click();
+      cy.get('button')
+        .eq(3)
+        .click();
+      cy.wait(100);
+      cy.focused().should('have.text', 'Option 2');
+      cy.get('[name="listbox-form-test"]').should('have.value', 'option-2');
+
+      expect(submitted, 'form submitted').to.be.false;
     });
   });
 

--- a/cypress/integration/Popover.spec.js
+++ b/cypress/integration/Popover.spec.js
@@ -71,7 +71,6 @@ describe('Uncontrolled Popover with Actionlist', () => {
   it('should navigate through actionlist buttons with down arrow', () => {
     cy.contains('More Actions').click();
     cy.get('[data-id="popover-content"]').should('be.visible');
-    cy.get('body').type('{downArrow}');
     cy.focused().should('have.text', 'Edit');
     cy.get('body').type('{downArrow}');
     cy.focused().should('have.text', 'Duplicate');
@@ -113,14 +112,15 @@ describe('Uncontrolled Popover with Actionlist', () => {
     cy.focused().should('have.text', 'More Actions');
     cy.get('body').type('{upArrow}');
     cy.get('[data-id="popover-content"]').should('be.visible');
-    cy.focused().should('have.text', 'Delete');
+    cy.focused().should('have.text', 'Edit');
   });
 
-  it('should focus on the container when opening', () => {
+  it('should focus on the first item when opening', () => {
     cy.get('[data-id="popover-content"]').should('not.exist');
     cy.contains('More Actions').click();
     cy.get('[data-id="popover-content"]').should('be.visible');
-    cy.focused().should('have.attr', 'role', 'menu');
+    cy.focused().should('have.attr', 'role', 'menuitem');
+    cy.focused().should('have.text', 'Edit');
   });
 
   it('should close when clicking outside the popover', () => {

--- a/cypress/integration/Popover.spec.js
+++ b/cypress/integration/Popover.spec.js
@@ -56,16 +56,58 @@ describe('Uncontrolled Popover with Actionlist', () => {
     cy.get('[data-id="popover-content"]').should('be.visible');
   });
 
-  it('should tab through actionlist buttons', () => {
+  it('should close when pressing tab', () => {
     cy.contains('More Actions').click();
     cy.get('[data-id="popover-content"]').should('be.visible');
-    cy.focused().should('have.attr', 'tabindex', '-1');
-    // Container is focused with tabindex=-1 here, not "tabbable" by cypress
-    // So we reset to start at the button instead
     cy.get('body').tab();
-    cy.focused().tab();
+    cy.get('[data-id="popover-content"]').should('not.be.visible');
+  });
+
+  it('should navigate through actionlist buttons with down arrow', () => {
+    cy.contains('More Actions').click();
+    cy.get('[data-id="popover-content"]').should('be.visible');
+    cy.get('body').type('{downArrow}');
     cy.focused().should('have.text', 'Edit');
-    cy.focused().tab();
+    cy.get('body').type('{downArrow}');
+    cy.focused().should('have.text', 'Duplicate');
+    cy.get('body').type('{downArrow}');
+    cy.focused().should('have.text', 'Publish');
+    cy.get('body').type('{downArrow}');
+    cy.focused().should('have.text', 'Delete');
+    cy.get('body').type('{downArrow}');
+    cy.focused().should('have.text', 'Edit');
+  });
+
+  it('should navigate through actionlist buttons with up arrow', () => {
+    cy.contains('More Actions').click();
+    cy.get('[data-id="popover-content"]').should('be.visible');
+    cy.get('body').type('{upArrow}');
+    cy.focused().should('have.text', 'Delete');
+    cy.get('body').type('{upArrow}');
+    cy.focused().should('have.text', 'Publish');
+    cy.get('body').type('{upArrow}');
+    cy.focused().should('have.text', 'Duplicate');
+    cy.get('body').type('{upArrow}');
+    cy.focused().should('have.text', 'Edit');
+    cy.get('body').type('{upArrow}');
+    cy.focused().should('have.text', 'Delete');
+  });
+
+  it('should open when pressing down arrow', () => {
+    cy.get('body').tab();
+    cy.get('[data-id="popover-content"]').should('not.exist');
+    cy.focused().should('have.text', 'More Actions');
+    cy.get('body').type('{downArrow}');
+    cy.get('[data-id="popover-content"]').should('be.visible');
+    cy.focused().should('have.text', 'Edit');
+  });
+
+  it('should open when pressing up arrow', () => {
+    cy.get('body').tab();
+    cy.get('[data-id="popover-content"]').should('not.exist');
+    cy.focused().should('have.text', 'More Actions');
+    cy.get('body').type('{upArrow}');
+    cy.get('[data-id="popover-content"]').should('be.visible');
     cy.focused().should('have.text', 'Delete');
   });
 

--- a/cypress/integration/Popover.spec.js
+++ b/cypress/integration/Popover.spec.js
@@ -36,6 +36,11 @@ describe('Controlled Popover component', () => {
       cy.get('[data-id="close-button"]').click();
       cy.get('[data-id="popover-content"]').should('not.exist');
     });
+
+    it('should focus on a focusable child when opening', () => {
+      cy.get('[data-id="popover-content"]').should('be.visible');
+      cy.focused().should('have.text', 'Close me');
+    });
   });
 });
 
@@ -109,6 +114,13 @@ describe('Uncontrolled Popover with Actionlist', () => {
     cy.get('body').type('{upArrow}');
     cy.get('[data-id="popover-content"]').should('be.visible');
     cy.focused().should('have.text', 'Delete');
+  });
+
+  it('should focus on the container when opening', () => {
+    cy.get('[data-id="popover-content"]').should('not.exist');
+    cy.contains('More Actions').click();
+    cy.get('[data-id="popover-content"]').should('be.visible');
+    cy.focused().should('have.attr', 'role', 'menu');
   });
 
   it('should close when clicking outside the popover', () => {

--- a/cypress/integration/Popover.spec.js
+++ b/cypress/integration/Popover.spec.js
@@ -137,4 +137,11 @@ describe('Uncontrolled Popover with Actionlist', () => {
     cy.get('[data-id="popover-content"]').should('not.exist');
     cy.focused().should('have.text', 'More Actions');
   });
+
+  it('should render the correct a11y attributes automatically', () => {
+    cy.findByRole('button', { name: 'More Actions' }).should('have.attr', 'aria-haspopup', 'true');
+    cy.findByRole('button', { name: 'More Actions' }).should('have.attr', 'aria-expanded', 'false');
+    cy.contains('More Actions').click();
+    cy.findByRole('button', { name: 'More Actions' }).should('have.attr', 'aria-expanded', 'true');
+  });
 });

--- a/cypress/integration/Tab.spec.js
+++ b/cypress/integration/Tab.spec.js
@@ -93,9 +93,10 @@ describe('The Tabs component', () => {
       cy.get('[data-id="popover-content"]').should('not.exist');
     });
 
-    it('should focus on the menu', () => {
+    it('should focus on the first menuitem', () => {
       cy.get('[data-id="tab-options-button"]').click();
-      cy.focused().should('have.attr', 'role', 'menu');
+      cy.focused().should('have.attr', 'role', 'menuitem');
+      cy.focused().should('have.text', 'Details');
     });
   });
 });

--- a/cypress/integration/Tab.spec.js
+++ b/cypress/integration/Tab.spec.js
@@ -95,7 +95,7 @@ describe('The Tabs component', () => {
 
     it('should focus on the menu', () => {
       cy.get('[data-id="tab-options-button"]').click();
-      cy.get('[data-id="popover-focus-wrapper"]').should('have.focus');
+      cy.focused().should('have.attr', 'role', 'menu');
     });
   });
 });

--- a/cypress/integration/Table.spec.js
+++ b/cypress/integration/Table.spec.js
@@ -54,29 +54,14 @@ describe('The Table component', () => {
     });
 
     it('should render overflowing popovers correctly', () => {
-      cy.get('table')
+      cy.contains('Content').should('not.exist');
+      cy.get('button')
         .eq(0)
-        .within(() => {
-          cy.contains('Content').should('not.exist');
-          cy.get('button')
-            .eq(0)
-            .should('exist');
-          cy.get('button')
-            .eq(0)
-            .click({ force: true });
-          cy.contains('Content').should('be.visible');
-        });
-    });
-
-    it('should scroll correctly', () => {
-      cy.contains('4').should('not.be.visible');
-      cy.get('[data-id="matchbox-scroll-wrapper"]')
-        .eq(1)
-        .scrollTo(500, 0);
-      cy.wait(500);
-      cy.findAllByText('am i visible')
-        .eq(1)
-        .should('be.visible');
+        .should('exist');
+      cy.get('button')
+        .eq(0)
+        .click({ force: true });
+      cy.contains('Content').should('be.visible');
     });
   });
 });

--- a/libby/overlays/Popover.lib.js
+++ b/libby/overlays/Popover.lib.js
@@ -70,6 +70,11 @@ describe('Popover', () => {
         <ActionList.Action onClick={noop} is="button">
           Publish
         </ActionList.Action>
+        <ActionList.Section>
+          <ActionList.Action onClick={noop} is="button">
+            test
+          </ActionList.Action>
+        </ActionList.Section>
       </ActionList>
     </Popover>
   ));

--- a/libby/overlays/Popover.lib.js
+++ b/libby/overlays/Popover.lib.js
@@ -65,14 +65,14 @@ describe('Popover', () => {
           Edit
         </ActionList.Action>
         <ActionList.Action onClick={noop} is="button">
-          Delete
+          Duplicate
         </ActionList.Action>
         <ActionList.Action onClick={noop} is="button">
           Publish
         </ActionList.Action>
         <ActionList.Section>
           <ActionList.Action onClick={noop} is="button">
-            test
+            Delete
           </ActionList.Action>
         </ActionList.Section>
       </ActionList>

--- a/libby/overlays/Popover.lib.js
+++ b/libby/overlays/Popover.lib.js
@@ -58,7 +58,7 @@ describe('Popover', () => {
   add('with an ActionList', () => (
     <Popover
       trigger={
-        <Button id="trigger" aria-haspopup="true" aria-controls="menu">
+        <Button id="trigger" aria-controls="menu">
           More Actions
         </Button>
       }

--- a/libby/overlays/Popover.lib.js
+++ b/libby/overlays/Popover.lib.js
@@ -57,10 +57,13 @@ describe('Popover', () => {
 
   add('with an ActionList', () => (
     <Popover
-      id="test-popover"
-      trigger={<Button aria-describedby="test-popover">More Actions</Button>}
+      trigger={
+        <Button id="trigger" aria-haspopup="true" aria-controls="menu">
+          More Actions
+        </Button>
+      }
     >
-      <ActionList>
+      <ActionList aria-labelledby="trigger" id="menu">
         <ActionList.Action onClick={noop} is="button">
           Edit
         </ActionList.Action>

--- a/packages/matchbox/src/components/ActionList/Action.js
+++ b/packages/matchbox/src/components/ActionList/Action.js
@@ -32,6 +32,8 @@ const Action = React.forwardRef(function Action(props, userRef) {
       disabled={disabled}
       isType={is}
       ref={userRef}
+      role="menuitem"
+      tabIndex="-1"
       {...action}
     >
       {linkContent}

--- a/packages/matchbox/src/components/ActionList/ActionList.js
+++ b/packages/matchbox/src/components/ActionList/ActionList.js
@@ -29,6 +29,7 @@ const ActionList = React.forwardRef(function ActionList(props, userRef) {
     ...rest
   } = props;
 
+  // TODO Remove `actions` and `sections` support in favor of composable components
   let list = actions && actions.length ? groupByValues(actions, groupByKey) : [];
   if (sections && sections.length) {
     list = list.concat(sections);
@@ -38,8 +39,11 @@ const ActionList = React.forwardRef(function ActionList(props, userRef) {
 
   const wrapperRef = React.useRef();
   const [focusableItemList, setFocusableItemList] = React.useState([]);
+
+  // Focus index starts at -1, so we can focus on the first item on mount
   const [focusIndex, setFocusIndex] = React.useState(-1);
 
+  // Creates a list of focusable links or buttons inside the actionlist
   React.useEffect(() => {
     if (wrapperRef && wrapperRef.current) {
       setFocusableItemList(wrapperRef.current.querySelectorAll('[role="menuitem"]'));
@@ -48,9 +52,7 @@ const ActionList = React.forwardRef(function ActionList(props, userRef) {
 
   useWindowEvent('keydown', e => {
     onKey('arrowDown', () => {
-      if (focusIndex === -1) {
-        setFocusIndex(0);
-      } else if (focusIndex < focusableItemList.length - 1) {
+      if (focusIndex < focusableItemList.length - 1 && focusIndex >= 0) {
         setFocusIndex(focusIndex + 1);
       } else {
         setFocusIndex(0);
@@ -68,9 +70,10 @@ const ActionList = React.forwardRef(function ActionList(props, userRef) {
 
   React.useLayoutEffect(() => {
     if (focusableItemList[focusIndex]) {
+      // Honestly not sure why this doesn't work without a timeout
       setTimeout(() => {
         focusableItemList[focusIndex].focus();
-      }, 50);
+      }, 10);
     }
   }, [focusIndex, focusableItemList]);
 

--- a/packages/matchbox/src/components/ActionList/ActionList.js
+++ b/packages/matchbox/src/components/ActionList/ActionList.js
@@ -7,7 +7,6 @@ import { groupByValues } from '../../helpers/array';
 import { deprecate } from '../../helpers/propTypes';
 import Section from './Section';
 import Action from './Action';
-import { useWindowEvent } from '../../hooks';
 import { onKey } from '../../helpers/keyEvents';
 
 const system = compose(margin, layout);
@@ -40,8 +39,7 @@ const ActionList = React.forwardRef(function ActionList(props, userRef) {
   const wrapperRef = React.useRef();
   const [focusableItemList, setFocusableItemList] = React.useState([]);
 
-  // Focus index starts at -1, so we can focus on the first item on mount
-  const [focusIndex, setFocusIndex] = React.useState(-1);
+  const [focusIndex, setFocusIndex] = React.useState(0);
 
   // Creates a list of focusable links or buttons inside the actionlist
   React.useEffect(() => {
@@ -50,9 +48,18 @@ const ActionList = React.forwardRef(function ActionList(props, userRef) {
     }
   }, []);
 
-  useWindowEvent('keydown', e => {
+  React.useLayoutEffect(() => {
+    if (focusableItemList[focusIndex]) {
+      // Honestly not sure why this doesn't work without a timeout
+      setTimeout(() => {
+        focusableItemList[focusIndex].focus();
+      }, 10);
+    }
+  }, [focusIndex, focusableItemList]);
+
+  function handleKeyDown(e) {
     onKey('arrowDown', () => {
-      if (focusIndex < focusableItemList.length - 1 && focusIndex >= 0) {
+      if (focusIndex < focusableItemList.length - 1) {
         setFocusIndex(focusIndex + 1);
       } else {
         setFocusIndex(0);
@@ -66,16 +73,7 @@ const ActionList = React.forwardRef(function ActionList(props, userRef) {
         setFocusIndex(focusIndex - 1);
       }
     })(e);
-  });
-
-  React.useLayoutEffect(() => {
-    if (focusableItemList[focusIndex]) {
-      // Honestly not sure why this doesn't work without a timeout
-      setTimeout(() => {
-        focusableItemList[focusIndex].focus();
-      }, 10);
-    }
-  }, [focusIndex, focusableItemList]);
+  }
 
   function assignRefs(node) {
     wrapperRef.current = node;
@@ -93,6 +91,7 @@ const ActionList = React.forwardRef(function ActionList(props, userRef) {
       tabIndex="-1"
       role="menu"
       ref={assignRefs}
+      onKeyDown={handleKeyDown}
       {...rest}
     >
       {listMarkup}

--- a/packages/matchbox/src/components/ActionList/ActionList.js
+++ b/packages/matchbox/src/components/ActionList/ActionList.js
@@ -61,6 +61,9 @@ const ActionList = React.forwardRef(function ActionList(props, userRef) {
 
   function handleKeyDown(e) {
     onKey('arrowDown', () => {
+      // Stop arrow keys from scrolling the page
+      e.preventDefault();
+
       if (focusIndex < focusableItemList.length - 1) {
         setFocusIndex(focusIndex + 1);
       } else {
@@ -69,6 +72,9 @@ const ActionList = React.forwardRef(function ActionList(props, userRef) {
     })(e);
 
     onKey('arrowUp', () => {
+      // Stop arrow keys from scrolling the page
+      e.preventDefault();
+
       if (focusIndex <= 0) {
         setFocusIndex(focusableItemList.length - 1);
       } else {

--- a/packages/matchbox/src/components/ActionList/ActionList.js
+++ b/packages/matchbox/src/components/ActionList/ActionList.js
@@ -74,7 +74,7 @@ const ActionList = React.forwardRef(function ActionList(props, userRef) {
     }
   }, [focusIndex, focusableItemList]);
 
-  function assignRefs() {
+  function assignRefs(node) {
     wrapperRef.current = node;
     if (userRef) {
       userRef.current = node;

--- a/packages/matchbox/src/components/ActionList/ActionList.js
+++ b/packages/matchbox/src/components/ActionList/ActionList.js
@@ -18,9 +18,11 @@ const Wrapper = styled('div')`
 const ActionList = React.forwardRef(function ActionList(props, userRef) {
   const {
     actions = [],
+    'aria-labelledby': labelledBy,
     className,
     children,
     'data-id': dataId,
+    id,
     sections = [],
     maxHeight = 'none',
     onClick,
@@ -84,8 +86,10 @@ const ActionList = React.forwardRef(function ActionList(props, userRef) {
 
   return (
     <Wrapper
+      aria-labelledby={labelledBy}
       className={className}
       data-id={dataId}
+      id={id}
       maxHeight={typeof maxHeight === 'number' ? `${maxHeight}px` : maxHeight}
       onClick={onClick}
       tabIndex="-1"
@@ -114,6 +118,8 @@ ActionList.propTypes = {
   ),
   className: PropTypes.string,
   'data-id': PropTypes.string,
+  'aria-labelledby': PropTypes.string,
+  id: PropTypes.string,
   /**
    * Creates sections
    * e.g. [[{ content: 'action label', onClick: callback() }]]

--- a/packages/matchbox/src/components/ActionList/styles.js
+++ b/packages/matchbox/src/components/ActionList/styles.js
@@ -35,13 +35,13 @@ export const StyledLink = styled(UnstyledLink)`
   &:visited {
     text-decoration: none;
     color: ${props => (props.highlighted ? tokens.color_blue_700 : tokens.color_gray_900)};
-    background: ${props => (props.highlighted ? tokens.color_blue_100 : 'none')};
+    background: ${props => (props.highlighted ? tokens.color_blue_200 : 'none')};
   }
 
   &:hover,
   &:focus {
     outline: none;
-    color: ${tokens.color_blue_700};
+    color: ${tokens.color_gray_900};
     background: ${tokens.color_blue_100};
   }
 

--- a/packages/matchbox/src/components/ComboBox/tests/ComboBox.test.js
+++ b/packages/matchbox/src/components/ComboBox/tests/ComboBox.test.js
@@ -16,7 +16,7 @@ describe('ComboBox Wrapper', () => {
   it('should menu correctly inside textfield', () => {
     const { getByRole, getByText } = subject();
     expect(getByRole('textbox')).toBeTruthy();
-    expect(getByRole('button', { name: 'foo' })).toBeTruthy();
+    expect(getByRole('menuitem', { name: 'foo' })).toBeTruthy();
     expect(getByText(/test help/g)).toBeTruthy();
   });
 });

--- a/packages/matchbox/src/components/Popover/Popover.js
+++ b/packages/matchbox/src/components/Popover/Popover.js
@@ -5,7 +5,7 @@ import { createPropTypes } from '@styled-system/prop-types';
 import { Box } from '../Box';
 import PopoverOverlay from './PopoverOverlay';
 import PopoverContent from './PopoverContent';
-import { onKeys } from '../../helpers/keyEvents';
+import { onKey, onKeys } from '../../helpers/keyEvents';
 import useWindowEvent from '../../hooks/useWindowEvent';
 import { deprecate } from '../../helpers/propTypes';
 import { findFocusableChild } from '../../helpers/focus';
@@ -20,6 +20,7 @@ const Popover = React.forwardRef(function Popover(props, ref) {
     trigger,
     wrapper,
     portalId,
+    closeOnTab,
     ...rest
   } = props;
   const [open, setOpen] = React.useState(null);
@@ -88,14 +89,30 @@ const Popover = React.forwardRef(function Popover(props, ref) {
   // Toggles uncontrolled popovers on escape keydown, and calls `onClose` for controlled popovers
   function handleEsc(e) {
     if (onClose && shouldBeOpen) {
-      onKeys(['escape'], () => {
+      onKey('escape', () => {
         onClose(e);
         focusOnActivator();
       })(e);
     }
 
+    if (onClose && shouldBeOpen && closeOnTab) {
+      onKey('tab', () => {
+        onClose(e);
+        focusOnActivator();
+      })(e);
+    }
+
+    // Uncontrolled
     if (open) {
-      onKeys(['escape', 'tab'], () => {
+      onKey('escape', () => {
+        handleUncontrolledToggle();
+        focusOnActivator();
+      })(e);
+    }
+
+    // Uncontrolled
+    if (closeOnTab && open) {
+      onKey('tab', () => {
         handleUncontrolledToggle();
         focusOnActivator();
       })(e);
@@ -200,8 +217,13 @@ Popover.propTypes = {
   as: PropTypes.oneOf(['div', 'span']),
   wrapper: deprecate(PropTypes.oneOf(['div', 'span']), 'Use `as` prop instead'),
   portalId: PropTypes.string,
+  closeOnTab: PropTypes.bool,
   ...createPropTypes(padding.propNames),
   ...createPropTypes(layout.propNames),
+};
+
+Popover.defaultProps = {
+  closeOnTab: true,
 };
 
 export default Popover;

--- a/packages/matchbox/src/components/Popover/Popover.js
+++ b/packages/matchbox/src/components/Popover/Popover.js
@@ -5,13 +5,23 @@ import { createPropTypes } from '@styled-system/prop-types';
 import { Box } from '../Box';
 import PopoverOverlay from './PopoverOverlay';
 import PopoverContent from './PopoverContent';
-import { onKey } from '../../helpers/keyEvents';
+import { onKeys } from '../../helpers/keyEvents';
 import useWindowEvent from '../../hooks/useWindowEvent';
 import { deprecate } from '../../helpers/propTypes';
 import { findFocusableChild } from '../../helpers/focus';
 
 const Popover = React.forwardRef(function Popover(props, ref) {
-  const { as, id, open: controlledOpen, onClose, children, trigger, wrapper, ...rest } = props;
+  const {
+    as,
+    id,
+    open: controlledOpen,
+    onClose,
+    children,
+    trigger,
+    wrapper,
+    portalId,
+    ...rest
+  } = props;
   const [open, setOpen] = React.useState(null);
   const popoverRef = React.useRef();
   const activatorRef = React.useRef();
@@ -73,14 +83,14 @@ const Popover = React.forwardRef(function Popover(props, ref) {
   // Toggles uncontrolled popovers on escape keydown, and calls `onClose` for controlled popovers
   function handleEsc(e) {
     if (onClose && shouldBeOpen) {
-      onKey('escape', () => {
+      onKeys(['escape', 'tab'], () => {
         onClose(e);
         focusOnActivator();
       })(e);
     }
 
     if (open) {
-      onKey('escape', () => {
+      onKeys(['escape', 'tab'], () => {
         handleUncontrolledToggle();
         focusOnActivator();
       })(e);
@@ -139,6 +149,7 @@ const Popover = React.forwardRef(function Popover(props, ref) {
       renderActivator={renderActivator}
       renderPopover={renderPopover}
       activatorRef={activatorRef}
+      portalId={portalId}
     />
   );
 });
@@ -174,7 +185,7 @@ Popover.propTypes = {
   children: PropTypes.node,
   as: PropTypes.oneOf(['div', 'span']),
   wrapper: deprecate(PropTypes.oneOf(['div', 'span']), 'Use `as` prop instead'),
-  portalId: deprecate(PropTypes.string, 'Portals are no longer used in Popovers'),
+  portalId: PropTypes.string,
   ...createPropTypes(padding.propNames),
   ...createPropTypes(layout.propNames),
 };

--- a/packages/matchbox/src/components/Popover/Popover.js
+++ b/packages/matchbox/src/components/Popover/Popover.js
@@ -8,7 +8,7 @@ import PopoverContent from './PopoverContent';
 import { onKeys } from '../../helpers/keyEvents';
 import useWindowEvent from '../../hooks/useWindowEvent';
 import { deprecate } from '../../helpers/propTypes';
-import { findFocusableChild } from '../../helpers/focus';
+import { findFocusableChild, findInteractiveChild } from '../../helpers/focus';
 
 const Popover = React.forwardRef(function Popover(props, ref) {
   const {
@@ -43,7 +43,8 @@ const Popover = React.forwardRef(function Popover(props, ref) {
   // Automatically focuses on content when opening
   React.useLayoutEffect(() => {
     if (shouldBeOpen && popoverRef && popoverRef.current) {
-      popoverRef.current.focus();
+      const contentToFocus = findInteractiveChild(popoverRef.current) || popoverRef.current;
+      contentToFocus.focus();
     }
   }, [shouldBeOpen]);
 
@@ -104,6 +105,14 @@ const Popover = React.forwardRef(function Popover(props, ref) {
     }
   }
 
+  function handleActivatorKey(e) {
+    if (open === false) {
+      onKeys(['arrowUp', 'arrowDown'], () => {
+        handleUncontrolledToggle();
+      })(e);
+    }
+  }
+
   // Renders popover content
   function renderPopover() {
     function assignRefs(node) {
@@ -134,6 +143,7 @@ const Popover = React.forwardRef(function Popover(props, ref) {
         display={Wrapper === 'span' ? 'inline-block' : null}
         position="relative"
         onClick={handleTrigger}
+        onKeyDown={handleActivatorKey}
         ref={assignRefs}
       >
         {trigger}

--- a/packages/matchbox/src/components/Popover/Popover.js
+++ b/packages/matchbox/src/components/Popover/Popover.js
@@ -60,7 +60,7 @@ const Popover = React.forwardRef(function Popover(props, ref) {
       activatorElem.setAttribute('aria-haspopup', 'true');
       activatorElem.setAttribute('aria-expanded', Boolean(shouldBeOpen));
     }
-  }, [activatorRef, open, controlledOpen]);
+  }, [trigger, activatorRef, open, controlledOpen]);
 
   // Toggles uncontrolled open state
   function handleUncontrolledToggle() {

--- a/packages/matchbox/src/components/Popover/Popover.js
+++ b/packages/matchbox/src/components/Popover/Popover.js
@@ -84,7 +84,7 @@ const Popover = React.forwardRef(function Popover(props, ref) {
   // Toggles uncontrolled popovers on escape keydown, and calls `onClose` for controlled popovers
   function handleEsc(e) {
     if (onClose && shouldBeOpen) {
-      onKeys(['escape', 'tab'], () => {
+      onKeys(['escape'], () => {
         onClose(e);
         focusOnActivator();
       })(e);

--- a/packages/matchbox/src/components/Popover/Popover.js
+++ b/packages/matchbox/src/components/Popover/Popover.js
@@ -129,6 +129,8 @@ const Popover = React.forwardRef(function Popover(props, ref) {
   function handleActivatorKey(e) {
     if (open === false) {
       onKeys(['arrowUp', 'arrowDown'], () => {
+        // Stop arrow keys from scrolling the page
+        e.preventDefault();
         handleUncontrolledToggle();
       })(e);
     }

--- a/packages/matchbox/src/components/Popover/Popover.js
+++ b/packages/matchbox/src/components/Popover/Popover.js
@@ -8,7 +8,7 @@ import PopoverContent from './PopoverContent';
 import { onKeys } from '../../helpers/keyEvents';
 import useWindowEvent from '../../hooks/useWindowEvent';
 import { deprecate } from '../../helpers/propTypes';
-import { findFocusableChild, findInteractiveChild } from '../../helpers/focus';
+import { findFocusableChild } from '../../helpers/focus';
 
 const Popover = React.forwardRef(function Popover(props, ref) {
   const {
@@ -41,10 +41,15 @@ const Popover = React.forwardRef(function Popover(props, ref) {
   }, []);
 
   // Automatically focuses on content when opening
-  React.useLayoutEffect(() => {
+  React.useEffect(() => {
     if (shouldBeOpen && popoverRef && popoverRef.current) {
-      const contentToFocus = findInteractiveChild(popoverRef.current) || popoverRef.current;
-      contentToFocus.focus();
+      const contentToFocus = findFocusableChild(popoverRef.current) || popoverRef.current;
+
+      // Honestly not sure why this doesn't work without a timeout
+      setTimeout(() => {
+        console.log(contentToFocus);
+        contentToFocus.focus();
+      }, 10);
     }
   }, [shouldBeOpen]);
 

--- a/packages/matchbox/src/components/Popover/Popover.js
+++ b/packages/matchbox/src/components/Popover/Popover.js
@@ -55,8 +55,12 @@ const Popover = React.forwardRef(function Popover(props, ref) {
 
   // Handles `aria-haspopup` and `aria-expanded` attributes on the activator
   React.useEffect(() => {
-    applyActivatorAttributes();
-  }, [activatorRef, shouldBeOpen]);
+    if (activatorRef && activatorRef.current) {
+      const activatorElem = findFocusableChild(activatorRef.current) || activatorRef.current;
+      activatorElem.setAttribute('aria-haspopup', 'true');
+      activatorElem.setAttribute('aria-expanded', Boolean(shouldBeOpen));
+    }
+  }, [activatorRef, open, controlledOpen]);
 
   // Toggles uncontrolled open state
   function handleUncontrolledToggle() {
@@ -69,14 +73,6 @@ const Popover = React.forwardRef(function Popover(props, ref) {
     if (activatorRef && activatorRef.current) {
       const activatorToFocus = findFocusableChild(activatorRef.current) || activatorRef.current;
       activatorToFocus.focus();
-    }
-  }
-
-  function applyActivatorAttributes() {
-    if (activatorRef && activatorRef.current) {
-      const activatorElem = findFocusableChild(activatorRef.current) || activatorRef.current;
-      activatorElem.setAttribute('aria-haspopup', 'true');
-      activatorElem.setAttribute('aria-expanded', shouldBeOpen);
     }
   }
 

--- a/packages/matchbox/src/components/Popover/Popover.js
+++ b/packages/matchbox/src/components/Popover/Popover.js
@@ -53,6 +53,11 @@ const Popover = React.forwardRef(function Popover(props, ref) {
     }
   }, [shouldBeOpen]);
 
+  // Handles `aria-haspopup` and `aria-expanded` attributes on the activator
+  React.useEffect(() => {
+    applyActivatorAttributes();
+  }, [activatorRef, shouldBeOpen]);
+
   // Toggles uncontrolled open state
   function handleUncontrolledToggle() {
     setOpen(!open);
@@ -64,6 +69,14 @@ const Popover = React.forwardRef(function Popover(props, ref) {
     if (activatorRef && activatorRef.current) {
       const activatorToFocus = findFocusableChild(activatorRef.current) || activatorRef.current;
       activatorToFocus.focus();
+    }
+  }
+
+  function applyActivatorAttributes() {
+    if (activatorRef && activatorRef.current) {
+      const activatorElem = findFocusableChild(activatorRef.current) || activatorRef.current;
+      activatorElem.setAttribute('aria-haspopup', 'true');
+      activatorElem.setAttribute('aria-expanded', shouldBeOpen);
     }
   }
 

--- a/packages/matchbox/src/components/Popover/Popover.js
+++ b/packages/matchbox/src/components/Popover/Popover.js
@@ -47,7 +47,6 @@ const Popover = React.forwardRef(function Popover(props, ref) {
 
       // Honestly not sure why this doesn't work without a timeout
       setTimeout(() => {
-        console.log(contentToFocus);
         contentToFocus.focus();
       }, 10);
     }

--- a/packages/matchbox/src/components/Popover/PopoverContent.js
+++ b/packages/matchbox/src/components/Popover/PopoverContent.js
@@ -69,13 +69,7 @@ const Content = React.forwardRef(function Content(props, userRef) {
       nodeRef={transitionRef}
     >
       {state => (
-        <Box
-          data-id="popover-focus-wrapper"
-          position="relative"
-          height="100%"
-          ref={userRef}
-          tabIndex="-1"
-        >
+        <Box position="relative" height="100%" ref={userRef} tabIndex="-1">
           <StyledContent
             data-id="popover-content"
             className={className}

--- a/packages/matchbox/src/components/Popover/PopoverContent.js
+++ b/packages/matchbox/src/components/Popover/PopoverContent.js
@@ -69,7 +69,13 @@ const Content = React.forwardRef(function Content(props, userRef) {
       nodeRef={transitionRef}
     >
       {state => (
-        <Box data-id="popover-focus-wrapper" position="relative" height="100%" ref={userRef}>
+        <Box
+          data-id="popover-focus-wrapper"
+          position="relative"
+          height="100%"
+          ref={userRef}
+          tabIndex="-1"
+        >
           <StyledContent
             data-id="popover-content"
             className={className}

--- a/packages/matchbox/src/components/Popover/PopoverContent.js
+++ b/packages/matchbox/src/components/Popover/PopoverContent.js
@@ -69,13 +69,7 @@ const Content = React.forwardRef(function Content(props, userRef) {
       nodeRef={transitionRef}
     >
       {state => (
-        <Box
-          data-id="popover-focus-wrapper"
-          position="relative"
-          height="100%"
-          ref={userRef}
-          tabIndex="-1"
-        >
+        <Box data-id="popover-focus-wrapper" position="relative" height="100%" ref={userRef}>
           <StyledContent
             data-id="popover-content"
             className={className}

--- a/packages/matchbox/src/components/Popover/PopoverOverlay.js
+++ b/packages/matchbox/src/components/Popover/PopoverOverlay.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { WindowEvent } from '../WindowEvent';
+import { Portal } from '../Portal';
 import { Box } from '../Box';
 import { getPositionFor } from '../../helpers/geometry';
 
@@ -14,7 +15,7 @@ const defaultPosition = {
 function PopoverOverlay(props) {
   const [position, setPosition] = React.useState(defaultPosition);
   const activatorRef = React.useRef(null);
-  const { as, id, open, renderPopover, renderActivator } = props;
+  const { as, id, open, renderPopover, renderActivator, portalId } = props;
 
   function handleMeasurement() {
     setPosition(getPositionFor(activatorRef.current));
@@ -38,19 +39,21 @@ function PopoverOverlay(props) {
             activatorRef.current = node;
           },
         })}
-        <Box
-          {...(!open ? { 'aria-hidden': true } : {})}
-          id={id}
-          position="absolute"
-          top="0"
-          left="0"
-          height={`${position.height}px`}
-          width={`${position.width}px`}
-          zIndex="overlay"
-          style={{ pointerEvents: 'none' }}
-        >
-          {renderPopover()}
-        </Box>
+        <Portal containerId={portalId}>
+          <Box
+            {...(!open ? { 'aria-hidden': true } : {})}
+            id={id}
+            position="fixed"
+            left={`${position.left}px`}
+            top={`${position.top}px`}
+            height={`${position.height}px`}
+            width={`${position.width}px`}
+            zIndex="overlay"
+            style={{ pointerEvents: 'none' }}
+          >
+            {renderPopover()}
+          </Box>
+        </Portal>
       </Box>
     </>
   );

--- a/packages/matchbox/src/components/Popover/PopoverOverlay.js
+++ b/packages/matchbox/src/components/Popover/PopoverOverlay.js
@@ -43,7 +43,7 @@ function PopoverOverlay(props) {
           <Box
             {...(!open ? { 'aria-hidden': true } : {})}
             id={id}
-            position="fixed"
+            position="absolute"
             left={`${position.left}px`}
             top={`${position.top}px`}
             height={`${position.height}px`}

--- a/packages/matchbox/src/components/Popover/PopoverOverlay.js
+++ b/packages/matchbox/src/components/Popover/PopoverOverlay.js
@@ -4,6 +4,7 @@ import { WindowEvent } from '../WindowEvent';
 import { Portal } from '../Portal';
 import { Box } from '../Box';
 import { getPositionFor } from '../../helpers/geometry';
+import { tokens } from '@sparkpost/design-tokens';
 
 const defaultPosition = {
   top: 0,
@@ -48,7 +49,7 @@ function PopoverOverlay(props) {
             top={`${position.top}px`}
             height={`${position.height}px`}
             width={`${position.width}px`}
-            zIndex="overlay"
+            zIndex={tokens.zIndex_overlay + 1}
             style={{ pointerEvents: 'none' }}
           >
             {renderPopover()}

--- a/packages/matchbox/src/components/Portal/Portal.js
+++ b/packages/matchbox/src/components/Portal/Portal.js
@@ -1,34 +1,29 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 
-class Portal extends Component {
-  static displayName = 'Portal';
+function Portal(props) {
+  const { containerId, children } = props;
 
-  static propTypes = {
-    /**
-     * ID of the target portal container. Appends a new portal to document body if not provided.
-     */
-    containerId: PropTypes.string,
-    /**
-      * Content rendered inside the portal
-      */
-    children: PropTypes.node
-  };
-
-  render() {
-    const { containerId, children } = this.props;
-
-    if (typeof document !== 'undefined') {
-      const container = containerId
-        ? document.getElementById(containerId)
-        : document.body;
-
+  if (typeof document !== 'undefined') {
+    const container = containerId ? document.getElementById(containerId) : document.body;
+    if (container) {
       return ReactDOM.createPortal(children, container);
     }
-
-    return null;
   }
+
+  return null;
 }
+
+Portal.displayName = 'Portal';
+Portal.propTypes = {
+  /**
+   * ID of the target portal container. Appends a new portal to document body if not provided.
+   */
+  containerId: PropTypes.string,
+  /**
+   * Content rendered inside the portal
+   */
+  children: PropTypes.node,
+};
 
 export default Portal;

--- a/packages/matchbox/src/components/Table/Table.js
+++ b/packages/matchbox/src/components/Table/Table.js
@@ -9,39 +9,17 @@ import { pick } from '../../helpers/props';
 import { Cell, HeaderCell, Row, TotalsRow } from './TableElements';
 import SortButton from './SortButton';
 import { TablePaddingContext } from './context';
-import { table, wrapper } from './styles';
+import { table, wrapper, sticky } from './styles';
 
 const StyledTable = styled('table')`
   ${table}
   ${padding}
+  ${sticky}
 `;
 
 const Wrapper = styled(Box)`
   ${wrapper}
   ${margin}
-`;
-
-const DuplicatedTable = styled(Box)`
-  pointer-events: none;
-  z-index: ${({ theme }) => theme.zIndices.default};
-
-  th:not(:first-child),
-  td:not(:first-child) {
-    visibility: hidden;
-    pointer-events: none;
-    border-color: transparent !important;
-  }
-  tr {
-    background: none !important;
-  }
-  th:first-child,
-  td:first-child {
-    background: ${({ theme }) => theme.colors.white};
-    pointer-events: auto;
-    ${({ isScrolled, theme }) => (isScrolled ? `box-shadow: ${theme.shadows[200]};` : '')};
-    transition: ${({ theme }) =>
-      `box-shadow ${theme.motion.duration.medium} ${theme.motion.ease.inOut}`};
-  }
 `;
 
 function Table(props) {
@@ -57,14 +35,12 @@ function Table(props) {
     ...rest
   } = props;
   const [isScrolled, setIsScrolled] = React.useState(false);
-
   const handleScroll = React.useCallback(
     e => {
       setIsScrolled(e.target.scrollLeft > 10);
     },
     [freezeFirstColumn],
   );
-
   const dataMarkup = data ? (
     <tbody>
       {data.map((rowData, i) => (
@@ -74,50 +50,33 @@ function Table(props) {
   ) : (
     children
   );
-
   const { px = '450', py = '400', ...paddingProps } = pick(rest, padding.propNames);
   const marginProps = pick(rest, margin.propNames);
 
   return (
-    <Box position="relative">
-      <TablePaddingContext.Provider value={{ px, py, ...paddingProps }}>
-        {freezeFirstColumn && (
-          <DuplicatedTable
-            data-id="matchbox-sticky-table"
-            position="absolute"
-            top="0"
-            left="0"
-            right="0"
-            overflow="clip visible"
-            isScrolled={isScrolled}
-          >
-            <StyledTable>{dataMarkup}</StyledTable>
-          </DuplicatedTable>
-        )}
-        <Wrapper
-          data-id="matchbox-scroll-wrapper"
-          freezeFirstColumn={freezeFirstColumn}
-          onScroll={freezeFirstColumn ? handleScroll : null}
-          {...marginProps}
-        >
-          <StyledTable
-            aria-readonly={readOnly}
-            data-id={dataId}
-            freezeFirstColumn={freezeFirstColumn}
-            id={id}
-            isScrolled={isScrolled}
-            role={role}
-          >
-            {title && (
-              <caption>
-                <ScreenReaderOnly>{title}</ScreenReaderOnly>
-              </caption>
-            )}
-            {dataMarkup}
-          </StyledTable>
-        </Wrapper>
-      </TablePaddingContext.Provider>
-    </Box>
+    <Wrapper
+      freezeFirstColumn={freezeFirstColumn}
+      onScroll={freezeFirstColumn ? handleScroll : null}
+      {...marginProps}
+    >
+      <StyledTable
+        aria-readonly={readOnly}
+        data-id={dataId}
+        freezeFirstColumn={freezeFirstColumn}
+        id={id}
+        isScrolled={isScrolled}
+        role={role}
+      >
+        <TablePaddingContext.Provider value={{ px, py, ...paddingProps }}>
+          {title && (
+            <caption>
+              <ScreenReaderOnly>{title}</ScreenReaderOnly>
+            </caption>
+          )}
+          {dataMarkup}
+        </TablePaddingContext.Provider>
+      </StyledTable>
+    </Wrapper>
   );
 }
 

--- a/packages/matchbox/src/components/Table/styles.js
+++ b/packages/matchbox/src/components/Table/styles.js
@@ -15,21 +15,30 @@ export const headerCell = ({ theme }) => `
   font-weight: ${theme.fontWeights.semibold};
 `;
 
-export const sticky = ({ isScrolled, freezeFirstColumn, theme }) => {
+export const sticky = ({ isScrolled, freezeFirstColumn }) => {
   return `
     td:first-child, th:first-child {
       ${
         freezeFirstColumn
           ? `
-            transition: box-shadow ${tokens.motionDuration_medium} ${tokens.motionEase_in_out};
             position: sticky;
             left: 0;
             background: inherit;
             z-index: 1;
+            &:after {
+              transition: box-shadow ${tokens.motionDuration_medium} ${tokens.motionEase_in_out};
+              ${isScrolled ? `box-shadow: 16px 0 10px -12px inset rgb(44 53 61 / 20%);` : ''}
+              content: "";
+              height: 100%;
+              position: absolute;
+              top: 0;
+              right: -15px;
+              width: 15px;
+            }
           `
           : ''
       }
-      ${isScrolled ? `box-shadow: ${theme.shadows['400']};` : ''}
+      
     }
   `;
 };

--- a/packages/matchbox/src/components/Table/styles.js
+++ b/packages/matchbox/src/components/Table/styles.js
@@ -1,22 +1,12 @@
+import { tokens } from '@sparkpost/design-tokens';
 import { system } from 'styled-system';
 
-export const table = ({ freezeFirstColumn }) => `
+export const table = () => `
   position: relative;
   text-align: left;
   width: 100%;
   padding: 0;
   border-collapse: collapse;
-
-  ${
-    freezeFirstColumn
-      ? `
-        td:first-child, th:first-child {
-          visibility: hidden;
-        }
-  `
-      : ''
-  }
-  
 `;
 
 export const headerCell = ({ theme }) => `
@@ -25,44 +15,56 @@ export const headerCell = ({ theme }) => `
   font-weight: ${theme.fontWeights.semibold};
 `;
 
+export const sticky = ({ isScrolled, freezeFirstColumn, theme }) => {
+  return `
+    td:first-child, th:first-child {
+      ${
+        freezeFirstColumn
+          ? `
+            transition: box-shadow ${tokens.motionDuration_medium} ${tokens.motionEase_in_out};
+            position: sticky;
+            left: 0;
+            background: inherit;
+            z-index: 1;
+          `
+          : ''
+      }
+      ${isScrolled ? `box-shadow: ${theme.shadows['400']};` : ''}
+    }
+  `;
+};
+
 export const cell = () => `
   word-break: break-all;
 `;
 
 const zebra = theme => `
-  tbody &:nth-of-type(odd) td {
-    background: ${theme.colors.gray[100]};
-  }
-  tbody &:nth-of-type(even) td, thead & th {
-    background: ${theme.colors.white};
+  tbody &:nth-of-type(odd) {
+    background: ${theme.colors.gray['100']};
   }
 `;
 
 export const row = ({ theme }) => `
+  background: ${theme.colors.white};
   border: none;
-
-  thead & th {
+  thead & {
     border-bottom:${theme.borders['300']};
   }
-
   ${zebra(theme)}
 `;
 
 export const totalsRow = ({ theme }) => `
-  &:not(:last-child) td {
+  &:not(:last-child) {
     border-bottom: ${theme.borders['500']};
   }
-
-  &:not(:first-child) td {
+  &:not(:first-child) {
     border-top: ${theme.borders['500']};
   }
-
   td {
     font-weight: ${theme.fontWeights.semibold};
   }
   ${zebra(theme)}
 `;
-
 export const verticalAlignment = system({
   alignY: {
     property: 'verticalAlign',
@@ -73,7 +75,6 @@ export const verticalAlignment = system({
     },
   },
 });
-
 export const horizontalAlignment = system({
   align: {
     property: 'textAlign',
@@ -86,5 +87,5 @@ export const horizontalAlignment = system({
 });
 
 export const wrapper = ({ freezeFirstColumn }) => `
-  ${freezeFirstColumn ? 'overflow: auto;' : ''}
+   ${freezeFirstColumn ? 'overflow: auto;' : ''}
 `;

--- a/packages/matchbox/src/components/Table/tests/Table.test.js
+++ b/packages/matchbox/src/components/Table/tests/Table.test.js
@@ -94,7 +94,7 @@ describe('Table', () => {
 
   it('should distribute system props correctly', () => {
     wrapper = subject({ p: '100', m: '100' });
-    expect(wrapper.find('div').at(1)).toHaveStyleRule('margin', '100');
+    expect(wrapper.find('div').at(0)).toHaveStyleRule('margin', '100');
     expect(wrapper.find('div').at(1)).not.toHaveStyleRule('padding', '100');
     expect(wrapper.find('table')).not.toHaveStyleRule('margin', '100');
   });

--- a/packages/matchbox/src/helpers/focus.js
+++ b/packages/matchbox/src/helpers/focus.js
@@ -1,12 +1,6 @@
 const FOCUSABLE_SELECTOR =
   'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled),*[tabindex]';
-const INTERACTIVE_SELECTOR =
-  'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled)';
 
 export function findFocusableChild(element) {
   return element.querySelector(FOCUSABLE_SELECTOR);
-}
-
-export function findInteractiveChild(element) {
-  return element.querySelector(INTERACTIVE_SELECTOR);
 }

--- a/packages/matchbox/src/helpers/focus.js
+++ b/packages/matchbox/src/helpers/focus.js
@@ -1,6 +1,12 @@
 const FOCUSABLE_SELECTOR =
   'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled),*[tabindex]';
+const INTERACTIVE_SELECTOR =
+  'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled)';
 
 export function findFocusableChild(element) {
   return element.querySelector(FOCUSABLE_SELECTOR);
+}
+
+export function findInteractiveChild(element) {
+  return element.querySelector(INTERACTIVE_SELECTOR);
 }

--- a/packages/matchbox/src/helpers/string.js
+++ b/packages/matchbox/src/helpers/string.js
@@ -1,3 +1,3 @@
 export function secondsToMS(secondsStr) {
-  return Number(secondsStr.replace(/\D/g, '')) * 100;
+  return Number(secondsStr.replace(/\D/g, '')) * 10;
 }


### PR DESCRIPTION
### What Changed
- Changes the behavior of Popovers
  - Popovers are now rendered in a `Portal`
  - Popovers now correctly focus on a focusable child when opening
  - Popovers now open when hitting the up or down arrows when uncontrolled
  - Popovers now close when pressing tab (via a new prop)
- ActionList
  - ActionLists are now keyboard navigable with the up and down arrows
  - ActionLists now properly set `role="menuitem"` and `role="menu"`
- Table
  - Tables now only render one table with the `freezeFirstColumn` prop

### How To Test or Verify

- Run libby
- Visit http://localhost:9001/?path=Popover__with-an-ActionList
  - Verify the changes above
- On: http://localhost:9001/?path=Popover__uncontrolled
  - Verify the popover container is focused when opened
- On: http://localhost:9001/?path=Popover__controlled
  - Verify the close button is focused when opened
- On: http://localhost:9001/?path=Table__frozen-first-column
  - Verify popovers work correctly in the first column of the table

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
