### PR TITLE
UX-714 Fix prefix type on TextField

### DIFF
--- a/libby/form/TextField.lib.tsx
+++ b/libby/form/TextField.lib.tsx
@@ -74,13 +74,14 @@ describe('TextField', () => {
     <TextField id="id" prefix="$" suffix={<Autorenew />} suffixClassname="test" />
   ));
 
-  add('connected with suffix', () => (
+  add('connected with suffix and suffix', () => (
     <TextField
       id="id"
       label="Date Range"
       value="July 21, 2017 - July 28, 2017"
       connectLeft={<Select options={['Last Week', 'Last 24 Hours']} />}
       suffix={<Search />}
+      prefix={<Search />}
     />
   ));
 

--- a/libby/form/TextField.lib.tsx
+++ b/libby/form/TextField.lib.tsx
@@ -74,7 +74,7 @@ describe('TextField', () => {
     <TextField id="id" prefix="$" suffix={<Autorenew />} suffixClassname="test" />
   ));
 
-  add('connected with suffix and suffix', () => (
+  add('connected with prefix and suffix', () => (
     <TextField
       id="id"
       label="Date Range"

--- a/packages/matchbox/src/components/TextField/TextField.tsx
+++ b/packages/matchbox/src/components/TextField/TextField.tsx
@@ -112,12 +112,15 @@ type SharedTextFieldProps = {
 } & MarginProps &
   MaxWidthProps;
 
-type MultiLineProps = React.ComponentPropsWithoutRef<'textarea'> &
+// Omitting 'prefix' because it is a native html attribute
+type OmitPrefix<T extends React.ElementType> = Omit<React.ComponentPropsWithoutRef<T>, 'prefix'>;
+
+type MultiLineProps = OmitPrefix<'textarea'> &
   SharedTextFieldProps & {
     multiline: true;
   };
 
-type InputProps = React.ComponentPropsWithoutRef<'input'> &
+type InputProps = OmitPrefix<'input'> &
   SharedTextFieldProps & {
     multiline?: false;
   };

--- a/packages/matchbox/src/components/TextField/TextField.tsx
+++ b/packages/matchbox/src/components/TextField/TextField.tsx
@@ -14,6 +14,7 @@ import useInputDescribedBy from '../../hooks/useInputDescribedBy';
 import useResizeObserver from '../../hooks/useResizeObserver';
 import { pick } from '../../helpers/props';
 import { focusOutline } from '../../styles/helpers';
+import type { ComponentPropsWithout } from '../../helpers/types';
 
 const system = compose(margin, maxWidth);
 const StyledWrapper = styled('div')`
@@ -113,14 +114,13 @@ type SharedTextFieldProps = {
   MaxWidthProps;
 
 // Omitting 'prefix' because it is a native html attribute
-type OmitPrefix<T extends React.ElementType> = Omit<React.ComponentPropsWithoutRef<T>, 'prefix'>;
-
-type MultiLineProps = OmitPrefix<'textarea'> &
+type MultiLineProps = ComponentPropsWithout<'textarea', 'prefix'> &
   SharedTextFieldProps & {
     multiline: true;
   };
 
-type InputProps = OmitPrefix<'input'> &
+// Omitting 'prefix' because it is a native html attribute
+type InputProps = ComponentPropsWithout<'input', 'prefix'> &
   SharedTextFieldProps & {
     multiline?: false;
   };

--- a/packages/matchbox/src/helpers/types.ts
+++ b/packages/matchbox/src/helpers/types.ts
@@ -6,19 +6,20 @@ import * as React from 'react';
 /* -------------------------------------------------------------------------------------------------
  * Utility types
  * -----------------------------------------------------------------------------------------------*/
-type Merge<P1 = { [key: string]: any }, P2 = { [key: string]: any }> = Omit<P1, keyof P2> & P2;
+export type Merge<P1 = { [key: string]: any }, P2 = { [key: string]: any }> = Omit<P1, keyof P2> &
+  P2;
 
 /**
  * Infers the OwnProps if E is a ForwardRefExoticComponentWithAs
  */
-type OwnProps<E> = E extends ForwardRefComponent<any, infer P> ? P : { [key: string]: any };
+export type OwnProps<E> = E extends ForwardRefComponent<any, infer P> ? P : { [key: string]: any };
 
 /**
  * Infers the JSX.IntrinsicElement if E is a ForwardRefExoticComponentWithAs
  */
-type IntrinsicElement<E> = E extends ForwardRefComponent<infer I, any> ? I : never;
+export type IntrinsicElement<E> = E extends ForwardRefComponent<infer I, any> ? I : never;
 
-type ForwardRefExoticComponent<E, OwnProps> = React.ForwardRefExoticComponent<
+export type ForwardRefExoticComponent<E, OwnProps> = React.ForwardRefExoticComponent<
   Merge<E extends React.ElementType ? React.ComponentPropsWithRef<E> : never, OwnProps & { as?: E }>
 >;
 
@@ -26,7 +27,7 @@ type ForwardRefExoticComponent<E, OwnProps> = React.ForwardRefExoticComponent<
  * ForwardRefComponent
  * -----------------------------------------------------------------------------------------------*/
 
-interface ForwardRefComponent<
+export interface ForwardRefComponent<
   IntrinsicElementString,
   OwnProps = { [key: string]: any },
   /**
@@ -56,15 +57,15 @@ interface ForwardRefComponent<
 /**
  * Alignment Types
  */
-type AlignX = 'center' | 'left' | 'right';
-type AlignY = 'center' | 'top' | 'bottom';
+export type AlignX = 'center' | 'left' | 'right';
+export type AlignY = 'center' | 'top' | 'bottom';
 
-type Breakpoints = 'default' | 'xs' | 'sm' | 'md' | 'lg' | 'xl';
-type BreakpointsWithoutDefault = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+export type Breakpoints = 'default' | 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+export type BreakpointsWithoutDefault = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 
-type Headings = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+export type Headings = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 
-type LinkActionProps = {
+export type LinkActionProps = {
   to?: string | { [key: string]: any }; // object here to support react router: https://reactrouter.com/web/api/location
   disabled?: boolean;
   external?: boolean;
@@ -78,15 +79,10 @@ type LinkActionProps = {
   Component?: React.ElementType;
 };
 
-export type {
-  ForwardRefComponent,
-  OwnProps,
-  IntrinsicElement,
-  Merge,
-  AlignX,
-  AlignY,
-  Breakpoints,
-  BreakpointsWithoutDefault,
-  Headings,
-  LinkActionProps,
-};
+/**
+ * Omits a single prop from React.ComponentPropsWithoutRef
+ */
+export type ComponentPropsWithout<T extends React.ElementType, K extends string> = Omit<
+  React.ComponentPropsWithoutRef<T>,
+  K
+>;


### PR DESCRIPTION
### What Changed
- TextField now correctly accepts ReactNodes in the `prefix` field

### How To Test or Verify
- Try to add any ReactNode (or Icon) to the `prefix` field
- There should be no TS errors

### PR Checklist

- [x] Add the correct `type` label
- [x] Pull request approval from #uxfe or #design-guild
