### PR TITLE
UX-780 Bottom align sort button icons

### DIFF
--- a/packages/matchbox/src/components/Table/SortButton.tsx
+++ b/packages/matchbox/src/components/Table/SortButton.tsx
@@ -40,6 +40,7 @@ const Button = styled.button<{ $sorted?: boolean }>`
 
 const IconWrapper = styled.span<{ $sorted?: boolean }>`
   display: inline-block;
+  align-self: end;
   margin-left: ${({ theme }) => theme.space[100]};
   color: ${({ theme }) => theme.colors.gray[700]};
   transition: ${({ theme }) => theme.motion.duration.fast};


### PR DESCRIPTION
### What Changed
- Bottom aligns icons within table sort buttons

### How To Test or Verify
- Run libby and visit http://localhost:9001/?path=Table__all-table-components
- Verify the arrow icons are bottom aligned with

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
