### PR TITLE
UX-771 Fix design token scss import

### DIFF
--- a/packages/design-tokens/index.scss
+++ b/packages/design-tokens/index.scss
@@ -1,0 +1,1 @@
+@import './dist/scss/tokens.scss';

--- a/packages/design-tokens/tokens.scss
+++ b/packages/design-tokens/tokens.scss
@@ -1,0 +1,1 @@
+@import './dist/scss/tokens.scss';


### PR DESCRIPTION
### What Changed
- Adds the legacy `tokens.scss` file to the design tokens package. This was used by some applications to import tokens.
- Adds  a new `index.scss` file to the design tokens package.
- The old file: https://github.com/SparkPost/matchbox/pull/1029/files#diff-7de20171f753783af812d7ada1b4ad49fab5e63dc4e4ba9a375cc513cba30c84

### How To Test or Verify
- Verify the files import the correct scss files

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
