### PR TITLE
UX-708 Take Percy snapshots of the Drawer component

### DIFF
--- a/cypress/regression/ActionList.spec.js
+++ b/cypress/regression/ActionList.spec.js
@@ -1,6 +1,0 @@
-describe('ActionList component', () => {
-  it('renders correctly', () => {
-    cy.visit('/iframe.html?path=ActionList__Actions-as-links-buttons-or-checkboxes&source=false');
-    cy.percySnapshot();
-  });
-});

--- a/cypress/regression/Drawer.spec.js
+++ b/cypress/regression/Drawer.spec.js
@@ -1,0 +1,8 @@
+describe('Drawer component', () => {
+  it('renders correctly', () => {
+    cy.visit('/iframe.html?path=Drawer-Visual-Regression__renders-properly');
+    cy.get('button').first().click();
+    cy.wait(500); // Wait for animation
+    cy.percySnapshot();
+  });
+});

--- a/libby/regression/Drawer.lib.tsx
+++ b/libby/regression/Drawer.lib.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { describe, add } from '@sparkpost/libby-react';
+import { Box, Drawer, Button, useDrawer, Tabs } from '@sparkpost/matchbox';
+
+describe('Drawer - Visual Regression', () => {
+  add('renders properly', () => {
+    const drawer = useDrawer();
+
+    return (
+      <>
+        <Button {...drawer.getActivatorProps()}>Open Drawer</Button>
+        <Drawer {...drawer.getDrawerProps()}>
+          <Drawer.Header>Drawer Title</Drawer.Header>
+          <Drawer.Content p="0">
+            <Tabs
+              fitted
+              selected={0}
+              tabs={[{ content: 'Metrics' }, { content: 'Filters' }, { content: 'Compare' }]}
+            />
+            <Box p="500">Content</Box>
+          </Drawer.Content>
+          <Drawer.Footer>
+            <Box display="flex">
+              <Box flex="1" pr="100">
+                <Button width="100%" color="blue">
+                  Apply
+                </Button>
+              </Box>
+              <Box flex="1" pl="100">
+                <Button width="100%" variant="outline">
+                  Cancel
+                </Button>
+              </Box>
+            </Box>
+          </Drawer.Footer>
+        </Drawer>
+      </>
+    );
+  });
+});


### PR DESCRIPTION
### What Changed
- Adds a new story for Drawer regression testing

### How To Test or Verify
- Run Libby
- Run `npm run test:regression:headless` to run Percy snapshots
- Log into Percy and verify the snapshots are uploaded
- Here is a test build: https://percy.io/efff6832/matchbox/builds/12939422/changed/731207350

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
