### PR TITLE
UX-777 Add small radio card variant

### DIFF
--- a/libby/form/RadioCard.lib.tsx
+++ b/libby/form/RadioCard.lib.tsx
@@ -107,11 +107,11 @@ describe('RadioCard', () => {
 
   add('small variant', () => (
     <RadioCard.Group label="Radio Card Group" space="compact">
-      <RadioCard id="id1" label="Check Me 1" name="group" defaultChecked variant="small">
+      <RadioCard id="id1" label="Check Me 1" name="group" defaultChecked size="small">
         I am help text
       </RadioCard>
-      <RadioCard id="id2" label="Check Me 2" name="group" variant="small"></RadioCard>
-      <RadioCard id="id3" label="Check Me 3" name="group" variant="small"></RadioCard>
+      <RadioCard id="id2" label="Check Me 2" name="group" size="small"></RadioCard>
+      <RadioCard id="id3" label="Check Me 3" name="group" size="small"></RadioCard>
     </RadioCard.Group>
   ));
 });

--- a/libby/form/RadioCard.lib.tsx
+++ b/libby/form/RadioCard.lib.tsx
@@ -104,4 +104,14 @@ describe('RadioCard', () => {
       </RadioCard>
     </RadioCard.Group>
   ));
+
+  add('small variant', () => (
+    <RadioCard.Group label="Radio Card Group" space="compact">
+      <RadioCard id="id1" label="Check Me 1" name="group" defaultChecked variant="small">
+        I am help text
+      </RadioCard>
+      <RadioCard id="id2" label="Check Me 2" name="group" variant="small"></RadioCard>
+      <RadioCard id="id3" label="Check Me 3" name="group" variant="small"></RadioCard>
+    </RadioCard.Group>
+  ));
 });

