### PR TITLE
UX-584 Fix Popover Overlay bug

### DIFF
--- a/packages/matchbox/src/components/Popover/PopoverOverlay.js
+++ b/packages/matchbox/src/components/Popover/PopoverOverlay.js
@@ -28,7 +28,7 @@ function PopoverOverlay(props) {
 
   return (
     <>
-      {open && <WindowEvent event="resize" handler={handleMeasurement} />}
+      <WindowEvent event="resize" handler={handleMeasurement} />
       <Box
         as={as}
         // Inline block is required to measure and set height correctly on spans


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed

- Update positioning values for `PopoverOverlay` when popover is open or closed

### How To Test or Verify

- Verify the Popover [Story](http://localhost:9001/?path=Popover__positioning) 
- Open and close the popover, make the window smaller, and try scrolling to the right. Before the page would overflow because the overlay element positioning had not been updated

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
