### PR TITLE
UX-722 Fix placeholder rendering when value is controlled

### DIFF
--- a/libby/form/ListBox.lib.tsx
+++ b/libby/form/ListBox.lib.tsx
@@ -41,7 +41,7 @@ describe('ListBox', () => {
   ));
 
   add('placeholder', () => (
-    <ListBox id="listbox-2" label="Select an option" placeholder="Select One">
+    <ListBox id="listbox-2" label="Select an option" placeholder="Select One" value="">
       <ListBox.Option value="option-1">Option 1</ListBox.Option>
       <ListBox.Option value="option-2">Option 2</ListBox.Option>
       <ListBox.Option value="option-3">Option 3</ListBox.Option>

--- a/libby/regression/ListBox.lib.tsx
+++ b/libby/regression/ListBox.lib.tsx
@@ -13,7 +13,7 @@ describe('Visual Regression', () => {
         <ListBox.Option value="option-4">Option 4</ListBox.Option>
       </ListBox>
       {/* Placeholder */}
-      <ListBox id="listbox-2" label="Select an option" placeholder="Select One">
+      <ListBox id="listbox-2" label="Select an option" placeholder="Select One" value="">
         <ListBox.Option value="option-1">Option 1</ListBox.Option>
         <ListBox.Option value="option-2">Option 2</ListBox.Option>
         <ListBox.Option value="option-3">Option 3</ListBox.Option>

--- a/packages/matchbox/src/components/ListBox/ListBox.tsx
+++ b/packages/matchbox/src/components/ListBox/ListBox.tsx
@@ -182,7 +182,6 @@ const ListBox = React.forwardRef<HTMLInputElement, ListBoxProps>(function ListBo
     const activeOption = options.find((option) => {
       return option.props.value === currentValue;
     });
-
     return activeOption ? activeOption.props.children : currentValue;
   }, [currentValue]);
 
@@ -259,7 +258,7 @@ const ListBox = React.forwardRef<HTMLInputElement, ListBoxProps>(function ListBo
               {...describedBy}
               ref={assignRefs}
             >
-              {contentFromValue}
+              {contentFromValue || placeholder}
             </ListBoxButton>
             <StyledChevron size={24} $disabled={disabled} />
           </Box>


### PR DESCRIPTION
### What Changed
- Fixes a bug that prevented Listbox's placeholder from rendering when the component is controlled

### How To Test or Verify
- Run libby
- Visit the placeholder Listbox story: http://localhost:9001/?path=ListBox__placeholder
- Verify the placeholder renders

### PR Checklist

- [x] Add the correct `type` label
- [x] Pull request approval from #uxfe or #design-guild
