### PR TITLE
UX-761 Remove children from Button.Icon types

### DIFF
--- a/packages/matchbox/src/components/Button/Icon.tsx
+++ b/packages/matchbox/src/components/Button/Icon.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 import { pick } from '../../helpers/props';
 
 type IconBaseProps = {
-  children?: React.ReactNode;
   width?: number | string;
   height?: number | string;
   size?: number | string;


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed
- Removes an unused type from `Button.Icon`

### How To Test or Verify
- Verify adding children to `Button.Icon` results in an error

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
