### PR TITLE
Resloves #878 Fix error label icon alignment

### DIFF
--- a/libby/form/TextField.lib.js
+++ b/libby/form/TextField.lib.js
@@ -17,7 +17,7 @@ describe('TextField', () => {
   add('help text and error', () => (
     <TextField
       id="id"
-      error="You forgot an ID!"
+      error="You forgot an ID! You forgot an ID! You forgot an ID! ! You forgot an ID! You forgot an ID! ! You forgot an ID! You forgot an ID! ! You forgot an ID! You forgot an ID! You forgot an ID! You forgot an ID! You forgot an ID! You forgot an ID! You forgot an ID! You forgot an ID!"
       label="Template ID"
       helpText={
         <>

--- a/libby/form/TextField.lib.js
+++ b/libby/form/TextField.lib.js
@@ -17,7 +17,7 @@ describe('TextField', () => {
   add('help text and error', () => (
     <TextField
       id="id"
-      error="You forgot an ID! You forgot an ID! You forgot an ID! ! You forgot an ID! You forgot an ID! ! You forgot an ID! You forgot an ID! ! You forgot an ID! You forgot an ID! You forgot an ID! You forgot an ID! You forgot an ID! You forgot an ID! You forgot an ID! You forgot an ID!"
+      error="You forgot an ID!"
       label="Template ID"
       helpText={
         <>

--- a/packages/matchbox/src/components/Error/Error.js
+++ b/packages/matchbox/src/components/Error/Error.js
@@ -13,9 +13,9 @@ function Error(props) {
         fontSize="200"
         lineHeight="200"
         display="inline-flex"
-        alignItems="center"
+        alignItems="flex-start"
       >
-        <Box as="span" display="inline-block" mr="100" lineHeight="0">
+        <Box as="span" display="inline-block" mr="100" pt="2px" lineHeight="0">
           <ErrorIcon size={14} label="Error" />
         </Box>
         <span>{error}</span>


### PR DESCRIPTION
Closes #878 

### What Changed

Top aligns the icon in the Error component:

<img width="954" alt="Screen Shot 2021-07-02 at 7 12 29 AM" src="https://user-images.githubusercontent.com/3903325/124266378-e7c91800-db04-11eb-858d-c9a81266c786.png">

### How To Test or Verify
- Run libby
- Visit any input story with the error component
- Try adding a long error message
- Verify the icon is top aligned

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
