### PR TITLE
UX-701 Window event should correctly type its event parameter

### DIFF
--- a/libby/utility/WindowEvent.lib.tsx
+++ b/libby/utility/WindowEvent.lib.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, add } from '@sparkpost/libby-react';
-import { WindowEvent } from '@sparkpost/matchbox';
+import { WindowEvent, useWindowEvent } from '@sparkpost/matchbox';
 
 describe('WindowEvent', () => {
   add('keydown', () => (
@@ -9,7 +9,22 @@ describe('WindowEvent', () => {
         This component does not render anything, but hit your keyboard and watch the action logger.
         This component handles event binding for you.
       </p>
-      <WindowEvent event="keydown" handler={() => console.log('Keydown')} />
+      <WindowEvent
+        event="keydown"
+        handler={(e) => {
+          console.log(e.key);
+          console.log('Keydown');
+        }}
+      />
     </>
   ));
+
+  add('hook', () => {
+    useWindowEvent('keydown', function (e) {
+      // This should be KeyboardEvent
+      console.log(e.key);
+    });
+
+    return <div>view dev console</div>;
+  });
 });

--- a/packages/matchbox/src/components/WindowEvent/WindowEvent.tsx
+++ b/packages/matchbox/src/components/WindowEvent/WindowEvent.tsx
@@ -1,22 +1,22 @@
 import React from 'react';
 import { getWindow } from '../../helpers/window';
 
-export type WindowEventProps = {
+export type WindowEventProps<T extends keyof WindowEventMap> = {
   /**
    * Type of event
    */
-  event?: string;
+  event?: T;
   /**
    * Event callback function
    */
-  handler?: EventListenerOrEventListenerObject;
+  handler?: (e: WindowEventMap[T]) => void;
 };
 
 /**
  * Adds and removes events for you
  * @example <WindowEvent event='keydown' handler={handleKeyDown} />
  */
-function WindowEvent(props: WindowEventProps): JSX.Element {
+function WindowEvent<T extends keyof WindowEventMap>(props: WindowEventProps<T>): JSX.Element {
   const { event, handler } = props;
   const environment = getWindow();
 

--- a/packages/matchbox/src/hooks/useWindowEvent.ts
+++ b/packages/matchbox/src/hooks/useWindowEvent.ts
@@ -12,7 +12,10 @@ import { getWindow } from '../helpers/window';
  *    ...
  *  }
  */
-function useWindowEvent(event: string, callback: EventListenerOrEventListenerObject): void {
+function useWindowEvent<T extends keyof WindowEventMap>(
+  event: T,
+  callback: (e: WindowEventMap[T]) => void,
+): void {
   const environment = getWindow();
 
   React.useEffect(() => {


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->


### What Changed
- WindowEvent and useWindowEvent are properly typed 

### How To Test or Verify
- Open the window event libby story on VSCode
- Ensure that the passed `event` for both stories are correctly typed as `KeyboardEvent`

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
