### PR TITLE
UX-253 Add CheckboxCard component

### DIFF
--- a/cypress/regression/CheckboxCard.spec.js
+++ b/cypress/regression/CheckboxCard.spec.js
@@ -1,0 +1,6 @@
+describe('CheckboxCard component', () => {
+  it('renders correctly', () => {
+    cy.visit('/iframe.html?path=Visual-Regression__CheckboxCard');
+    cy.percySnapshot('CheckboxCard', { widths: [1280] });
+  });
+});

--- a/libby/form/CheckboxCard.lib.tsx
+++ b/libby/form/CheckboxCard.lib.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { describe, add } from '@sparkpost/libby-react';
+import { CheckboxCard } from '@sparkpost/matchbox';
+
+describe('CheckboxCard', () => {
+  add('basic usage', () => <CheckboxCard id="id1" label="Check Me" />);
+
+  add('disabled', () => (
+    <CheckboxCard.Group label="Radio Card Group">
+      <CheckboxCard id="id1" label="Check Me 1" disabled>
+        This one is disabled
+      </CheckboxCard>
+      <CheckboxCard id="id2" label="Check Me 2" disabled defaultChecked>
+        This one is disabled
+      </CheckboxCard>
+      <CheckboxCard id="id3" label="Check Me 3">
+        This one is not disabled
+      </CheckboxCard>
+    </CheckboxCard.Group>
+  ));
+
+  add('vertical', () => (
+    <CheckboxCard.Group label="Radio Card Group">
+      <CheckboxCard id="id1" label="Check Me 1" name="group" defaultChecked>
+        I am help text
+      </CheckboxCard>
+      <CheckboxCard id="id2" label="Check Me 2" name="group">
+        I am help text
+      </CheckboxCard>
+      <CheckboxCard id="id3" label="Check Me 3" name="group">
+        I am help text
+      </CheckboxCard>
+    </CheckboxCard.Group>
+  ));
+
+  add('grid', () => (
+    <CheckboxCard.Group label="Radio Card Group" orientation="grid">
+      <CheckboxCard id="id1" label="Check Me 1" name="group" defaultChecked>
+        I am help text
+      </CheckboxCard>
+      <CheckboxCard id="id2" label="Check Me 2" name="group">
+        I am help text
+      </CheckboxCard>
+      <CheckboxCard id="id3" label="Check Me 3" name="group" defaultChecked>
+        I am help text
+      </CheckboxCard>
+      <CheckboxCard id="id4" label="Check Me 4" name="group">
+        I am help text
+      </CheckboxCard>
+    </CheckboxCard.Group>
+  ));
+
+  add('collapsing horizontal', () => (
+    <CheckboxCard.Group collapseBelow="sm" label="Radio Card Group" orientation="horizontal">
+      <CheckboxCard id="id1" label="Check Me 1" name="group" defaultChecked>
+        I am help text
+      </CheckboxCard>
+      <CheckboxCard id="id2" label="Check Me 2" name="group">
+        I am help text
+      </CheckboxCard>
+    </CheckboxCard.Group>
+  ));
+
+  add('group with hidden label', () => (
+    <CheckboxCard.Group label="Radio Card Group" labelHidden>
+      <CheckboxCard id="id1" label="Check Me 1" name="group" defaultChecked>
+        I am help text
+      </CheckboxCard>
+      <CheckboxCard id="id2" label="Check Me 2" name="group">
+        I am help text
+      </CheckboxCard>
+      <CheckboxCard id="id3" label="Check Me 3" name="group">
+        I am help text
+      </CheckboxCard>
+    </CheckboxCard.Group>
+  ));
+
+  add('group with optional label', () => (
+    <CheckboxCard.Group label="Radio Card Group" optional>
+      <CheckboxCard id="id1" label="Check Me 1" name="group" defaultChecked>
+        I am help text
+      </CheckboxCard>
+      <CheckboxCard id="id2" label="Check Me 2" name="group">
+        I am help text
+      </CheckboxCard>
+      <CheckboxCard id="id3" label="Check Me 3" name="group">
+        I am help text
+      </CheckboxCard>
+    </CheckboxCard.Group>
+  ));
+
+  add('works with system props', () => (
+    <CheckboxCard.Group label="Radio Card Group" my="500" mx="700">
+      <CheckboxCard id="id1" label="Check Me 1" name="group" defaultChecked>
+        I am help text
+      </CheckboxCard>
+      <CheckboxCard id="id2" label="Check Me 2" name="group">
+        I am help text
+      </CheckboxCard>
+      <CheckboxCard id="id3" label="Check Me 3" name="group">
+        I am help text
+      </CheckboxCard>
+    </CheckboxCard.Group>
+  ));
+});

