### PR TITLE
UX-705 Support both window and react key events in keyEvent helpers

### DIFF
--- a/packages/matchbox/src/components/ActionList/ActionList.tsx
+++ b/packages/matchbox/src/components/ActionList/ActionList.tsx
@@ -97,7 +97,7 @@ const ActionList = React.forwardRef<HTMLDivElement, ActionListProps>(function Ac
     }
   }, [focusIndex, focusableItemList]);
 
-  function handleKeyDown(e) {
+  function handleKeyDown(e: React.KeyboardEvent) {
     onKey('arrowDown', () => {
       // Stop arrow keys from scrolling the page
       e.preventDefault();

--- a/packages/matchbox/src/components/Drawer/Drawer.tsx
+++ b/packages/matchbox/src/components/Drawer/Drawer.tsx
@@ -65,7 +65,7 @@ const Drawer = React.forwardRef<HTMLDivElement, DrawerProps>(function Drawer(pro
   }
 
   // Calls onClose when receiving a escape keydown event
-  function handleEscape(e) {
+  function handleEscape(e: KeyboardEvent) {
     if (closeOnEscape && open && onClose) {
       onKey('escape', onClose)(e);
     }

--- a/packages/matchbox/src/components/Popover/Popover.tsx
+++ b/packages/matchbox/src/components/Popover/Popover.tsx
@@ -149,7 +149,7 @@ const Popover = React.forwardRef<HTMLSpanElement, BaseProps>(function Popover(pr
   }
 
   // Toggles uncontrolled popovers on escape keydown, and calls `onClose` for controlled popovers
-  function handleEsc(e) {
+  function handleEsc(e: KeyboardEvent) {
     if (onClose && shouldBeOpen) {
       onKey('escape', () => {
         onClose(e);

--- a/packages/matchbox/src/helpers/keyEvents.ts
+++ b/packages/matchbox/src/helpers/keyEvents.ts
@@ -83,7 +83,7 @@ const keys = {
   },
 };
 
-function compareEvent<T extends Element>(event: EventKeys, e: React.KeyboardEvent<T>): boolean {
+function compareEvent(event: EventKeys, e: React.KeyboardEvent | KeyboardEvent): boolean {
   return (
     !!keys[event] &&
     (e.key === keys[event].key || e.keyCode === keys[event].keyCode) &&
@@ -95,8 +95,11 @@ function compareEvent<T extends Element>(event: EventKeys, e: React.KeyboardEven
  * Key down event handler
  * @example onKey('escape', () => foo())(e)
  */
-export function onKey<T extends Element>(event: EventKeys, callback: React.KeyboardEventHandler) {
-  return function handleEvent(e: React.KeyboardEvent<T>): void {
+export function onKey(
+  event: EventKeys,
+  callback: (e: React.KeyboardEvent | KeyboardEvent) => void,
+) {
+  return function handleEvent(e: React.KeyboardEvent | KeyboardEvent): void {
     if (compareEvent(event, e)) {
       return callback(e);
     }
@@ -107,11 +110,11 @@ export function onKey<T extends Element>(event: EventKeys, callback: React.Keybo
  * Multiple key down event handler
  * @example onKeys(['escape', 'enter'], () => foo())(e)
  */
-export function onKeys<T extends Element>(
+export function onKeys(
   events: EventKeys[],
-  callback: React.KeyboardEventHandler,
+  callback: (e: React.KeyboardEvent | KeyboardEvent) => void,
 ) {
-  return function handleEvents(e: React.KeyboardEvent<T>): void {
+  return function handleEvents(e: React.KeyboardEvent | KeyboardEvent): void {
     events.forEach((event) => onKey(event, callback)(e));
   };
 }


### PR DESCRIPTION

### What Changed
- Key event helpers now support global window/document key events as well as React key events

### How To Test or Verify
- Verify the build passes and that there are no typescript errors
- 

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
