### PR TITLE
UX-760 Fix button `to`  types

### DIFF
--- a/packages/matchbox/src/components/Button/Button.tsx
+++ b/packages/matchbox/src/components/Button/Button.tsx
@@ -27,7 +27,7 @@ import {
   childwrapper,
 } from './styles';
 
-import type * as Polymorphic from '../../helpers/types';
+import type * as Types from '../../helpers/types';
 
 export function getLoaderColor({ variant = 'filled', color = 'gray' } = {}):
   | 'gray'
@@ -139,7 +139,7 @@ export type ButtonProps = {
   outlineBorder?: boolean;
   variant?: 'outline' | 'mutedOutline' | 'text' | 'filled';
   size?: 'default' | 'small' | 'large';
-  to?: string;
+  to?: Types.LinkActionProps['to'];
   fullWidth?: boolean;
   submit?: boolean;
   external?: boolean;
@@ -149,7 +149,7 @@ export type ButtonProps = {
   WidthProps &
   PaddingProps;
 
-export type PolymorphicButton = Polymorphic.ForwardRefComponent<'button', ButtonProps>;
+export type PolymorphicButton = Types.ForwardRefComponent<'button', ButtonProps>;
 
 const Button = React.forwardRef(function Button(props, ref) {
   const {


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed
- Fixes the `to` prop's type so that it accepts objects for react-router support

### How To Test or Verify
- Try to use an object within Button's `to` prop, verify it does not produce an error

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
