### PR TITLE
UX-696 Only render either content or children in ActionLists

### DIFF
--- a/cypress/integration/ActionList.spec.js
+++ b/cypress/integration/ActionList.spec.js
@@ -11,18 +11,26 @@ describe('ActionList component', () => {
   it('should render Actions correctly as buttons and links', () => {
     cy.get('button').should('have.length', 2);
     cy.get('a').should('have.length', 2);
+    cy.get('[role="menuitem"]').should('have.length', 4);
   });
 
   it('should handle disabled Actions correctly', () => {
-    cy.get('button')
-      .eq(1)
-      .should('be.disabled');
+    cy.get('button').eq(1).should('be.disabled');
+    cy.get('a').eq(1).should('have.attr', 'tabindex', '-1');
+    cy.get('a').eq(1).should('have.css', 'pointer-events', 'none');
+  });
+});
 
-    cy.get('a')
-      .eq(1)
-      .should('have.attr', 'tabindex', '-1');
-    cy.get('a')
-      .eq(1)
-      .should('have.css', 'pointer-events', 'none');
+describe('Deprecated ActionList', () => {
+  beforeEach(() => {
+    cy.visit(
+      '/iframe.html?path=ActionList-Deprecated__should-only-render-either-content-or-children',
+    );
+  });
+
+  it('should handle disabled Actions correctly', () => {
+    cy.get('a[role="menuitem"]').should('have.length', 2);
+    cy.get('a').eq(0).should('have.text', 'render me');
+    cy.get('a').eq(1).should('have.text', 'render me');
   });
 });

--- a/libby/action/ActionList.lib.tsx
+++ b/libby/action/ActionList.lib.tsx
@@ -165,6 +165,13 @@ describe('ActionList', () => {
   ));
 
   describe('Deprecated', () => {
+    add('should only render either content or children', () => (
+      <ActionList>
+        <ActionList.Action content="render me">not me</ActionList.Action>
+        <ActionList.Action>render me</ActionList.Action>
+      </ActionList>
+    ));
+
     add('without Action component', () => (
       <Inline space="15rem">
         <Popover open trigger={<Button>Actions</Button>} style={{ width: '200px' }}>

--- a/packages/matchbox/src/components/ActionList/Action.tsx
+++ b/packages/matchbox/src/components/ActionList/Action.tsx
@@ -49,8 +49,7 @@ function Content(props: ActionListActionProps): JSX.Element {
   return (
     <Box as="span" alignItems="flex-start" display="flex">
       <Box as="span" flex="1" fontSize="300" lineHeight="300">
-        {content}
-        {children}
+        {content || children}
       </Box>
       {selected && (
         <Box as="span" color="blue.700">


### PR DESCRIPTION
### What Changed
- Fixes a bug that rendered both `content` and `children` inside Actionlist Actions

### How To Test or Verify
- Verify tests pass correctly or visit http://localhost:9001/?path=ActionList-Deprecated__should-only-render-either-content-or-children
 
### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
