### PR TITLE
UX-759 Add transpileOnly ts-loader flag for development

### DIFF
--- a/libby.config.js
+++ b/libby.config.js
@@ -31,6 +31,10 @@ module.exports = {
             exclude: /node_modules/,
             use: {
               loader: 'ts-loader',
+              options: {
+                // See https://github.com/TypeStrong/ts-loader#transpileonly
+                transpileOnly: process.env.NODE_ENV !== 'production',
+              },
             },
           },
           {


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed
- Adds the `transpileOnly` flag to libby's ts-loader config to massively speed up TS compilation
- This means that type-checking will not happen when running Libby locally, but we will still have type-checking through the Github workflow (which runs a production build)

### How To Test or Verify
- Run `npm run start:libby` 
- Start up time should be noticeably faster

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
