### PR TITLE
UX-598 Restyle large Banners

### DIFF
--- a/packages/matchbox/src/components/Banner/Banner.js
+++ b/packages/matchbox/src/components/Banner/Banner.js
@@ -27,27 +27,17 @@ function IconSection({ status, size }) {
 
   return (
     <Box
-      position="relative"
       display="flex"
       flexShrink="0"
       alignItems="center"
       justifyContent="center"
       width={iconSize}
       height={iconSize}
+      color={fillColor}
       mr="300"
-      mt={size === 'large' ? '3px' : null}
+      mt={size === 'large' ? '4px' : '2px'}
     >
-      <Box
-        position="absolute"
-        top="0"
-        left="0"
-        width={iconSize}
-        height={iconSize}
-        borderRadius="circle"
-      />
-      <Box position="relative" color={fillColor}>
-        <Icon size={size === 'large' ? 24 : 20} label={statusIcon.iconLabel} />
-      </Box>
+      <Icon size={size === 'large' ? 24 : 20} label={statusIcon.iconLabel} />
     </Box>
   );
 }

--- a/packages/matchbox/src/components/Banner/Banner.js
+++ b/packages/matchbox/src/components/Banner/Banner.js
@@ -22,11 +22,8 @@ function IconSection({ status, size }) {
   }, [statusIcons, status]);
 
   const Icon = statusIcon.iconName;
-
-  const iconSize = size === 'large' ? '3rem' : '1rem';
-  const bgColor = size === 'large' ? statusIcon.bg : null;
-  const fillColor = size === 'large' ? statusIcon.fill : statusIcon.fillMobile;
-  const iconMargin = size === 'large' ? '500' : '300';
+  const iconSize = '450';
+  const fillColor = statusIcon.fill;
 
   return (
     <Box
@@ -37,8 +34,8 @@ function IconSection({ status, size }) {
       justifyContent="center"
       width={iconSize}
       height={iconSize}
-      mr={iconMargin}
-      mt={size === 'large' ? null : '2px'}
+      mr="300"
+      mt={size === 'large' ? '3px' : null}
     >
       <Box
         position="absolute"
@@ -47,10 +44,9 @@ function IconSection({ status, size }) {
         width={iconSize}
         height={iconSize}
         borderRadius="circle"
-        bg={bgColor}
       />
       <Box position="relative" color={fillColor}>
-        <Icon size={size === 'large' ? 30 : 20} label={statusIcon.iconLabel} />
+        <Icon size={size === 'large' ? 24 : 20} label={statusIcon.iconLabel} />
       </Box>
     </Box>
   );
@@ -87,8 +83,8 @@ const Banner = React.forwardRef(function Banner(props, userRef) {
   const systemProps = pick(rest, margin.propNames);
 
   const titleMarkup = title ? (
-    <Box pt={status !== 'muted' ? ['300', null, '200'] : null} mb="200">
-      <Text fontSize={['400', null, '500']} lineHeight={['400', null, '500']} as="h5">
+    <Box mb="200">
+      <Text fontSize="400" lineHeight="400" as="h5">
         {title}
       </Text>
     </Box>
@@ -149,7 +145,7 @@ const Banner = React.forwardRef(function Banner(props, userRef) {
     <StyledContainer
       display="flex"
       flexWrap={['wrap', null, 'nowrap']}
-      p={size === 'large' ? '500' : '300'}
+      p={size === 'large' ? '450' : '300'}
       py={size === 'large' ? null : '200'}
       borderRadius="100"
       status={status}

--- a/packages/matchbox/src/components/Banner/styles.js
+++ b/packages/matchbox/src/components/Banner/styles.js
@@ -41,7 +41,7 @@ export function container(props) {
 export function childLinks(props) {
   return `
   p, ul, ol {
-    font-size: ${props.size === 'small' ? props.theme.fontSizes['200'] : null};
+    font-size: ${props.theme.fontSizes[200]};
   a, a: visited {
     color: ${tokens.color_blue_800};
       &: hover {

--- a/packages/matchbox/src/components/Banner/styles.js
+++ b/packages/matchbox/src/components/Banner/styles.js
@@ -57,29 +57,25 @@ export const statusIcons = {
     iconName: CheckCircleOutline,
     iconLabel: 'Success',
     bg: 'green.600',
-    fill: 'white',
-    fillMobile: 'green.700',
+    fill: 'green.700',
   },
   info: {
     iconName: InfoOutline,
     iconLabel: 'Info',
     bg: 'blue.700',
-    fill: 'white',
-    fillMobile: 'blue.700',
+    fill: 'blue.700',
   },
   warning: {
     iconName: ReportProblemOutlined,
     iconLabel: 'Warning',
     bg: 'yellow.300',
     fill: 'yellow.700',
-    fillMobile: 'yellow.700',
   },
   danger: {
     iconName: ErrorOutline,
     iconLabel: 'Error',
     bg: 'red.700',
-    fill: 'white',
-    fillMobile: 'red.700',
+    fill: 'red.700',
   },
 };
 

--- a/packages/matchbox/src/components/Banner/tests/Banner.test.js
+++ b/packages/matchbox/src/components/Banner/tests/Banner.test.js
@@ -68,20 +68,6 @@ describe('Banner', () => {
     expect(wrapper.find('img').props().src).toEqual('/test.jpg');
   });
 
-  it('renders responsive styles correctly', () => {
-    let wrapper = subject();
-    // targets content container
-    expect(wrapper.find('Box').at(3)).toHaveStyleRule('flex-basis', '100%');
-    expect(wrapper.find('Box').at(3)).toHaveStyleRule('order', '1');
-    const media = 'screen and (min-width:800px)';
-    expect(wrapper.find('Box').at(3)).toHaveStyleRule('flex-basis', 'auto', { media });
-    expect(wrapper.find('Box').at(3)).toHaveStyleRule('order', '0', { media });
-
-    // targets dismiss
-    expect(wrapper.find('Box').at(8)).toHaveStyleRule('flex', '1');
-    expect(wrapper.find('Box').at(8)).toHaveStyleRule('flex', '0', { media });
-  });
-
   it('dismisses banner correctly upon clicking dismiss icon', () => {
     let wrapper = subject();
     wrapper


### PR DESCRIPTION
### What Changed
- Restyles Banners to match these mockups: https://www.figma.com/file/juWNBofvmmQBLABf2PPBWY/Page-Header-Rework?node-id=4%3A566

### How To Test or Verify
- Run Libby and visit this story: http://localhost:9001/?path=Banner__success-Banner
- Verify styling matches the Figma mockup

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
