### PR TITLE
Resolves #894 Support color in panel actions

### DIFF
--- a/libby/layout/Panel.lib.js
+++ b/libby/layout/Panel.lib.js
@@ -57,7 +57,7 @@ describe('Panel', () => {
     <Panel accent="gray">
       <Panel.Header>
         <Panel.Action>Action</Panel.Action>
-        <Panel.Action>Action</Panel.Action>
+        <Panel.Action color="red">Action</Panel.Action>
         Header Header Header Header Header Header
       </Panel.Header>
       <Panel.Section>

--- a/packages/matchbox/src/components/Panel/Action.js
+++ b/packages/matchbox/src/components/Panel/Action.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Button } from '../Button';
 
 const Action = React.forwardRef(function Action(props, userRef) {
-  return <Button {...props} flat size="small" color="blue" ref={userRef} />;
+  return <Button color="blue" {...props} variant="text" size="small" ref={userRef} />;
 });
 
 Action.displayName = 'Panel.Action';


### PR DESCRIPTION
Closes #894 

### What Changed
- Supports the Button `color` prop in `Panel.Actions`

### How To Test or Verify
- Run libby and verify the red action works: http://localhost:9001/?path=Panel__actions

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
