### PR TITLE
UX-712 Fix center aligned custom Tabs, Add Percy snapshots for tabs

### DIFF
--- a/cypress/regression/Tabs.spec.js
+++ b/cypress/regression/Tabs.spec.js
@@ -1,0 +1,14 @@
+describe('Tabs component', () => {
+  it('renders correctly at full width', () => {
+    cy.viewport(1280, 375);
+    cy.visit('/iframe.html?path=Visual-Regression__Tabs');
+    cy.get('button').eq(1).click();
+    cy.percySnapshot('Tabs - Desktop', { widths: [1280] });
+  });
+
+  it('renders correctly at mobile width', () => {
+    cy.viewport(375, 375);
+    cy.visit('/iframe.html?path=Visual-Regression__Tabs');
+    cy.percySnapshot('Tabs - Mobile', { widths: [375] });
+  });
+});

--- a/libby/regression/Tabs.lib.tsx
+++ b/libby/regression/Tabs.lib.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { describe, add } from '@sparkpost/libby-react';
+import { Tabs, Panel, useTabs } from '@sparkpost/matchbox';
+
+const TestComponent = React.forwardRef<HTMLAnchorElement, unknown>(function TestComponent(
+  props,
+  ref,
+) {
+  return <a ref={ref} {...props} href="#" />;
+});
+
+const tabs = [
+  {
+    content: 'Tab 1',
+  },
+  {
+    content: 'Tab 2',
+  },
+  {
+    content: 'Tab 3',
+  },
+  {
+    content: 'Tab 4 with a lot of content',
+    as: TestComponent,
+  },
+];
+
+describe('Visual Regression', () => {
+  add('Tabs', () => {
+    const { getTabsProps } = useTabs({ tabs });
+    return (
+      <>
+        <Panel mb="400">
+          <Tabs {...getTabsProps()} />
+          <Panel.Section p="400">Content</Panel.Section>
+        </Panel>
+        <Panel>
+          <Tabs fitted {...getTabsProps()} />
+          <Panel.Section p="400">Content</Panel.Section>
+        </Panel>
+      </>
+    );
+  });
+});

--- a/packages/matchbox/src/components/Tabs/styles.ts
+++ b/packages/matchbox/src/components/Tabs/styles.ts
@@ -1,7 +1,13 @@
 import { buttonReset, focusOutline } from '../../styles/helpers';
 import { tokens } from '@sparkpost/design-tokens';
 
-export const tabStyles = ({ $selected, $fitted }) => `
+export const tabStyles = ({
+  $selected,
+  $fitted,
+}: {
+  $selected?: boolean;
+  $fitted?: boolean;
+}): string => `
   ${buttonReset}
   
   ${focusOutline({ offset: '0px', modifier: '&' })}
@@ -16,7 +22,8 @@ export const tabStyles = ({ $selected, $fitted }) => `
   flex: ${$fitted ? '1' : '0'};
   text-decoration: none;
   outline: none;
-  
+  text-align: center;
+
   padding: 0 ${tokens.spacing_400};
   margin-left: ${$fitted ? '0' : tokens.sizing_200};
 
@@ -70,7 +77,7 @@ export const tabStyles = ({ $selected, $fitted }) => `
   }
 `;
 
-export const overflowTabs = ({ isOverflowing }) => `
+export const overflowTabs = ({ isOverflowing }: { isOverflowing?: boolean }): string => `
   position: absolute;
   left: 0;
   top: 0;
@@ -81,7 +88,7 @@ export const overflowTabs = ({ isOverflowing }) => `
   overflow: ${isOverflowing ? 'hidden' : 'unset'};
 `;
 
-export const containerStyles = () => `
+export const containerStyles = (): string => `
   position: relative;
   height: ${tokens.sizing_650};
 `;


### PR DESCRIPTION
### What Changed
- Fixes the issue of custom tab wrappers with left aligned text
- Adds Percy snapshots for tabs at desktop and mobile

### How To Test or Verify
- Verify the snapshots in Percy - https://percy.io/efff6832/matchbox/builds/13071247/changed/738334520

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
