### PR TITLE
UX-724 Check browser before performing browser specific operations

### DIFF
--- a/packages/matchbox/src/components/WindowEvent/WindowEvent.tsx
+++ b/packages/matchbox/src/components/WindowEvent/WindowEvent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { getWindow } from '../../helpers/window';
+import { getWindow, isBrowser } from '../../helpers/window';
 
 export type WindowEventProps<T extends keyof WindowEventMap> = {
   /**
@@ -18,6 +18,11 @@ export type WindowEventProps<T extends keyof WindowEventMap> = {
  */
 function WindowEvent<T extends keyof WindowEventMap>(props: WindowEventProps<T>): JSX.Element {
   const { event, handler } = props;
+
+  if (isBrowser()) {
+    return null;
+  }
+
   const environment = getWindow();
 
   function addEvent() {

--- a/packages/matchbox/src/components/WindowEvent/WindowEvent.tsx
+++ b/packages/matchbox/src/components/WindowEvent/WindowEvent.tsx
@@ -19,7 +19,7 @@ export type WindowEventProps<T extends keyof WindowEventMap> = {
 function WindowEvent<T extends keyof WindowEventMap>(props: WindowEventProps<T>): JSX.Element {
   const { event, handler } = props;
 
-  if (isBrowser()) {
+  if (!isBrowser()) {
     return null;
   }
 

--- a/packages/matchbox/src/helpers/noop.ts
+++ b/packages/matchbox/src/helpers/noop.ts
@@ -1,0 +1,3 @@
+export function noop(): void {
+  return;
+}

--- a/packages/matchbox/src/helpers/tests/noop.test.js
+++ b/packages/matchbox/src/helpers/tests/noop.test.js
@@ -1,0 +1,7 @@
+import * as helpers from '../noop';
+
+describe('noop', () => {
+  it('doesnt do anything', () => {
+    expect(helpers.noop()).toBeUndefined();
+  });
+});

--- a/packages/matchbox/src/helpers/window.ts
+++ b/packages/matchbox/src/helpers/window.ts
@@ -1,5 +1,10 @@
-function noop() {
-  return;
+import { noop } from './noop';
+
+/**
+ * Checks if operating in a browser-based environment
+ */
+export function isBrowser(): boolean {
+  return typeof window !== 'undefined';
 }
 
 type GetWindowReturnType =
@@ -12,7 +17,7 @@ type GetWindowReturnType =
  * Checks if window is available to support SSG/SSR builds
  */
 export function getWindow(): GetWindowReturnType {
-  if (typeof window !== 'undefined') {
+  if (isBrowser()) {
     return window;
   }
 

--- a/packages/matchbox/src/hooks/useBreakpoint.ts
+++ b/packages/matchbox/src/hooks/useBreakpoint.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import { tokens } from '@sparkpost/design-tokens';
-import { getWindow } from '../helpers/window';
+import { getWindow, isBrowser } from '../helpers/window';
 import { Breakpoints } from '../helpers/types';
 
 // Defining queries here to ensure order is correct
@@ -27,6 +27,10 @@ const keys: Breakpoints[] = ['xl', 'lg', 'md', 'sm', 'xs'];
  * @see https://usehooks.com/useMedia/
  */
 function useBreakpoint(): Breakpoints {
+  if (!isBrowser()) {
+    return 'default';
+  }
+
   const environment = getWindow();
   const list = queries.map((q) => environment.matchMedia(q));
 

--- a/packages/matchbox/src/hooks/useInView.ts
+++ b/packages/matchbox/src/hooks/useInView.ts
@@ -1,7 +1,8 @@
 import React from 'react';
 import useWindowEvent from './useWindowEvent';
 import { getRectFor } from '../helpers/geometry';
-import { getWindow } from '../helpers/window';
+import { getWindow, isBrowser } from '../helpers/window';
+import { noop } from '../helpers/noop';
 
 /**
  * Reusable hook that returns true when element is scrolled into view
@@ -17,6 +18,10 @@ function useInView<T extends HTMLElement>({
   offset = 0,
   once = true,
 }: { offset?: number; once?: boolean } = {}): [React.RefCallback<T>, boolean] {
+  if (!isBrowser()) {
+    return [noop, false];
+  }
+
   const [node, setNode] = React.useState(null);
   const [inView, setInView] = React.useState(false);
   const [scroll, setScroll] = React.useState(0);

--- a/packages/matchbox/src/hooks/usePrefersColorScheme.ts
+++ b/packages/matchbox/src/hooks/usePrefersColorScheme.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { getWindow } from '../helpers/window';
+import { getWindow, isBrowser } from '../helpers/window';
 
 /**
  * SSR friendly hook that returns prefers-color-scheme status
@@ -15,6 +15,10 @@ import { getWindow } from '../helpers/window';
 const QUERY = '(prefers-color-scheme: dark)';
 
 function usePrefersColorScheme(): 'dark' | 'light' {
+  if (!isBrowser()) {
+    return 'light';
+  }
+
   const environment = getWindow();
   const matches = environment.matchMedia(QUERY) ? environment.matchMedia(QUERY).matches : false;
 

--- a/packages/matchbox/src/hooks/usePrefersReducedMotion.ts
+++ b/packages/matchbox/src/hooks/usePrefersReducedMotion.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { getWindow } from '../helpers/window';
+import { getWindow, isBrowser } from '../helpers/window';
 
 /**
  * SSR friendly hook that returns prefers-reduced-state status to disable animations
@@ -15,6 +15,10 @@ import { getWindow } from '../helpers/window';
 const QUERY = '(prefers-reduced-motion: reduce)';
 
 function usePrefersReducedMotion(): 'reduce' | 'no-preference' {
+  if (!isBrowser()) {
+    return 'no-preference';
+  }
+
   const environment = getWindow();
   const matches = environment.matchMedia(QUERY) ? environment.matchMedia(QUERY).matches : false;
 

--- a/packages/matchbox/src/hooks/useWindowEvent.ts
+++ b/packages/matchbox/src/hooks/useWindowEvent.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { getWindow } from '../helpers/window';
+import { getWindow, isBrowser } from '../helpers/window';
 
 /**
  * Handles global window event listeners in a reusable hook
@@ -16,6 +16,10 @@ function useWindowEvent<T extends keyof WindowEventMap>(
   event: T,
   callback: (e: WindowEventMap[T]) => void,
 ): void {
+  if (!isBrowser()) {
+    return;
+  }
+
   const environment = getWindow();
 
   React.useEffect(() => {


### PR DESCRIPTION

### What Changed
- Checks if `window` exists before rendering certain components or running hooks 

### How To Test or Verify
- Need to figure out how to verify this easily

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
