### PR TITLE
UX-762 (Type fix) Remove reverse prop from Column

### DIFF
--- a/packages/matchbox/src/components/Column/Column.tsx
+++ b/packages/matchbox/src/components/Column/Column.tsx
@@ -25,7 +25,6 @@ export type ColumnProps = {
   width?: 'content' | ResponsiveValue<SpaceKeys | number>;
   'data-id'?: string;
   className?: string;
-  reverse?: ResponsiveValue<boolean>;
 } & DisplayProps;
 
 const Column = React.forwardRef<HTMLDivElement, ColumnProps>(function Column(props, ref) {


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed
- Removes an unused type from the Column component

### How To Test or Verify
- Verify the `reverse` prop is not available to `Column`

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
