### PR TITLE
UX-715 Fix ListBox minWidth and label rendering

### DIFF
--- a/libby/form/TextField.lib.tsx
+++ b/libby/form/TextField.lib.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { describe, add } from '@sparkpost/libby-react';
 import { Autorenew, Search } from '@sparkpost/matchbox-icons';
-import { TextField, Button, Tooltip, Stack, Select } from '@sparkpost/matchbox';
+import { TextField, Button, Tooltip, Stack, Select, ListBox } from '@sparkpost/matchbox';
 
 describe('TextField', () => {
   add('basic usage', () => <TextField id="id" label="Name" placeholder="Leslie Knope" />);
@@ -66,7 +66,14 @@ describe('TextField', () => {
           <Button outline>Injection Time</Button>
         </Tooltip>
       }
-      connectRight={<Select options={['Last Week', 'Last 24 Hours']} />}
+      connectRight={
+        <ListBox id="listbox-1" defaultValue="option-1">
+          <ListBox.Option value="option-1">Option 1</ListBox.Option>
+          <ListBox.Option value="option-2">Option 2</ListBox.Option>
+          <ListBox.Option value="option-3">Option 3</ListBox.Option>
+          <ListBox.Option value="option-4">Option 4</ListBox.Option>
+        </ListBox>
+      }
     />
   ));
 

--- a/packages/matchbox/src/components/ListBox/ListBox.tsx
+++ b/packages/matchbox/src/components/ListBox/ListBox.tsx
@@ -186,7 +186,7 @@ const ListBox = React.forwardRef<HTMLInputElement, ListBoxProps>(function ListBo
     return activeOption ? activeOption.props.children : currentValue;
   }, [currentValue]);
 
-  const labelMarkup = (
+  const labelMarkup = label && (
     <Label id={`${id}Label`} htmlFor={`${id}LabelButton`} labelHidden={labelHidden}>
       <Box as="span" pr="200">
         {label}
@@ -239,6 +239,7 @@ const ListBox = React.forwardRef<HTMLInputElement, ListBoxProps>(function ListBo
         open={open}
         as="div"
         width="100%"
+        minWidth="5rem"
         trigger={
           <Box position="relative">
             <ListBoxButton

--- a/packages/matchbox/src/components/ListBox/tests/ListBox.test.js
+++ b/packages/matchbox/src/components/ListBox/tests/ListBox.test.js
@@ -11,11 +11,10 @@ describe('Select', () => {
       </ListBox>,
     );
     expect(document.querySelector('input#test-id')).toBeTruthy();
-    expect(document.querySelector('label#test-idLabel')).toBeTruthy();
     expect(document.querySelector('input[data-track="true"]')).toBeTruthy();
   });
 
-  const subject = props =>
+  const subject = (props) =>
     global.mountStyled(
       <ListBox {...props}>
         <ListBox.Option value="option-1">Option 1</ListBox.Option>
@@ -53,24 +52,14 @@ describe('Select', () => {
 
   it('should render with help text', () => {
     const wrapper = subject({ id: 'test-id', helpText: 'test-help' });
-    expect(
-      wrapper
-        .find('div')
-        .last()
-        .text(),
-    ).toEqual('test-help');
+    expect(wrapper.find('div').last().text()).toEqual('test-help');
     expect(wrapper.find('button')).toHaveAttributeValue('aria-describedby', 'test-id-helptext');
     expect(wrapper.find('div').last()).toHaveAttributeValue('id', 'test-id-helptext');
   });
 
   it('should render with error', () => {
     const wrapper = subject({ id: 'test-id', error: 'test-error' });
-    expect(
-      wrapper
-        .find('#test-id-error')
-        .at(1)
-        .text(),
-    ).toEqual('test-error');
+    expect(wrapper.find('#test-id-error').at(1).text()).toEqual('test-error');
   });
 
   it('should render with error and helptext describedby', () => {
@@ -92,12 +81,7 @@ describe('Select', () => {
     wrapper.find('button').simulate('click');
 
     expect(wrapper.find('li')).toHaveLength(2);
-    expect(
-      wrapper
-        .find('li')
-        .first()
-        .text(),
-    ).toEqual('Option 1');
+    expect(wrapper.find('li').first().text()).toEqual('Option 1');
   });
 
   it('should render placeholder option', () => {
@@ -106,11 +90,6 @@ describe('Select', () => {
     wrapper.find('button').simulate('click');
 
     expect(wrapper.find('li')).toHaveLength(3);
-    expect(
-      wrapper
-        .find('li')
-        .first()
-        .text(),
-    ).toEqual('placeholder');
+    expect(wrapper.find('li').first().text()).toEqual('placeholder');
   });
 });


### PR DESCRIPTION

### What Changed
- Lowers the Popover `minWidth` of the ListBox component
- Hides `label` if no label is provided

### How To Test or Verify
- Run libby
- Open up the TextField story with connections
- It should look like this:

<img width="389" alt="Screen Shot 2021-09-29 at 8 35 24 AM" src="https://user-images.githubusercontent.com/3903325/135269490-c90572b8-6e42-4b21-af8e-842abfd12593.png">

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
