### PR TITLE
Resolves #879 & #880 – Support data-id and className in input groups

### DIFF
--- a/packages/matchbox/src/components/Checkbox/Group.js
+++ b/packages/matchbox/src/components/Checkbox/Group.js
@@ -16,11 +16,20 @@ const StyledGroup = styled('fieldset')`
 `;
 
 function Group(props) {
-  const { children, label, labelHidden, required, optional, ...rest } = props;
+  const {
+    'data-id': dataId,
+    children,
+    className,
+    label,
+    labelHidden,
+    required,
+    optional,
+    ...rest
+  } = props;
   const systemProps = pick(rest);
 
   return (
-    <StyledGroup {...systemProps}>
+    <StyledGroup {...systemProps} className={className} data-id={dataId}>
       {label && (
         <Box width="100%">
           <Label as="legend" labelHidden={labelHidden}>
@@ -43,6 +52,8 @@ function Group(props) {
 
 Group.propTypes = {
   children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+  'data-id': PropTypes.string,
   label: PropTypes.node,
   required: PropTypes.bool,
   labelHidden: PropTypes.bool,

--- a/packages/matchbox/src/components/Checkbox/tests/Group.test.js
+++ b/packages/matchbox/src/components/Checkbox/tests/Group.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Group from '../Group';
+import { render } from 'test-utils';
 
 describe('Checkbox Group', () => {
   const subject = props => global.mountStyled(<Group {...props}>children</Group>);
@@ -33,5 +34,15 @@ describe('Checkbox Group', () => {
   it('renders with system props', () => {
     const wrapper = subject({ mb: '500' });
     expect(wrapper).toHaveStyleRule('margin-bottom', '1.5rem');
+  });
+
+  it('renders with a attributes', () => {
+    const { getByTestId, container } = render(
+      <Group data-id="test-id" className="test-class" label="test label">
+        children
+      </Group>,
+    );
+    expect(container.firstChild.classList.contains('test-class')).toBe(true);
+    expect(getByTestId('test-id')).toBeTruthy();
   });
 });

--- a/packages/matchbox/src/components/Radio/Group.js
+++ b/packages/matchbox/src/components/Radio/Group.js
@@ -17,11 +17,20 @@ const StyledGroup = styled('fieldset')`
 `;
 
 function Group(props) {
-  const { children, label, labelHidden, required, optional, ...rest } = props;
+  const {
+    'data-id': dataId,
+    children,
+    className,
+    label,
+    labelHidden,
+    required,
+    optional,
+    ...rest
+  } = props;
   const systemProps = pick(rest);
 
   return (
-    <StyledGroup {...systemProps} aria-required={required}>
+    <StyledGroup {...systemProps} aria-required={required} className={className} data-id={dataId}>
       {label && (
         <Box width="100%">
           <Label as="legend" labelHidden={labelHidden}>
@@ -40,6 +49,8 @@ function Group(props) {
 
 Group.propTypes = {
   children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+  'data-id': PropTypes.string,
   label: PropTypes.node.isRequired,
   labelHidden: PropTypes.bool,
   optional: PropTypes.bool,

--- a/packages/matchbox/src/components/Radio/tests/Group.test.js
+++ b/packages/matchbox/src/components/Radio/tests/Group.test.js
@@ -34,4 +34,14 @@ describe('Checkbox Group', () => {
     expect(getByText('test label')).toBeTruthy();
     expect(getByText('Required')).toBeTruthy();
   });
+
+  it('renders with a attributes', () => {
+    const { getByTestId, container } = render(
+      <Group data-id="test-id" className="test-class" label="test label">
+        children
+      </Group>,
+    );
+    expect(container.firstChild.classList.contains('test-class')).toBe(true);
+    expect(getByTestId('test-id')).toBeTruthy();
+  });
 });


### PR DESCRIPTION
Closes #879 
Closes #880 


<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed

<!--
What changes does this PR propose?
Provide screenshots or [screen recordings](https://getkap.co/) for any visual changes.
-->

### How To Test or Verify

<!--
Describe any steps that may help reviewers verify changes.
Anything beyond basic unit testing, such as assistive tech usage, or special interactions.
-->

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