--- a/libby/form/CheckboxCard.lib.tsx
+++ b/libby/form/CheckboxCard.lib.tsx
@@ -102,4 +102,14 @@ describe('CheckboxCard', () => {
       </CheckboxCard>
     </CheckboxCard.Group>
   ));
+
+  add('small variant', () => (
+    <CheckboxCard.Group label="Radio Card Group" space="compact">
+      <CheckboxCard id="id1" label="Check Me 1" name="group" defaultChecked size="small">
+        I am help text
+      </CheckboxCard>
+      <CheckboxCard id="id2" label="Check Me 2" name="group" size="small"></CheckboxCard>
+      <CheckboxCard id="id3" label="Check Me 3" name="group" size="small"></CheckboxCard>
+    </CheckboxCard.Group>
+  ));
 });

--- a/libby/regression/CheckboxCard.lib.tsx
+++ b/libby/regression/CheckboxCard.lib.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { describe, add } from '@sparkpost/libby-react';
+import { CheckboxCard } from '@sparkpost/matchbox';
+
+describe('Visual Regression', () => {
+  add('CheckboxCard', () => (
+    <>
+      <CheckboxCard id="id1" label="Check Me" data-track="true" />
+      {/* Disabled */}
+      <CheckboxCard.Group label="Radio Card Group">
+        <CheckboxCard id="id1" label="Check Me 1" disabled>
+          This one is disabled
+        </CheckboxCard>
+        <CheckboxCard id="id2" label="Check Me 2" disabled defaultChecked>
+          This one is disabled
+        </CheckboxCard>
+        <CheckboxCard id="id3" label="Check Me 3">
+          This one is not disabled
+        </CheckboxCard>
+      </CheckboxCard.Group>
+      {/* Vertical */}
+      <CheckboxCard.Group label="Radio Card Group">
+        <CheckboxCard id="id4" label="Check Me 1" name="group" defaultChecked>
+          I am help text
+        </CheckboxCard>
+        <CheckboxCard id="id5" label="Check Me 2" name="group">
+          I am help text
+        </CheckboxCard>
+        <CheckboxCard id="id6" label="Check Me 3" name="group">
+          I am help text
+        </CheckboxCard>
+      </CheckboxCard.Group>
+      {/* Grid */}
+      <CheckboxCard.Group label="Radio Card Group" orientation="grid">
+        <CheckboxCard id="id7" label="Check Me 1" name="group" defaultChecked>
+          I am help text
+        </CheckboxCard>
+        <CheckboxCard id="id8" label="Check Me 2" name="group">
+          I am help text
+        </CheckboxCard>
+        <CheckboxCard id="id9" label="Check Me 3" name="group" defaultChecked>
+          I am help text
+        </CheckboxCard>
+        <CheckboxCard id="id10" label="Check Me 4" name="group">
+          I am help text
+        </CheckboxCard>
+      </CheckboxCard.Group>
+      {/* Group with hidden label */}
+      <CheckboxCard.Group label="Radio Card Group" labelHidden>
+        <CheckboxCard id="id11" label="Check Me 1" name="group" defaultChecked>
+          I am help text
+        </CheckboxCard>
+        <CheckboxCard id="id12" label="Check Me 2" name="group">
+          I am help text
+        </CheckboxCard>
+        <CheckboxCard id="id13" label="Check Me 3" name="group">
+          I am help text
+        </CheckboxCard>
+      </CheckboxCard.Group>
+      {/* Group with optional label */}
+      <CheckboxCard.Group label="Radio Card Group" optional>
+        <CheckboxCard id="id14" label="Check Me 1" name="group" defaultChecked>
+          I am help text
+        </CheckboxCard>
+        <CheckboxCard id="id15" label="Check Me 2" name="group">
+          I am help text
+        </CheckboxCard>
+        <CheckboxCard id="id16" label="Check Me 3" name="group">
+          I am help text
+        </CheckboxCard>
+      </CheckboxCard.Group>
+      {/* Collapsing horizontal */}
+      <CheckboxCard.Group collapseBelow="sm" label="Radio Card Group" orientation="horizontal">
+        <CheckboxCard id="id1" label="Check Me 1" name="group" defaultChecked>
+          I am help text
+        </CheckboxCard>
+        <CheckboxCard id="id2" label="Check Me 2" name="group">
+          I am help text
+        </CheckboxCard>
+      </CheckboxCard.Group>
+      {/* System props */}
+      <CheckboxCard.Group label="Radio Card Group" my="500" mx="700">
+        <CheckboxCard id="id17" label="Check Me 1" name="group" defaultChecked>
+          I am help text
+        </CheckboxCard>
+        <CheckboxCard id="id18" label="Check Me 2" name="group">
+          I am help text
+        </CheckboxCard>
+        <CheckboxCard id="id19" label="Check Me 3" name="group">
+          I am help text
+        </CheckboxCard>
+      </CheckboxCard.Group>
+
+      {/* Small */}
+      <CheckboxCard.Group label="Radio Card Group" space="compact">
+        <CheckboxCard id="id20" label="Check Me 1" name="group-small" defaultChecked size="small">
+          I am help text
+        </CheckboxCard>
+        <CheckboxCard id="id21" label="Check Me 2" name="group-small" size="small">
+          I am help text
+        </CheckboxCard>
+        <CheckboxCard id="id23" label="Check Me 3" name="group-small" size="small"></CheckboxCard>
+      </CheckboxCard.Group>
+    </>
+  ));
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@babel/preset-react": "^7.12.5",
         "@percy/cli": "^1.0.0-beta.70",
         "@percy/cypress": "^3.1.1",
-        "@sparkpost/libby-react": "^0.0.45",
+        "@sparkpost/libby-react": "^0.0.46",
         "@testing-library/cypress": "^7.0.4",
         "@testing-library/react": "^11.2.6",
         "@types/jest": "^26.0.24",
@@ -7608,9 +7608,9 @@
       }
     },
     "node_modules/@sparkpost/libby-react": {
-      "version": "0.0.45",
-      "resolved": "https://registry.npmjs.org/@sparkpost/libby-react/-/libby-react-0.0.45.tgz",
-      "integrity": "sha512-bJeiSpfFuqGCizSRDu1kd6pDST/XI98mu6AYNLEZwjPwpiNmOkQtTdeU9wdEMSGQ/ZyyUk3iqILF2rMCilUDhw==",
+      "version": "0.0.46",
+      "resolved": "https://registry.npmjs.org/@sparkpost/libby-react/-/libby-react-0.0.46.tgz",
+      "integrity": "sha512-s7+4fZhPcOnOfC/1HXCNlH1Zmw08nfZMDwKDia8MgEPXABes44ZOXy9gCujJRQR9CZIYo87Fxb1Mh1oYB3M11w==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.12.3",
@@ -44190,9 +44190,9 @@
       }
     },
     "@sparkpost/libby-react": {
-      "version": "0.0.45",
-      "resolved": "https://registry.npmjs.org/@sparkpost/libby-react/-/libby-react-0.0.45.tgz",
-      "integrity": "sha512-bJeiSpfFuqGCizSRDu1kd6pDST/XI98mu6AYNLEZwjPwpiNmOkQtTdeU9wdEMSGQ/ZyyUk3iqILF2rMCilUDhw==",
+      "version": "0.0.46",
+      "resolved": "https://registry.npmjs.org/@sparkpost/libby-react/-/libby-react-0.0.46.tgz",
+      "integrity": "sha512-s7+4fZhPcOnOfC/1HXCNlH1Zmw08nfZMDwKDia8MgEPXABes44ZOXy9gCujJRQR9CZIYo87Fxb1Mh1oYB3M11w==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.12.3",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@babel/preset-react": "^7.12.5",
     "@percy/cli": "^1.0.0-beta.70",
     "@percy/cypress": "^3.1.1",
-    "@sparkpost/libby-react": "^0.0.45",
+    "@sparkpost/libby-react": "^0.0.46",
     "@testing-library/cypress": "^7.0.4",
     "@testing-library/react": "^11.2.6",
     "@types/jest": "^26.0.24",

--- a/packages/matchbox/src/components/CheckboxCard/CheckboxCard.tsx
+++ b/packages/matchbox/src/components/CheckboxCard/CheckboxCard.tsx
@@ -61,7 +61,7 @@ const CheckboxCard = React.forwardRef<HTMLInputElement, CheckboxCardProps>(funct
               <StyledChecked size="1.25rem" as={CheckBox} />
             </Box>
           </Box>
-          <Box flex="1" pl="300">
+          <Box flex="1" pl={isSmall ? '400' : '300'}>
             <StyledHeader
               data-id="radio-card-header"
               fontSize={isSmall ? '200' : '300'}
@@ -76,9 +76,10 @@ const CheckboxCard = React.forwardRef<HTMLInputElement, CheckboxCardProps>(funct
           <Box
             data-id="checkbox-card-content"
             pt={isSmall ? '0' : '200'}
-            pl={isSmall ? '450' : '0'}
-            fontSize={isSmall ? '100' : '300'}
-            lineHeight={isSmall ? '100' : '300'}
+            pl={isSmall ? '500' : '0'}
+            fontSize={isSmall ? '200' : '300'}
+            lineHeight={isSmall ? '200' : '300'}
+            color={isSmall ? 'gray.700' : 'gray.900'}
           >
             {children}
           </Box>

--- a/packages/matchbox/src/components/CheckboxCard/CheckboxCard.tsx
+++ b/packages/matchbox/src/components/CheckboxCard/CheckboxCard.tsx
@@ -57,8 +57,8 @@ const CheckboxCard = React.forwardRef<HTMLInputElement, CheckboxCardProps>(funct
         <Box display="flex">
           <Box flex="0 0 auto" width={isSmall ? '200' : '400'}>
             <Box position="absolute" top={isSmall ? '100' : '500'} left={isSmall ? '200' : '500'}>
-              <StyledUnchecked size="1rem" as={CheckBoxOutlineBlank} />
-              <StyledChecked size="1rem" as={CheckBox} />
+              <StyledUnchecked size="1.25rem" as={CheckBoxOutlineBlank} />
+              <StyledChecked size="1.25rem" as={CheckBox} />
             </Box>
           </Box>
           <Box flex="1" pl="300">

--- a/packages/matchbox/src/components/CheckboxCard/CheckboxCard.tsx
+++ b/packages/matchbox/src/components/CheckboxCard/CheckboxCard.tsx
@@ -8,7 +8,8 @@ export type CheckboxCardProps = {
   'data-id'?: string;
   'data-track'?: string;
   label?: React.ReactNode;
-} & Omit<React.ComponentPropsWithoutRef<'input'>, 'type'>;
+  size?: 'small' | 'default';
+} & Omit<React.ComponentPropsWithoutRef<'input'>, 'type' | 'size'>;
 
 const CheckboxCard = React.forwardRef<HTMLInputElement, CheckboxCardProps>(function CheckboxCard(
   props,
@@ -25,11 +26,14 @@ const CheckboxCard = React.forwardRef<HTMLInputElement, CheckboxCardProps>(funct
     onChange,
     onFocus,
     onBlur,
+    size = 'default',
     value,
     'data-id': dataId,
     'data-track': dataTrack,
     ...rest
   } = props;
+
+  const isSmall = size === 'small';
 
   return (
     <Box data-id="radio-card">
@@ -49,10 +53,10 @@ const CheckboxCard = React.forwardRef<HTMLInputElement, CheckboxCardProps>(funct
         value={value}
         {...rest}
       />
-      <StyledLabel as="label" htmlFor={id}>
+      <StyledLabel as="label" htmlFor={id} $size={size}>
         <Box display="flex">
-          <Box flex="0 0 auto" width="400">
-            <Box position="absolute" top="500" left="500">
+          <Box flex="0 0 auto" width={isSmall ? '200' : '400'}>
+            <Box position="absolute" top={isSmall ? '100' : '500'} left={isSmall ? '200' : '500'}>
               <StyledUnchecked size="1rem" as={CheckBoxOutlineBlank} />
               <StyledChecked size="1rem" as={CheckBox} />
             </Box>
@@ -60,16 +64,22 @@ const CheckboxCard = React.forwardRef<HTMLInputElement, CheckboxCardProps>(funct
           <Box flex="1" pl="300">
             <StyledHeader
               data-id="radio-card-header"
-              fontSize="300"
-              lineHeight="400"
-              fontWeight="semibold"
+              fontSize={isSmall ? '200' : '300'}
+              lineHeight={isSmall ? '200' : '400'}
+              fontWeight={isSmall ? 'medium' : 'semibold'}
             >
               {label}
             </StyledHeader>
           </Box>
         </Box>
         {children && (
-          <Box data-id="checkbox-card-content" pt="200">
+          <Box
+            data-id="checkbox-card-content"
+            pt={isSmall ? '0' : '200'}
+            pl={isSmall ? '450' : '0'}
+            fontSize={isSmall ? '100' : '300'}
+            lineHeight={isSmall ? '100' : '300'}
+          >
             {children}
           </Box>
         )}

--- a/packages/matchbox/src/components/CheckboxCard/CheckboxCard.tsx
+++ b/packages/matchbox/src/components/CheckboxCard/CheckboxCard.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { CheckBox, CheckBoxOutlineBlank } from '@sparkpost/matchbox-icons';
+import { Box } from '../Box';
+import Group from './Group';
+import { StyledLabel, StyledInput, StyledUnchecked, StyledChecked, StyledHeader } from './styles';
+
+export type CheckboxCardProps = {
+  'data-id'?: string;
+  'data-track'?: string;
+  label?: React.ReactNode;
+} & Omit<React.ComponentPropsWithoutRef<'input'>, 'type'>;
+
+const CheckboxCard = React.forwardRef<HTMLInputElement, CheckboxCardProps>(function CheckboxCard(
+  props,
+  userRef,
+) {
+  const {
+    id,
+    checked,
+    children,
+    defaultChecked,
+    disabled,
+    label,
+    name,
+    onChange,
+    onFocus,
+    onBlur,
+    value,
+    'data-id': dataId,
+    'data-track': dataTrack,
+    ...rest
+  } = props;
+
+  return (
+    <Box data-id="radio-card">
+      <StyledInput
+        checked={checked}
+        data-id={dataId}
+        data-track={dataTrack}
+        disabled={disabled}
+        defaultChecked={defaultChecked}
+        id={id}
+        name={name}
+        onChange={onChange}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        ref={userRef}
+        type="checkbox"
+        value={value}
+        {...rest}
+      />
+      <StyledLabel as="label" htmlFor={id}>
+        <Box display="flex">
+          <Box flex="0 0 auto" width="400">
+            <Box position="absolute" top="500" left="500">
+              <StyledUnchecked size="1rem" as={CheckBoxOutlineBlank} />
+              <StyledChecked size="1rem" as={CheckBox} />
+            </Box>
+          </Box>
+          <Box flex="1" pl="300">
+            <StyledHeader
+              data-id="radio-card-header"
+              fontSize="300"
+              lineHeight="400"
+              fontWeight="semibold"
+            >
+              {label}
+            </StyledHeader>
+          </Box>
+        </Box>
+        {children && (
+          <Box data-id="checkbox-card-content" pt="200">
+            {children}
+          </Box>
+        )}
+      </StyledLabel>
+    </Box>
+  );
+}) as React.ForwardRefExoticComponent<CheckboxCardProps> & {
+  Group: typeof Group;
+};
+
+CheckboxCard.displayName = 'CheckboxCard';
+
+CheckboxCard.Group = Group;
+export default CheckboxCard;

--- a/packages/matchbox/src/components/CheckboxCard/Group.tsx
+++ b/packages/matchbox/src/components/CheckboxCard/Group.tsx
@@ -8,8 +8,26 @@ import { Label } from '../Label';
 import { OptionalLabel } from '../OptionalLabel';
 import { Stack } from '../Stack';
 import { Breakpoints } from '../../helpers/types';
-
 import { pick } from '../../helpers/props';
+
+const CardWrapper = styled.div<{ $space: 'compact' | 'default' }>`
+  ${(props) => {
+    if (props.$space === 'compact') {
+      return `
+        & > div:not(:first-child) label {
+          margin-top: -1px;
+          border-top-right-radius: 0;
+          border-top-left-radius: 0;
+        }
+        & > div:not(:last-child) label {
+          border-bottom-right-radius: 0;
+          border-bottom-left-radius: 0;
+        }
+      `;
+    }
+    return ``;
+  }}
+`;
 
 const Fieldset = styled.fieldset`
   border: none;
@@ -26,6 +44,7 @@ export type CheckboxCardGroupProps = {
   optional?: boolean;
   id?: string;
   orientation?: 'horizontal' | 'vertical' | 'grid';
+  space?: 'compact' | 'default';
 } & MarginProps;
 
 const Group = React.forwardRef<HTMLFieldSetElement, CheckboxCardGroupProps>(function Group(
@@ -40,6 +59,7 @@ const Group = React.forwardRef<HTMLFieldSetElement, CheckboxCardGroupProps>(func
     labelHidden,
     orientation = 'vertical',
     optional,
+    space = 'default',
     ...rest
   } = props;
 
@@ -64,11 +84,21 @@ const Group = React.forwardRef<HTMLFieldSetElement, CheckboxCardGroupProps>(func
       )}
 
       {orientation === 'vertical' && (
-        <Stack space="300">
-          {items.map((item, i) => (
-            <div key={i}>{item}</div>
-          ))}
-        </Stack>
+        <CardWrapper $space={space}>
+          {space !== 'compact' ? (
+            <Stack space="300">
+              {items.map((item, i) => (
+                <div key={i}>{item}</div>
+              ))}
+            </Stack>
+          ) : (
+            <>
+              {items.map((item, i) => (
+                <div key={i}>{item}</div>
+              ))}
+            </>
+          )}
+        </CardWrapper>
       )}
 
       {orientation === 'grid' && (

--- a/packages/matchbox/src/components/CheckboxCard/Group.tsx
+++ b/packages/matchbox/src/components/CheckboxCard/Group.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import styled from 'styled-components';
+import { margin, MarginProps } from 'styled-system';
+import { Box } from '../Box';
+import { Columns } from '../Columns';
+import { Column } from '../Column';
+import { Label } from '../Label';
+import { OptionalLabel } from '../OptionalLabel';
+import { Stack } from '../Stack';
+import { Breakpoints } from '../../helpers/types';
+
+import { pick } from '../../helpers/props';
+
+const Fieldset = styled.fieldset`
+  border: none;
+  padding: 0;
+  ${margin}
+`;
+
+export type CheckboxCardGroupProps = {
+  children?: React.ReactNode;
+  collapseBelow?: Breakpoints;
+  'data-id'?: string;
+  label: string;
+  labelHidden?: boolean;
+  optional?: boolean;
+  id?: string;
+  orientation?: 'horizontal' | 'vertical' | 'grid';
+} & MarginProps;
+
+const Group = React.forwardRef<HTMLFieldSetElement, CheckboxCardGroupProps>(function Group(
+  props,
+  userRef,
+) {
+  const {
+    children,
+    collapseBelow,
+    id,
+    label,
+    labelHidden,
+    orientation = 'vertical',
+    optional,
+    ...rest
+  } = props;
+
+  const items = React.Children.toArray(children);
+  const systemProps = pick(rest, margin.propNames);
+
+  return (
+    <Fieldset data-id={rest['data-id']} id={id} ref={userRef} {...systemProps}>
+      <Label as="legend" labelHidden={labelHidden}>
+        <Box as="span" pr="200">
+          {label}
+        </Box>
+        {optional && <OptionalLabel />}
+      </Label>
+
+      {orientation === 'horizontal' && (
+        <Columns space="300" collapseBelow={collapseBelow}>
+          {items.map((item, i) => (
+            <Column key={i}>{item}</Column>
+          ))}
+        </Columns>
+      )}
+
+      {orientation === 'vertical' && (
+        <Stack space="300">
+          {items.map((item, i) => (
+            <div key={i}>{item}</div>
+          ))}
+        </Stack>
+      )}
+
+      {orientation === 'grid' && (
+        <Box display="grid" gridTemplateColumns={['1fr', null, '1fr 1fr']} gridGap="300">
+          {items.map((item, i) => (
+            <div key={i}>{item}</div>
+          ))}
+        </Box>
+      )}
+    </Fieldset>
+  );
+});
+
+Group.displayName = 'CheckboxCard.Group';
+
+export default Group;

--- a/packages/matchbox/src/components/CheckboxCard/index.ts
+++ b/packages/matchbox/src/components/CheckboxCard/index.ts
@@ -1,0 +1,3 @@
+export { default as CheckboxCard } from './CheckboxCard';
+export * from './CheckboxCard';
+export * from './Group';

--- a/packages/matchbox/src/components/CheckboxCard/styles.ts
+++ b/packages/matchbox/src/components/CheckboxCard/styles.ts
@@ -3,11 +3,12 @@ import { tokens } from '@sparkpost/design-tokens';
 import { focusOutline, visuallyHidden } from '../../styles/helpers';
 import { Box } from '../Box';
 
-export const StyledLabel = styled(Box)`
+export const StyledLabel = styled(Box)<{ $size?: 'small' | 'default' }>`
   display: block;
   position: relative;
   background: ${(props) => props.theme.colors.white};
-  padding: ${(props) => props.theme.space['500']};
+  padding: ${(props) =>
+    props.$size === 'small' ? props.theme.space['200'] : props.theme.space['500']};
   border: ${(props) => props.theme.borders['400']};
   border-radius: ${(props) => props.theme.radii['200']};
   cursor: pointer;
@@ -36,6 +37,21 @@ export const StyledLabel = styled(Box)`
 
 export const StyledInput = styled.input`
   ${visuallyHidden}
+  &:hover {
+    & + ${StyledLabel} {
+      z-index: ${tokens.zIndex_default};
+    }
+  }
+  &:checked {
+    & + ${StyledLabel} {
+      z-index: ${tokens.zIndex_above};
+    }
+  }
+  &:focus {
+    & + ${StyledLabel} {
+      z-index: ${tokens.zIndex_above + 1};
+    }
+  }
 `;
 
 const commonCheckStyle = (props) => `

--- a/packages/matchbox/src/components/CheckboxCard/styles.ts
+++ b/packages/matchbox/src/components/CheckboxCard/styles.ts
@@ -76,7 +76,7 @@ export const StyledUnchecked = styled.svg`
 export const StyledChecked = styled.svg`
   ${(props) => commonCheckStyle(props)}
   opacity: 0;
-  left: -1rem;
+  left: -1.25rem;
   fill: ${(props) => props.theme.colors.blue['700']};
 
   input:checked ~ ${StyledLabel} & {

--- a/packages/matchbox/src/components/CheckboxCard/styles.ts
+++ b/packages/matchbox/src/components/CheckboxCard/styles.ts
@@ -1,0 +1,79 @@
+import styled from 'styled-components';
+import { tokens } from '@sparkpost/design-tokens';
+import { focusOutline, visuallyHidden } from '../../styles/helpers';
+import { Box } from '../Box';
+
+export const StyledLabel = styled(Box)`
+  display: block;
+  position: relative;
+  background: ${(props) => props.theme.colors.white};
+  padding: ${(props) => props.theme.space['500']};
+  border: ${(props) => props.theme.borders['400']};
+  border-radius: ${(props) => props.theme.radii['200']};
+  cursor: pointer;
+  transition: ${tokens.motionDuration_medium};
+  transition-property: box-shadow, border;
+  ${focusOutline({ offset: '2px', modifier: 'input:focus ~ &' })}
+
+  &:hover {
+    border: ${(props) => props.theme.borderWidths['100']} solid
+      ${(props) => props.theme.colors.gray['600']};
+  }
+
+  input:checked ~ & {
+    border: ${(props) => props.theme.borderWidths['100']} solid
+      ${(props) => props.theme.colors.blue['700']};
+  }
+
+  input:disabled ~ & {
+    cursor: not-allowed;
+    background: ${(props) => props.theme.colors.gray['100']};
+    border: ${(props) => props.theme.borderWidths['100']} solid
+      ${(props) => props.theme.colors.gray['300']};
+    color: ${(props) => props.theme.colors.gray['800']};
+  }
+`;
+
+export const StyledInput = styled.input`
+  ${visuallyHidden}
+`;
+
+const commonCheckStyle = (props) => `
+  position: relative;
+  transition: opacity ${tokens.motionDuration_fast} ${tokens.motionEase_in_out}, fill ${tokens.motionDuration_fast} ${tokens.motionEase_in_out}, box-shadow ${tokens.motionDuration_fast} ${tokens.motionEase_in_out};
+  
+  input:disabled ~ ${StyledLabel} & {
+    fill: ${props.theme.colors.gray['700']};
+  }
+`;
+
+export const StyledUnchecked = styled.svg`
+  ${(props) => commonCheckStyle(props)}
+  opacity: 1;
+  fill: ${(props) => props.theme.colors.gray['700']};
+
+  input:checked ~ ${StyledLabel} & {
+    opacity: 0;
+  }
+`;
+
+export const StyledChecked = styled.svg`
+  ${(props) => commonCheckStyle(props)}
+  opacity: 0;
+  left: -1rem;
+  fill: ${(props) => props.theme.colors.blue['700']};
+
+  input:checked ~ ${StyledLabel} & {
+    opacity: 1;
+  }
+`;
+
+export const StyledHeader = styled(Box)`
+  input:checked ~ ${StyledLabel} & {
+    color: ${(props) => props.theme.colors.blue['700']};
+  }
+
+  input:disabled ~ ${StyledLabel} & {
+    color: ${(props) => props.theme.colors.gray['800']};
+  }
+`;

--- a/packages/matchbox/src/components/CheckboxCard/tests/CheckboxCard.test.js
+++ b/packages/matchbox/src/components/CheckboxCard/tests/CheckboxCard.test.js
@@ -103,5 +103,16 @@ describe('CheckboxCard', () => {
       );
       expect(wrapper.find('#test-id')).toExist();
     });
+
+    it('renders a compact space when vertical', () => {
+      const wrapper = global.mountStyled(
+        <CheckboxCard.Group label="label" space="compact">
+          <CheckboxCard id="test-id" />
+          <CheckboxCard id="test-id-2" />
+        </CheckboxCard.Group>,
+      );
+      expect(wrapper.find('#test-id')).toExist();
+      expect(wrapper.find('#test-id-2')).toExist();
+    });
   });
 });

--- a/packages/matchbox/src/components/CheckboxCard/tests/CheckboxCard.test.js
+++ b/packages/matchbox/src/components/CheckboxCard/tests/CheckboxCard.test.js
@@ -1,0 +1,107 @@
+import React from 'react';
+import CheckboxCard from '../CheckboxCard';
+import { render } from 'test-utils';
+
+describe('CheckboxCard', () => {
+  const events = {
+    onChange: jest.fn(),
+    onBlur: jest.fn(),
+    onFocus: jest.fn(),
+  };
+  const subject = (props) =>
+    global.mountStyled(<CheckboxCard id="test-id" {...events} {...props} />);
+
+  it('renders with id and default attributes', () => {
+    render(<CheckboxCard id="test-id" data-track="true" />);
+    expect(document.querySelector('input#test-id')).toBeTruthy();
+    expect(document.querySelector('input[data-track="true"]')).toBeTruthy();
+  });
+
+  it('renders checked, value, and name', () => {
+    const wrapper = subject({ checked: true, value: 'test-value', name: 'test-name' });
+    expect(wrapper.find('input')).toHaveAttributeValue('checked', '');
+    expect(wrapper.find('input')).toHaveAttributeValue('value', 'test-value');
+    expect(wrapper.find('input')).toHaveAttributeValue('name', 'test-name');
+  });
+
+  it('renders a label', () => {
+    const wrapper = subject({ label: 'test-label' });
+    expect(wrapper.text()).toEqual('test-label');
+  });
+
+  it('renders a label and children', () => {
+    const wrapper = subject({ label: 'test-label', children: <>test children</> });
+    expect(wrapper.text()).toEqual('test-labeltest children');
+  });
+
+  it('renders disabled', () => {
+    const wrapper = subject({ disabled: true });
+    expect(wrapper.find('input')).toBeDisabled();
+  });
+
+  it('should invoke events', () => {
+    const wrapper = subject();
+    wrapper.find('input').simulate('change');
+    wrapper.find('input').simulate('focus');
+    wrapper.find('input').simulate('blur');
+    expect(events.onChange).toHaveBeenCalled();
+    expect(events.onBlur).toHaveBeenCalled();
+    expect(events.onFocus).toHaveBeenCalled();
+  });
+
+  it('renders with with a ref', () => {
+    function Test() {
+      const ref = React.useRef();
+      React.useEffect(() => {
+        ref.current.focus();
+      }, []);
+      return (
+        <>
+          <CheckboxCard ref={ref} id="test-card"></CheckboxCard>
+        </>
+      );
+    }
+    global.mountStyled(<Test />);
+    expect(document.activeElement.id).toEqual('test-card');
+  });
+
+  describe('Group', () => {
+    it('renders disabled in a group', () => {
+      const wrapper = global.mountStyled(
+        <CheckboxCard.Group label="label">
+          <CheckboxCard id="test-id1" disabled />
+          <CheckboxCard id="test-id2" />
+        </CheckboxCard.Group>,
+      );
+      expect(wrapper.find('input').at(0)).toBeDisabled();
+      expect(wrapper.find('input').at(1)).not.toBeDisabled();
+    });
+
+    it('renders an optional and label', () => {
+      const wrapper = global.mountStyled(
+        <CheckboxCard.Group label="label" optional>
+          <CheckboxCard id="test-id" />
+        </CheckboxCard.Group>,
+      );
+      expect(wrapper.text()).toEqual('labelOptional');
+    });
+
+    it('renders an horizontal orientation', () => {
+      const wrapper = global.mountStyled(
+        <CheckboxCard.Group label="label" orientation="horizontal">
+          <CheckboxCard id="test-id" />
+        </CheckboxCard.Group>,
+      );
+      expect(wrapper.find('#test-id')).toExist();
+    });
+
+    it('renders a grid orientation', () => {
+      const wrapper = global.mountStyled(
+        <CheckboxCard.Group label="label" orientation="grid">
+          <CheckboxCard id="test-id" />
+        </CheckboxCard.Group>,
+      );
+      expect(wrapper.find('#test-id')).toExist();
+    });
+  });
+});

--- a/packages/matchbox/src/components/RadioCard/tests/RadioCard.test.js
+++ b/packages/matchbox/src/components/RadioCard/tests/RadioCard.test.js
@@ -8,7 +8,7 @@ describe('RadioCard', () => {
     onBlur: jest.fn(),
     onFocus: jest.fn(),
   };
-  const subject = props => global.mountStyled(<RadioCard id="test-id" {...events} {...props} />);
+  const subject = (props) => global.mountStyled(<RadioCard id="test-id" {...events} {...props} />);
 
   it('renders with id and default attributes', () => {
     render(<RadioCard id="test-id" data-track="true" />);

--- a/packages/matchbox/src/components/index.tsx
+++ b/packages/matchbox/src/components/index.tsx
@@ -5,6 +5,7 @@ export * from './Box';
 export * from './Breadcrumb';
 export * from './Button';
 export * from './Checkbox';
+export * from './CheckboxCard';
 export * from './CodeBlock';
 export * from './Column';
 export * from './Columns';


### PR DESCRIPTION

### What Changed
- Adds `CheckboxCard` and `CheckboxCard.Group` components

### How To Test or Verify
- Run libby and visit: http://localhost:9001/?path=CheckboxCard__basic-usage
- Verify all the stories work correctly
- Verify the component matches the mockups: https://www.figma.com/file/kbeuqghvpagMmaLWwqszQo/Forms?node-id=279%3A269

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
