### PR TITLE
UX-779 Add helpText prop to RadioCard.Group and CheckboxCard.Group

### DIFF
--- a/libby/form/CheckboxCard.lib.tsx
+++ b/libby/form/CheckboxCard.lib.tsx
@@ -89,6 +89,20 @@ describe('CheckboxCard', () => {
     </CheckboxCard.Group>
   ));
 
+  add('help text', () => (
+    <CheckboxCard.Group label="Radio Card Group" helpText="Help Text">
+      <CheckboxCard id="id1" label="Check Me 1" name="group" defaultChecked>
+        I am help text
+      </CheckboxCard>
+      <CheckboxCard id="id2" label="Check Me 2" name="group">
+        I am help text
+      </CheckboxCard>
+      <CheckboxCard id="id3" label="Check Me 3" name="group">
+        I am help text
+      </CheckboxCard>
+    </CheckboxCard.Group>
+  ));
+
   add('works with system props', () => (
     <CheckboxCard.Group label="Radio Card Group" my="500" mx="700">
       <CheckboxCard id="id1" label="Check Me 1" name="group" defaultChecked>

--- a/libby/form/RadioCard.lib.tsx
+++ b/libby/form/RadioCard.lib.tsx
@@ -75,6 +75,20 @@ describe('RadioCard', () => {
     </RadioCard.Group>
   ));
 
+  add('help text', () => (
+    <RadioCard.Group label="Radio Card Group" helpText="Help Text">
+      <RadioCard id="id1" label="Check Me 1" name="group" defaultChecked>
+        I am help text
+      </RadioCard>
+      <RadioCard id="id2" label="Check Me 2" name="group">
+        I am help text
+      </RadioCard>
+      <RadioCard id="id3" label="Check Me 3" name="group">
+        I am help text
+      </RadioCard>
+    </RadioCard.Group>
+  ));
+
   add('group with optional label', () => (
     <RadioCard.Group label="Radio Card Group" optional>
       <RadioCard id="id1" label="Check Me 1" name="group" defaultChecked>

--- a/libby/regression/CheckboxCard.lib.tsx
+++ b/libby/regression/CheckboxCard.lib.tsx
@@ -7,7 +7,7 @@ describe('Visual Regression', () => {
     <>
       <CheckboxCard id="id1" label="Check Me" data-track="true" />
       {/* Disabled */}
-      <CheckboxCard.Group label="Radio Card Group">
+      <CheckboxCard.Group label="Radio Card Group" helpText="Help">
         <CheckboxCard id="id1" label="Check Me 1" disabled>
           This one is disabled
         </CheckboxCard>

--- a/libby/regression/RadioCard.lib.tsx
+++ b/libby/regression/RadioCard.lib.tsx
@@ -7,7 +7,7 @@ describe('Visual Regression', () => {
     <>
       <RadioCard id="id1" label="Check Me" data-track="true" />
       {/* Disabled */}
-      <RadioCard.Group label="Radio Card Group">
+      <RadioCard.Group label="Radio Card Group" helpText="Help">
         <RadioCard id="id1" label="Check Me 1" disabled>
           This one is disabled
         </RadioCard>

--- a/packages/matchbox/src/components/CheckboxCard/Group.tsx
+++ b/packages/matchbox/src/components/CheckboxCard/Group.tsx
@@ -6,6 +6,7 @@ import { Columns } from '../Columns';
 import { Column } from '../Column';
 import { Label } from '../Label';
 import { OptionalLabel } from '../OptionalLabel';
+import { HelpText } from '../HelpText';
 import { Stack } from '../Stack';
 import { Breakpoints } from '../../helpers/types';
 import { pick } from '../../helpers/props';
@@ -39,6 +40,7 @@ export type CheckboxCardGroupProps = {
   children?: React.ReactNode;
   collapseBelow?: Breakpoints;
   'data-id'?: string;
+  helpText?: React.ReactNode;
   label: string;
   labelHidden?: boolean;
   optional?: boolean;
@@ -54,6 +56,7 @@ const Group = React.forwardRef<HTMLFieldSetElement, CheckboxCardGroupProps>(func
   const {
     children,
     collapseBelow,
+    helpText,
     id,
     label,
     labelHidden,
@@ -74,6 +77,11 @@ const Group = React.forwardRef<HTMLFieldSetElement, CheckboxCardGroupProps>(func
         </Box>
         {optional && <OptionalLabel />}
       </Label>
+      {helpText && (
+        <Box mb="200">
+          <HelpText mt="0">{helpText}</HelpText>
+        </Box>
+      )}
 
       {orientation === 'horizontal' && (
         <Columns space="300" collapseBelow={collapseBelow}>

--- a/packages/matchbox/src/components/CheckboxCard/tests/CheckboxCard.test.js
+++ b/packages/matchbox/src/components/CheckboxCard/tests/CheckboxCard.test.js
@@ -114,5 +114,14 @@ describe('CheckboxCard', () => {
       expect(wrapper.find('#test-id')).toExist();
       expect(wrapper.find('#test-id-2')).toExist();
     });
+
+    it('renders helpText', () => {
+      const { getByText } = render(
+        <CheckboxCard.Group label="label" helpText="help">
+          <CheckboxCard id="test-id" />
+        </CheckboxCard.Group>,
+      );
+      expect(getByText('help')).toBeTruthy();
+    });
   });
 });

--- a/packages/matchbox/src/components/RadioCard/Group.tsx
+++ b/packages/matchbox/src/components/RadioCard/Group.tsx
@@ -6,6 +6,7 @@ import { Columns } from '../Columns';
 import { Column } from '../Column';
 import { Label } from '../Label';
 import { OptionalLabel } from '../OptionalLabel';
+import { HelpText } from '../HelpText';
 import { Stack } from '../Stack';
 import { Breakpoints } from '../../helpers/types';
 
@@ -42,6 +43,7 @@ export type RadioCardGroupProps = {
   children?: React.ReactNode;
   collapseBelow?: Breakpoints;
   'data-id'?: string;
+  helpText?: React.ReactNode;
   label: string;
   labelHidden?: boolean;
   optional?: boolean;
@@ -57,6 +59,7 @@ const Group = React.forwardRef<HTMLFieldSetElement, RadioCardGroupProps>(functio
   const {
     children,
     collapseBelow,
+    helpText,
     id,
     label,
     labelHidden,
@@ -77,6 +80,11 @@ const Group = React.forwardRef<HTMLFieldSetElement, RadioCardGroupProps>(functio
         </Box>
         {optional && <OptionalLabel />}
       </Label>
+      {helpText && (
+        <Box mb="200">
+          <HelpText mt="0">{helpText}</HelpText>
+        </Box>
+      )}
 
       {orientation === 'horizontal' && (
         <Columns space="300" collapseBelow={collapseBelow}>

--- a/packages/matchbox/src/components/RadioCard/tests/RadioCard.test.js
+++ b/packages/matchbox/src/components/RadioCard/tests/RadioCard.test.js
@@ -113,5 +113,14 @@ describe('RadioCard', () => {
       expect(wrapper.find('#test-id')).toExist();
       expect(wrapper.find('#test-id-2')).toExist();
     });
+
+    it('renders helpText', () => {
+      const { getByText } = render(
+        <RadioCard.Group label="label" helpText="help">
+          <RadioCard id="test-id" />
+        </RadioCard.Group>,
+      );
+      expect(getByText('help')).toBeTruthy();
+    });
   });
 });


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->


### What Changed
- Adds new `helpText` prop to `RadioCard.Group` and `CheckboxCard.Group`

### How To Test or Verify
- Run libby
- visit http://localhost:9001/?path=RadioCard__help-text
- and visit http://localhost:9001/?path=CheckboxCard__help-text
- Verify the prop works correctly 


### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