--- a/libby/form/RadioCard.lib.tsx
+++ b/libby/form/RadioCard.lib.tsx
@@ -3,9 +3,7 @@ import { describe, add } from '@sparkpost/libby-react';
 import { RadioCard } from '@sparkpost/matchbox';
 
 describe('RadioCard', () => {
-  add('basic usage', () => (
-    <RadioCard id="id1" label="Check Me" data-track="true" weight="light" />
-  ));
+  add('basic usage', () => <RadioCard id="id1" label="Check Me" data-track="true" />);
 
   add('disabled', () => (
     <RadioCard.Group label="Radio Card Group">

--- a/libby/regression/RadioCard.lib.tsx
+++ b/libby/regression/RadioCard.lib.tsx
@@ -93,13 +93,13 @@ describe('Visual Regression', () => {
 
       {/* Small */}
       <RadioCard.Group label="Radio Card Group" space="compact">
-        <RadioCard id="id20" label="Check Me 1" name="group-small" defaultChecked variant="small">
+        <RadioCard id="id20" label="Check Me 1" name="group-small" defaultChecked size="small">
           I am help text
         </RadioCard>
-        <RadioCard id="id21" label="Check Me 2" name="group-small" variant="small">
+        <RadioCard id="id21" label="Check Me 2" name="group-small" size="small">
           I am help text
         </RadioCard>
-        <RadioCard id="id23" label="Check Me 3" name="group-small" variant="small"></RadioCard>
+        <RadioCard id="id23" label="Check Me 3" name="group-small" size="small"></RadioCard>
       </RadioCard.Group>
     </>
   ));

--- a/libby/regression/RadioCard.lib.tsx
+++ b/libby/regression/RadioCard.lib.tsx
@@ -90,6 +90,17 @@ describe('Visual Regression', () => {
           I am help text
         </RadioCard>
       </RadioCard.Group>
+
+      {/* Small */}
+      <RadioCard.Group label="Radio Card Group" space="compact">
+        <RadioCard id="id20" label="Check Me 1" name="group-small" defaultChecked variant="small">
+          I am help text
+        </RadioCard>
+        <RadioCard id="id21" label="Check Me 2" name="group-small" variant="small">
+          I am help text
+        </RadioCard>
+        <RadioCard id="id23" label="Check Me 3" name="group-small" variant="small"></RadioCard>
+      </RadioCard.Group>
     </>
   ));
 });

--- a/libby/regression/RadioCard.lib.tsx
+++ b/libby/regression/RadioCard.lib.tsx
@@ -5,7 +5,7 @@ import { RadioCard } from '@sparkpost/matchbox';
 describe('Visual Regression', () => {
   add('RadioCard', () => (
     <>
-      <RadioCard id="id1" label="Check Me" data-track="true" weight="light" />
+      <RadioCard id="id1" label="Check Me" data-track="true" />
       {/* Disabled */}
       <RadioCard.Group label="Radio Card Group">
         <RadioCard id="id1" label="Check Me 1" disabled>

--- a/packages/matchbox/src/components/RadioCard/Group.tsx
+++ b/packages/matchbox/src/components/RadioCard/Group.tsx
@@ -17,7 +17,26 @@ const Fieldset = styled.fieldset`
   ${margin}
 `;
 
-const breakpoints = ['xs', 'sm', 'md', 'lg', 'xl'];
+const CardWrapper = styled.div<{ $space: 'compact' | 'default' }>`
+  ${(props) => {
+    if (props.$space === 'compact') {
+      return `
+        & > div:not(:first-child) label {
+          margin-top: -1px;
+          border-top-right-radius: 0;
+          border-top-left-radius: 0;
+        }
+
+        & > div:not(:last-child) label {
+          border-bottom-right-radius: 0;
+          border-bottom-left-radius: 0;
+        }
+      `;
+    }
+
+    return ``;
+  }}
+`;
 
 export type RadioCardGroupProps = {
   children?: React.ReactNode;
@@ -28,6 +47,7 @@ export type RadioCardGroupProps = {
   optional?: boolean;
   id?: string;
   orientation?: 'horizontal' | 'vertical' | 'grid';
+  space?: 'compact' | 'default';
 } & MarginProps;
 
 const Group = React.forwardRef<HTMLFieldSetElement, RadioCardGroupProps>(function Group(
@@ -42,6 +62,7 @@ const Group = React.forwardRef<HTMLFieldSetElement, RadioCardGroupProps>(functio
     labelHidden,
     orientation = 'vertical',
     optional,
+    space,
     ...rest
   } = props;
 
@@ -66,11 +87,21 @@ const Group = React.forwardRef<HTMLFieldSetElement, RadioCardGroupProps>(functio
       )}
 
       {orientation === 'vertical' && (
-        <Stack space="300">
-          {items.map((item, i) => (
-            <div key={i}>{item}</div>
-          ))}
-        </Stack>
+        <CardWrapper $space={space}>
+          {space !== 'compact' ? (
+            <Stack space="300">
+              {items.map((item, i) => (
+                <div key={i}>{item}</div>
+              ))}
+            </Stack>
+          ) : (
+            <>
+              {items.map((item, i) => (
+                <div key={i}>{item}</div>
+              ))}
+            </>
+          )}
+        </CardWrapper>
       )}
 
       {orientation === 'grid' && (

--- a/packages/matchbox/src/components/RadioCard/RadioCard.tsx
+++ b/packages/matchbox/src/components/RadioCard/RadioCard.tsx
@@ -27,7 +27,7 @@ const RadioCard = React.forwardRef<HTMLInputElement, RadioCardProps>(function Ra
     onChange,
     onFocus,
     onBlur,
-    size,
+    size = 'small',
     value,
     weight = 'light',
     'data-id': dataId,
@@ -36,6 +36,7 @@ const RadioCard = React.forwardRef<HTMLInputElement, RadioCardProps>(function Ra
   } = props;
 
   const fontSize = weight === 'heavy' ? '400' : '300';
+  const isSmall = size === 'small';
 
   return (
     <Box data-id="radio-card">
@@ -53,15 +54,12 @@ const RadioCard = React.forwardRef<HTMLInputElement, RadioCardProps>(function Ra
         ref={userRef}
         type="radio"
         value={value}
+        {...rest}
       />
       <StyledLabel as="label" htmlFor={id} $size={size}>
         <Box display="flex">
-          <Box flex="0 0 auto" width={size === 'small' ? '200' : '400'}>
-            <Box
-              position="absolute"
-              top={size === 'small' ? '100' : '500'}
-              left={size === 'small' ? '200' : '500'}
-            >
+          <Box flex="0 0 auto" width={isSmall ? '200' : '400'}>
+            <Box position="absolute" top={isSmall ? '100' : '500'} left={isSmall ? '200' : '500'}>
               <StyledUnchecked size="1rem" as={RadioButtonUnchecked} />
               <StyledChecked size="1rem" as={RadioButtonChecked} />
             </Box>
@@ -69,9 +67,9 @@ const RadioCard = React.forwardRef<HTMLInputElement, RadioCardProps>(function Ra
           <Box flex="1" pl="300">
             <StyledHeader
               data-id="radio-card-header"
-              fontSize={size === 'small' ? '200' : fontSize}
-              lineHeight={size === 'small' ? '200' : '400'}
-              fontWeight={size === 'small' ? 'medium' : 'semibold'}
+              fontSize={isSmall ? '200' : fontSize}
+              lineHeight={isSmall ? '200' : '400'}
+              fontWeight={isSmall ? 'medium' : 'semibold'}
             >
               {label}
             </StyledHeader>
@@ -80,10 +78,10 @@ const RadioCard = React.forwardRef<HTMLInputElement, RadioCardProps>(function Ra
         {children && (
           <Box
             data-id="radio-card-content"
-            pt={size === 'small' ? '0' : '200'}
-            pl={size === 'small' ? '450' : '0'}
-            fontSize={size === 'small' ? '100' : '300'}
-            lineHeight={size === 'small' ? '100' : '300'}
+            pt={isSmall ? '0' : '200'}
+            pl={isSmall ? '450' : '0'}
+            fontSize={isSmall ? '100' : '300'}
+            lineHeight={isSmall ? '100' : '300'}
           >
             {children}
           </Box>

--- a/packages/matchbox/src/components/RadioCard/RadioCard.tsx
+++ b/packages/matchbox/src/components/RadioCard/RadioCard.tsx
@@ -9,8 +9,8 @@ export type RadioCardProps = {
   'data-track'?: string;
   label?: React.ReactNode;
   weight?: 'light' | 'heavy';
-  variant?: 'small' | 'default';
-} & Omit<React.ComponentPropsWithoutRef<'input'>, 'type'>;
+  size?: 'small' | 'default';
+} & Omit<React.ComponentPropsWithoutRef<'input'>, 'type' | 'size'>;
 
 const RadioCard = React.forwardRef<HTMLInputElement, RadioCardProps>(function RadioCard(
   props,
@@ -27,7 +27,7 @@ const RadioCard = React.forwardRef<HTMLInputElement, RadioCardProps>(function Ra
     onChange,
     onFocus,
     onBlur,
-    variant,
+    size,
     value,
     weight = 'light',
     'data-id': dataId,
@@ -54,13 +54,13 @@ const RadioCard = React.forwardRef<HTMLInputElement, RadioCardProps>(function Ra
         type="radio"
         value={value}
       />
-      <StyledLabel as="label" htmlFor={id} $variant={variant}>
+      <StyledLabel as="label" htmlFor={id} $size={size}>
         <Box display="flex">
-          <Box flex="0 0 auto" width={variant === 'small' ? '200' : '400'}>
+          <Box flex="0 0 auto" width={size === 'small' ? '200' : '400'}>
             <Box
               position="absolute"
-              top={variant === 'small' ? '100' : '500'}
-              left={variant === 'small' ? '200' : '500'}
+              top={size === 'small' ? '100' : '500'}
+              left={size === 'small' ? '200' : '500'}
             >
               <StyledUnchecked size="1rem" as={RadioButtonUnchecked} />
               <StyledChecked size="1rem" as={RadioButtonChecked} />
@@ -69,9 +69,9 @@ const RadioCard = React.forwardRef<HTMLInputElement, RadioCardProps>(function Ra
           <Box flex="1" pl="300">
             <StyledHeader
               data-id="radio-card-header"
-              fontSize={variant === 'small' ? '200' : fontSize}
-              lineHeight={variant === 'small' ? '200' : '400'}
-              fontWeight={variant === 'small' ? 'medium' : 'semibold'}
+              fontSize={size === 'small' ? '200' : fontSize}
+              lineHeight={size === 'small' ? '200' : '400'}
+              fontWeight={size === 'small' ? 'medium' : 'semibold'}
             >
               {label}
             </StyledHeader>
@@ -80,10 +80,10 @@ const RadioCard = React.forwardRef<HTMLInputElement, RadioCardProps>(function Ra
         {children && (
           <Box
             data-id="radio-card-content"
-            pt={variant === 'small' ? '0' : '200'}
-            pl={variant === 'small' ? '450' : '0'}
-            fontSize={variant === 'small' ? '100' : '300'}
-            lineHeight={variant === 'small' ? '100' : '300'}
+            pt={size === 'small' ? '0' : '200'}
+            pl={size === 'small' ? '450' : '0'}
+            fontSize={size === 'small' ? '100' : '300'}
+            lineHeight={size === 'small' ? '100' : '300'}
           >
             {children}
           </Box>

--- a/packages/matchbox/src/components/RadioCard/RadioCard.tsx
+++ b/packages/matchbox/src/components/RadioCard/RadioCard.tsx
@@ -8,7 +8,6 @@ export type RadioCardProps = {
   'data-id'?: string;
   'data-track'?: string;
   label?: React.ReactNode;
-  weight?: 'light' | 'heavy';
   size?: 'small' | 'default';
 } & Omit<React.ComponentPropsWithoutRef<'input'>, 'type' | 'size'>;
 
@@ -29,25 +28,12 @@ const RadioCard = React.forwardRef<HTMLInputElement, RadioCardProps>(function Ra
     onBlur,
     size = 'default',
     value,
-    weight = 'light',
     'data-id': dataId,
     'data-track': dataTrack,
     ...rest
   } = props;
 
   const isSmall = size === 'small';
-
-  const headerFontSize = React.useMemo(() => {
-    if (isSmall) {
-      return '200';
-    }
-
-    if (weight === 'heavy') {
-      return '400';
-    }
-
-    return '300';
-  }, [weight, isSmall]);
 
   return (
     <Box data-id="radio-card">
@@ -78,7 +64,7 @@ const RadioCard = React.forwardRef<HTMLInputElement, RadioCardProps>(function Ra
           <Box flex="1" pl="300">
             <StyledHeader
               data-id="radio-card-header"
-              fontSize={headerFontSize}
+              fontSize={isSmall ? '200' : '300'}
               lineHeight={isSmall ? '200' : '400'}
               fontWeight={isSmall ? 'medium' : 'semibold'}
             >

--- a/packages/matchbox/src/components/RadioCard/RadioCard.tsx
+++ b/packages/matchbox/src/components/RadioCard/RadioCard.tsx
@@ -35,8 +35,19 @@ const RadioCard = React.forwardRef<HTMLInputElement, RadioCardProps>(function Ra
     ...rest
   } = props;
 
-  const fontSize = weight === 'heavy' ? '400' : '300';
   const isSmall = size === 'small';
+
+  const headerFontSize = React.useMemo(() => {
+    if (isSmall) {
+      return '200';
+    }
+
+    if (weight === 'heavy') {
+      return '400';
+    }
+
+    return '300';
+  }, [weight, isSmall]);
 
   return (
     <Box data-id="radio-card">
@@ -67,7 +78,7 @@ const RadioCard = React.forwardRef<HTMLInputElement, RadioCardProps>(function Ra
           <Box flex="1" pl="300">
             <StyledHeader
               data-id="radio-card-header"
-              fontSize={isSmall ? '200' : fontSize}
+              fontSize={headerFontSize}
               lineHeight={isSmall ? '200' : '400'}
               fontWeight={isSmall ? 'medium' : 'semibold'}
             >

--- a/packages/matchbox/src/components/RadioCard/RadioCard.tsx
+++ b/packages/matchbox/src/components/RadioCard/RadioCard.tsx
@@ -9,6 +9,7 @@ export type RadioCardProps = {
   'data-track'?: string;
   label?: React.ReactNode;
   weight?: 'light' | 'heavy';
+  variant?: 'small' | 'default';
 } & Omit<React.ComponentPropsWithoutRef<'input'>, 'type'>;
 
 const RadioCard = React.forwardRef<HTMLInputElement, RadioCardProps>(function RadioCard(
@@ -26,6 +27,7 @@ const RadioCard = React.forwardRef<HTMLInputElement, RadioCardProps>(function Ra
     onChange,
     onFocus,
     onBlur,
+    variant,
     value,
     weight = 'light',
     'data-id': dataId,
@@ -52,10 +54,14 @@ const RadioCard = React.forwardRef<HTMLInputElement, RadioCardProps>(function Ra
         type="radio"
         value={value}
       />
-      <StyledLabel as="label" htmlFor={id}>
+      <StyledLabel as="label" htmlFor={id} $variant={variant}>
         <Box display="flex">
-          <Box flex="0 0 auto" width="400">
-            <Box position="absolute" top="500" left="500">
+          <Box flex="0 0 auto" width={variant === 'small' ? '200' : '400'}>
+            <Box
+              position="absolute"
+              top={variant === 'small' ? '100' : '500'}
+              left={variant === 'small' ? '200' : '500'}
+            >
               <StyledUnchecked size="1rem" as={RadioButtonUnchecked} />
               <StyledChecked size="1rem" as={RadioButtonChecked} />
             </Box>
@@ -63,16 +69,22 @@ const RadioCard = React.forwardRef<HTMLInputElement, RadioCardProps>(function Ra
           <Box flex="1" pl="300">
             <StyledHeader
               data-id="radio-card-header"
-              fontSize={fontSize}
-              lineHeight="400"
-              fontWeight="semibold"
+              fontSize={variant === 'small' ? '200' : fontSize}
+              lineHeight={variant === 'small' ? '200' : '400'}
+              fontWeight={variant === 'small' ? 'medium' : 'semibold'}
             >
               {label}
             </StyledHeader>
           </Box>
         </Box>
         {children && (
-          <Box data-id="radio-card-content" pt="200">
+          <Box
+            data-id="radio-card-content"
+            pt={variant === 'small' ? '0' : '200'}
+            pl={variant === 'small' ? '450' : '0'}
+            fontSize={variant === 'small' ? '100' : '300'}
+            lineHeight={variant === 'small' ? '100' : '300'}
+          >
             {children}
           </Box>
         )}

--- a/packages/matchbox/src/components/RadioCard/RadioCard.tsx
+++ b/packages/matchbox/src/components/RadioCard/RadioCard.tsx
@@ -27,7 +27,7 @@ const RadioCard = React.forwardRef<HTMLInputElement, RadioCardProps>(function Ra
     onChange,
     onFocus,
     onBlur,
-    size = 'small',
+    size = 'default',
     value,
     weight = 'light',
     'data-id': dataId,

--- a/packages/matchbox/src/components/RadioCard/RadioCard.tsx
+++ b/packages/matchbox/src/components/RadioCard/RadioCard.tsx
@@ -91,8 +91,9 @@ const RadioCard = React.forwardRef<HTMLInputElement, RadioCardProps>(function Ra
             data-id="radio-card-content"
             pt={isSmall ? '0' : '200'}
             pl={isSmall ? '450' : '0'}
-            fontSize={isSmall ? '100' : '300'}
-            lineHeight={isSmall ? '100' : '300'}
+            fontSize={isSmall ? '200' : '300'}
+            lineHeight={isSmall ? '200' : '300'}
+            color={isSmall ? 'gray.700' : 'gray.900'}
           >
             {children}
           </Box>

--- a/packages/matchbox/src/components/RadioCard/styles.ts
+++ b/packages/matchbox/src/components/RadioCard/styles.ts
@@ -3,12 +3,12 @@ import { tokens } from '@sparkpost/design-tokens';
 import { focusOutline, visuallyHidden } from '../../styles/helpers';
 import { Box } from '../Box';
 
-export const StyledLabel = styled(Box)<{ $variant?: 'small' | 'default' }>`
+export const StyledLabel = styled(Box)<{ $size?: 'small' | 'default' }>`
   display: block;
   position: relative;
   background: ${(props) => props.theme.colors.white};
   padding: ${(props) =>
-    props.$variant === 'small' ? props.theme.space['200'] : props.theme.space['500']};
+    props.$size === 'small' ? props.theme.space['200'] : props.theme.space['500']};
   border: ${(props) => props.theme.borders['400']};
   border-radius: ${(props) => props.theme.radii['200']};
   cursor: pointer;

--- a/packages/matchbox/src/components/RadioCard/styles.ts
+++ b/packages/matchbox/src/components/RadioCard/styles.ts
@@ -3,11 +3,12 @@ import { tokens } from '@sparkpost/design-tokens';
 import { focusOutline, visuallyHidden } from '../../styles/helpers';
 import { Box } from '../Box';
 
-export const StyledLabel = styled(Box)`
+export const StyledLabel = styled(Box)<{ $variant?: 'small' | 'default' }>`
   display: block;
   position: relative;
   background: ${(props) => props.theme.colors.white};
-  padding: ${(props) => props.theme.space['500']};
+  padding: ${(props) =>
+    props.$variant === 'small' ? props.theme.space['200'] : props.theme.space['500']};
   border: ${(props) => props.theme.borders['400']};
   border-radius: ${(props) => props.theme.radii['200']};
   cursor: pointer;
@@ -36,6 +37,16 @@ export const StyledLabel = styled(Box)`
 
 export const StyledInput = styled.input`
   ${visuallyHidden}
+  &:hover {
+    & + ${StyledLabel} {
+      z-index: ${tokens.zIndex_default};
+    }
+  }
+  &:checked {
+    & + ${StyledLabel} {
+      z-index: ${tokens.zIndex_above};
+    }
+  }
 `;
 
 const commonCheckStyle = (props) => `

--- a/packages/matchbox/src/components/RadioCard/tests/RadioCard.test.js
+++ b/packages/matchbox/src/components/RadioCard/tests/RadioCard.test.js
@@ -8,7 +8,7 @@ describe('RadioCard', () => {
     onBlur: jest.fn(),
     onFocus: jest.fn(),
   };
-  const subject = props => global.mountStyled(<RadioCard id="test-id" {...events} {...props} />);
+  const subject = (props) => global.mountStyled(<RadioCard id="test-id" {...events} {...props} />);
 
   it('renders with id and default attributes', () => {
     render(<RadioCard id="test-id" data-track="true" />);
@@ -114,6 +114,17 @@ describe('RadioCard', () => {
         </RadioCard.Group>,
       );
       expect(wrapper.find('#test-id')).toExist();
+    });
+
+    it('renders a compact space when vertical', () => {
+      const wrapper = global.mountStyled(
+        <RadioCard.Group label="label" space="compact">
+          <RadioCard id="test-id" />
+          <RadioCard id="test-id-2" />
+        </RadioCard.Group>,
+      );
+      expect(wrapper.find('#test-id')).toExist();
+      expect(wrapper.find('#test-id-2')).toExist();
     });
   });
 });

--- a/packages/matchbox/src/components/RadioCard/tests/RadioCard.test.js
+++ b/packages/matchbox/src/components/RadioCard/tests/RadioCard.test.js
@@ -38,19 +38,6 @@ describe('RadioCard', () => {
     expect(wrapper.find('input')).toBeDisabled();
   });
 
-  it('renders heavy weight', () => {
-    const wrapper = subject({ weight: 'heavy' });
-    expect(wrapper.find('[data-id="radio-card-header"]').at(0)).toHaveStyleRule(
-      'font-size',
-      '1rem',
-    );
-  });
-
-  it('renders light weight', () => {
-    const wrapper = subject({ weight: 'light' });
-    expect(wrapper.find('[data-id="radio-card-header"]').at(0)).toHaveStyleRule('font-size', '300');
-  });
-
   it('should invoke events', () => {
     const wrapper = subject();
     wrapper.find('input').simulate('change');


### PR DESCRIPTION

### What Changed
- Adds new `size` prop to `RadioCard` which accepts `small`
- Adds new `space` prop to RadioCard.Group` which accepts `compact`

### How To Test or Verify
- Run Libby, visit http://localhost:9001/?path=RadioCard__small-variant
- Verify the component matches the mockups: https://www.figma.com/file/kbeuqghvpagMmaLWwqszQo/Forms?node-id=260%3A268

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
