### PR TITLE
UX-500 Add new `position` prop to `Popover`

### DIFF
--- a/libby/overlays/Popover.lib.js
+++ b/libby/overlays/Popover.lib.js
@@ -96,6 +96,63 @@ describe('Popover', () => {
     </>
   ));
 
+  add('positioning', () => (
+    <>
+      <Box display="flex">
+        <Box flex="1">
+          <Popover
+            id="test-popover-1"
+            p="200"
+            trigger={<Button aria-describedby="test-popover-1">Default</Button>}
+          >
+            Bottom & Right
+          </Popover>
+        </Box>
+        <Box flex="0">
+          <Popover
+            id="test-popover-2"
+            p="200"
+            position="bottomLeft"
+            trigger={<Button aria-describedby="test-popover-2">Bottom & Left</Button>}
+          >
+            Bottom & Left
+          </Popover>
+        </Box>
+      </Box>
+      <Box display="flex" mt="800">
+        <Box flex="1">
+          <Popover
+            id="test-popover-3"
+            p="200"
+            position="topRight"
+            trigger={<Button aria-describedby="test-popover-3">Top & Right</Button>}
+          >
+            Top & Right
+          </Popover>
+        </Box>
+        <Box flex="0">
+          <Popover
+            id="test-popover-4"
+            p="200"
+            position="topLeft"
+            trigger={<Button aria-describedby="test-popover-4">Top & Left</Button>}
+          >
+            Top & Left
+          </Popover>
+        </Box>
+      </Box>
+
+      <Popover
+        id="test-popover-5"
+        p="200"
+        position={['bottomRight', 'bottomLeft', 'topLeft', 'topRight']}
+        trigger={<Button aria-describedby="test-popover-5">Responsive positioning</Button>}
+      >
+        bottomRight, bottomLeft, topLeft, topRight
+      </Popover>
+    </>
+  ));
+
   describe('deprecated', () => {
     add('positioning', () => (
       <>

--- a/libby/overlays/Popover.lib.js
+++ b/libby/overlays/Popover.lib.js
@@ -82,56 +82,6 @@ describe('Popover', () => {
     </Popover>
   ));
 
-  add('positioning', () => (
-    <>
-      <Box display="flex">
-        <Box flex="1">
-          <Popover
-            id="test-popover-1"
-            p="200"
-            trigger={<Button aria-describedby="test-popover-1">Default</Button>}
-          >
-            Bottom & Right
-          </Popover>
-        </Box>
-        <Box flex="0">
-          <Popover
-            id="test-popover-2"
-            p="200"
-            bottom
-            left
-            trigger={<Button aria-describedby="test-popover-2">Bottom & Left</Button>}
-          >
-            Bottom & Left
-          </Popover>
-        </Box>
-      </Box>
-      <Box display="flex" mt="800">
-        <Box flex="1">
-          <Popover
-            id="test-popover-3"
-            p="200"
-            top
-            trigger={<Button aria-describedby="test-popover-3">Top & Right</Button>}
-          >
-            Top & Right
-          </Popover>
-        </Box>
-        <Box flex="0">
-          <Popover
-            id="test-popover-4"
-            p="200"
-            top
-            left
-            trigger={<Button aria-describedby="test-popover-4">Top & Left</Button>}
-          >
-            Top & Left
-          </Popover>
-        </Box>
-      </Box>
-    </>
-  ));
-
   add('works with system props', () => (
     <>
       <Popover
@@ -145,4 +95,56 @@ describe('Popover', () => {
       </Popover>
     </>
   ));
+
+  describe('deprecated', () => {
+    add('positioning', () => (
+      <>
+        <Box display="flex">
+          <Box flex="1">
+            <Popover
+              id="test-popover-1"
+              sectioned
+              trigger={<Button aria-describedby="test-popover-1">Default</Button>}
+            >
+              Bottom & Right
+            </Popover>
+          </Box>
+          <Box flex="0">
+            <Popover
+              id="test-popover-2"
+              p="200"
+              bottom
+              left
+              trigger={<Button aria-describedby="test-popover-2">Bottom & Left</Button>}
+            >
+              Bottom & Left
+            </Popover>
+          </Box>
+        </Box>
+        <Box display="flex" mt="800">
+          <Box flex="1">
+            <Popover
+              id="test-popover-3"
+              p="200"
+              top
+              trigger={<Button aria-describedby="test-popover-3">Top & Right</Button>}
+            >
+              Top & Right
+            </Popover>
+          </Box>
+          <Box flex="0">
+            <Popover
+              id="test-popover-4"
+              p="200"
+              top
+              left
+              trigger={<Button aria-describedby="test-popover-4">Top & Left</Button>}
+            >
+              Top & Left
+            </Popover>
+          </Box>
+        </Box>
+      </>
+    ));
+  });
 });

--- a/packages/matchbox/src/components/Page/Page.js
+++ b/packages/matchbox/src/components/Page/Page.js
@@ -79,7 +79,6 @@ function SecondaryActions({ actions = [], hasPrimaryAction }) {
       ml={hasPrimaryAction ? ['300', null, '0'] : '0'}
     >
       <Popover
-        bottom
         id="page-secondary-actions"
         position={['bottomRight', null, 'bottomLeft']}
         onClose={() => setIsOpen(false)}

--- a/packages/matchbox/src/components/Page/Page.js
+++ b/packages/matchbox/src/components/Page/Page.js
@@ -81,7 +81,7 @@ function SecondaryActions({ actions = [], hasPrimaryAction }) {
       <Popover
         bottom
         id="page-secondary-actions"
-        left={[false, null, true]}
+        position={['bottomRight', null, 'bottomLeft']}
         onClose={() => setIsOpen(false)}
         open={isOpen}
         trigger={

--- a/packages/matchbox/src/components/Popover/Popover.js
+++ b/packages/matchbox/src/components/Popover/Popover.js
@@ -217,7 +217,10 @@ Popover.propTypes = {
   right: deprecate(PropTypes.bool, 'Use `position` instead'),
   top: deprecate(PropTypes.bool, 'Use `position` instead'),
   bottom: deprecate(PropTypes.bool, 'Use `position` instead'),
-  position: PropTypes.oneOf(['topLeft', 'topRight', 'bottomLeft', 'bottomRight']),
+  position: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.oneOf(['topLeft', 'topRight', 'bottomLeft', 'bottomRight']),
+  ]),
   /**
    * Callback function that is called when clicking outside the popover, or hitting escape.
    */

--- a/packages/matchbox/src/components/Popover/Popover.js
+++ b/packages/matchbox/src/components/Popover/Popover.js
@@ -213,10 +213,11 @@ Popover.propTypes = {
    * By default, open state is handled automatically. Passing this value in will turn this into a controlled component.
    */
   open: PropTypes.bool,
-  left: PropTypes.oneOfType([PropTypes.bool, PropTypes.array]),
-  right: PropTypes.bool,
-  top: PropTypes.bool,
-  bottom: PropTypes.bool,
+  left: deprecate(PropTypes.bool, 'Use `position` instead'),
+  right: deprecate(PropTypes.bool, 'Use `position` instead'),
+  top: deprecate(PropTypes.bool, 'Use `position` instead'),
+  bottom: deprecate(PropTypes.bool, 'Use `position` instead'),
+  position: PropTypes.oneOf(['topLeft', 'topRight', 'bottomLeft', 'bottomRight']),
   /**
    * Callback function that is called when clicking outside the popover, or hitting escape.
    */

--- a/packages/matchbox/src/components/Popover/PopoverContent.js
+++ b/packages/matchbox/src/components/Popover/PopoverContent.js
@@ -14,29 +14,70 @@ const StyledContent = styled('div')`
   ${system}
   ${content}
   ${transition}
-  ${'' /* TODO Expand this to include top and bottom */}
   ${variant({
     variants: {
-      isLeft: {
+      bottomLeft: {
         right: '0',
         left: 'auto',
+        top: '100%',
+        bottom: 'auto',
+        mt: '100',
       },
-      isRight: {
+      bottomRight: {
         left: '0',
         right: 'auto',
+        top: '100%',
+        bottom: 'auto',
+        mt: '100',
+      },
+      topRight: {
+        left: '0',
+        right: 'auto',
+        top: 'auto',
+        bottom: '100%',
+        mb: '100',
+      },
+      topLeft: {
+        right: '0',
+        left: 'auto',
+        top: 'auto',
+        bottom: '100%',
+        mb: '100',
       },
     },
   })}
 `;
 
+function getPositionFromDeprecatedProps({ top, left }) {
+  if (left && !top) {
+    return 'bottomLeft';
+  }
+
+  if (!left && !top) {
+    return 'bottomRight';
+  }
+
+  if (left && top) {
+    return 'topLeft';
+  }
+
+  if (!left && top) {
+    return 'topRight';
+  }
+}
+
 const Content = React.forwardRef(function Content(props, userRef) {
   const {
     children,
     open,
+
+    // TODO: to be removed
     top = false,
     left = false,
     bottom = true,
-    // right = true,
+
+    // TODO: default to bottomRight when other deprecated props are removed
+    position,
     sectioned,
     className = '',
     trigger,
@@ -45,17 +86,10 @@ const Content = React.forwardRef(function Content(props, userRef) {
   } = props;
 
   const transitionRef = React.useRef();
-
   const systemProps = pick(rest);
 
-  // Allows for responsive positioning arrays
-  const horizontalPosition = React.useMemo(() => {
-    if (typeof left === 'object') {
-      return left.map(bool => (bool ? 'isLeft' : 'isRight'));
-    }
-
-    return left ? 'isLeft' : 'isRight';
-  });
+  // TODO: Remove in future
+  const variant = position || getPositionFromDeprecatedProps({ top, left, bottom });
 
   return (
     <Transition
@@ -75,9 +109,9 @@ const Content = React.forwardRef(function Content(props, userRef) {
             className={className}
             p={sectioned ? '400' : null}
             minWidth="13rem" // 208px
-            isTop={top}
-            isBottom={bottom}
-            variant={horizontalPosition}
+            variant={variant}
+            // TODO: remove in future, isTop is still needed for animation
+            isTop={variant.includes('top')}
             state={state}
             {...style}
             {...systemProps}

--- a/packages/matchbox/src/components/Popover/styles.js
+++ b/packages/matchbox/src/components/Popover/styles.js
@@ -6,11 +6,6 @@ export const content = props => `
   border: ${props.theme.borders['300']};
   border-radius: ${tokens.borderRadius_100};
   box-shadow: ${tokens.boxShadow_100};
-  margin-top: ${props.isTop ? tokens.spacing_0 : tokens.spacing_100};
-  margin-bottom: ${props.isTop ? tokens.spacing_100 : tokens.spacing_0};
-
-  top: ${props.isTop ? 'auto' : '100%'};
-  bottom: ${!props.isTop ? 'auto' : '100%'};
 `;
 
 export const transition = props => {

--- a/packages/matchbox/src/helpers/propTypes.js
+++ b/packages/matchbox/src/helpers/propTypes.js
@@ -11,8 +11,8 @@ function log(message, logLevel = 'warn') {
  */
 function deprecate(propType, message, logLevel = 'warn') {
   function validate(props, propName, componentName, ...rest) {
-    if (props[propName] != null && process.env.NODE_ENV !== 'production') {
-      const warning = `Matchbox: Deprecated prop "${propName}" of "${componentName}"\n${message}`;
+    if (props[propName] != null && process.env.NODE_ENV === 'development') {
+      const warning = `[Matchbox Deprecation]: Deprecated prop "${propName}" of "${componentName}"\n${message}`;
       if (!warned[warning]) {
         warned[warning] = true;
         log(warning, logLevel);


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed
- Popover now accepts a `position` prop
- Deprecates `left`, `right`, `top`, `bottom`
- Deprecated prop warnings wont be logged in tests anymore

### How To Test or Verify
- Verify these still work: http://localhost:9001/?path=Popover-deprecated__positioning
- Verify these work: http://localhost:9001/?path=Popover__positioning

### PR Checklist

- [x] Add the correct `type` label
- [x] Pull request approval from #uxfe or #design-guild
