### PR TITLE
UX-710 Take Percy screenshots for tooltip

### DIFF
--- a/cypress/regression/Tooltip.spec.js
+++ b/cypress/regression/Tooltip.spec.js
@@ -1,0 +1,8 @@
+describe('Tooltip component', () => {
+  it('renders correctly', () => {
+    cy.visit('/iframe.html?path=Visual-Regression__Tooltip');
+    cy.get('button').trigger('mouseover');
+    cy.wait(500);
+    cy.percySnapshot('Tooltip', { widths: [1280] });
+  });
+});

--- a/libby/regression/Tooltip.lib.tsx
+++ b/libby/regression/Tooltip.lib.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { describe, add } from '@sparkpost/libby-react';
+import { Tooltip, Button } from '@sparkpost/matchbox';
+
+describe('Visual Regression', () => {
+  add('Tooltip', () => (
+    <Tooltip id="test-tooltip" content="I am a Tooltip">
+      <Button aria-describedby="test-tooltip">Button</Button>
+    </Tooltip>
+  ));
+});


### PR DESCRIPTION

### What Changed
- Adds Percy snapshots for the Tooltip component

### How To Test or Verify
- Verify this Percy build: https://percy.io/efff6832/matchbox/builds/13182908

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
