### PR TITLE
UX-694 Fix Legacy Modals

### DIFF
--- a/cypress/integration/Modal.spec.js
+++ b/cypress/integration/Modal.spec.js
@@ -51,3 +51,12 @@ describe('The Modal component', () => {
     cy.focused().should('have.attr', 'data-id', 'modal-close');
   });
 });
+
+describe('Legacy Modal', () => {
+  it('renders correctly', () => {
+    cy.visit('/iframe.html?path=Modal-Deprecated__legacy-usage');
+    cy.contains('Delete Template').should('be.visible');
+    cy.findByText('Cancel').click();
+    cy.focused().should('have.text', 'Cancel');
+  });
+});

--- a/packages/matchbox/src/components/Modal/Legacy.js
+++ b/packages/matchbox/src/components/Modal/Legacy.js
@@ -42,26 +42,18 @@ const StyledContent = styled('div')`
 `;
 
 const Modal = React.forwardRef(function Modal(props, userRef) {
-  const {
-    onClose,
-    children,
-    portalId,
-    className,
-    showCloseButton,
-    maxWidth,
-    open,
-    ...rest
-  } = props;
+  const { onClose, children, portalId, className, showCloseButton, maxWidth, open, ...rest } =
+    props;
   const container = useRef();
   const content = useRef();
 
-  const handleKeydown = e => {
+  const handleKeydown = (e) => {
     if (open && onClose) {
       onKey('escape', onClose)(e);
     }
   };
 
-  const handleOutsideClick = e => {
+  const handleOutsideClick = (e) => {
     const isOutside =
       content &&
       !content.current.contains(e.target) &&
@@ -79,7 +71,7 @@ const Modal = React.forwardRef(function Modal(props, userRef) {
       <Portal containerId={portalId}>
         <TouchScrollable>
           <StyledBase
-            open={open}
+            $open={open}
             {...rest}
             className={className}
             onClose={onClose}
@@ -137,8 +129,8 @@ const ModalContent = React.forwardRef(function ModalContent(props, userRef) {
         }}
       >
         {/* Negative `tabIndex` required to programmatically focus */}
-        {state => (
-          <StyledContent state={state} tabIndex="-1" ref={userRef} data-id="modal-content-wrapper">
+        {(state) => (
+          <StyledContent $state={state} tabIndex="-1" ref={userRef} data-id="modal-content-wrapper">
             {children}
           </StyledContent>
         )}


### PR DESCRIPTION

### What Changed
- Fixes interaction inside Legacy Modals

### How To Test or Verify
- Visit http://localhost:9001/?path=Modal-Deprecated__legacy-usage
- Verify the modal is clickable and that the overlay is visible

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
