### PR TITLE
UX-782 remove selected and hover states from small CheckboxCard and RadioCard

### DIFF
--- a/libby/form/CheckboxCard.lib.tsx
+++ b/libby/form/CheckboxCard.lib.tsx
@@ -6,7 +6,7 @@ describe('CheckboxCard', () => {
   add('basic usage', () => <CheckboxCard id="id1" label="Check Me" />);
 
   add('disabled', () => (
-    <CheckboxCard.Group label="Radio Card Group">
+    <CheckboxCard.Group label="Checkbox Card Group">
       <CheckboxCard id="id1" label="Check Me 1" disabled>
         This one is disabled
       </CheckboxCard>
@@ -20,7 +20,7 @@ describe('CheckboxCard', () => {
   ));
 
   add('vertical', () => (
-    <CheckboxCard.Group label="Radio Card Group">
+    <CheckboxCard.Group label="Checkbox Card Group">
       <CheckboxCard id="id1" label="Check Me 1" name="group" defaultChecked>
         I am help text
       </CheckboxCard>
@@ -34,7 +34,7 @@ describe('CheckboxCard', () => {
   ));
 
   add('grid', () => (
-    <CheckboxCard.Group label="Radio Card Group" orientation="grid">
+    <CheckboxCard.Group label="Checkbox Card Group" orientation="grid">
       <CheckboxCard id="id1" label="Check Me 1" name="group" defaultChecked>
         I am help text
       </CheckboxCard>
@@ -51,7 +51,7 @@ describe('CheckboxCard', () => {
   ));
 
   add('collapsing horizontal', () => (
-    <CheckboxCard.Group collapseBelow="sm" label="Radio Card Group" orientation="horizontal">
+    <CheckboxCard.Group collapseBelow="sm" label="Checkbox Card Group" orientation="horizontal">
       <CheckboxCard id="id1" label="Check Me 1" name="group" defaultChecked>
         I am help text
       </CheckboxCard>
@@ -62,7 +62,7 @@ describe('CheckboxCard', () => {
   ));
 
   add('group with hidden label', () => (
-    <CheckboxCard.Group label="Radio Card Group" labelHidden>
+    <CheckboxCard.Group label="Checkbox Card Group" labelHidden>
       <CheckboxCard id="id1" label="Check Me 1" name="group" defaultChecked>
         I am help text
       </CheckboxCard>
@@ -76,7 +76,7 @@ describe('CheckboxCard', () => {
   ));
 
   add('group with optional label', () => (
-    <CheckboxCard.Group label="Radio Card Group" optional>
+    <CheckboxCard.Group label="Checkbox Card Group" optional>
       <CheckboxCard id="id1" label="Check Me 1" name="group" defaultChecked>
         I am help text
       </CheckboxCard>
@@ -90,7 +90,7 @@ describe('CheckboxCard', () => {
   ));
 
   add('help text', () => (
-    <CheckboxCard.Group label="Radio Card Group" helpText="Help Text">
+    <CheckboxCard.Group label="Checkbox Card Group" helpText="Help Text">
       <CheckboxCard id="id1" label="Check Me 1" name="group" defaultChecked>
         I am help text
       </CheckboxCard>
@@ -104,7 +104,7 @@ describe('CheckboxCard', () => {
   ));
 
   add('works with system props', () => (
-    <CheckboxCard.Group label="Radio Card Group" my="500" mx="700">
+    <CheckboxCard.Group label="Checkbox Card Group" my="500" mx="700">
       <CheckboxCard id="id1" label="Check Me 1" name="group" defaultChecked>
         I am help text
       </CheckboxCard>
@@ -118,7 +118,7 @@ describe('CheckboxCard', () => {
   ));
 
   add('small variant', () => (
-    <CheckboxCard.Group label="Radio Card Group" space="compact">
+    <CheckboxCard.Group label="Checkbox Card Group" space="compact">
       <CheckboxCard id="id1" label="Check Me 1" name="group" defaultChecked size="small">
         I am help text
       </CheckboxCard>

--- a/packages/matchbox/src/components/CheckboxCard/CheckboxCard.tsx
+++ b/packages/matchbox/src/components/CheckboxCard/CheckboxCard.tsx
@@ -67,6 +67,7 @@ const CheckboxCard = React.forwardRef<HTMLInputElement, CheckboxCardProps>(funct
               fontSize={isSmall ? '200' : '300'}
               lineHeight={isSmall ? '200' : '400'}
               fontWeight={isSmall ? 'medium' : 'semibold'}
+              $size={size}
             >
               {label}
             </StyledHeader>

--- a/packages/matchbox/src/components/CheckboxCard/styles.ts
+++ b/packages/matchbox/src/components/CheckboxCard/styles.ts
@@ -92,9 +92,10 @@ export const StyledChecked = styled.svg`
   }
 `;
 
-export const StyledHeader = styled(Box)`
+export const StyledHeader = styled(Box)<{ $size?: 'small' | 'default' }>`
   input:checked ~ ${StyledLabel} & {
-    color: ${(props) => props.theme.colors.blue['700']};
+    color: ${(props) =>
+      props.$size === 'small' ? props.theme.colors.gray['800'] : props.theme.colors.blue['700']};
   }
 
   input:disabled ~ ${StyledLabel} & {

--- a/packages/matchbox/src/components/CheckboxCard/styles.ts
+++ b/packages/matchbox/src/components/CheckboxCard/styles.ts
@@ -18,12 +18,20 @@ export const StyledLabel = styled(Box)<{ $size?: 'small' | 'default' }>`
 
   &:hover {
     border: ${(props) => props.theme.borderWidths['100']} solid
-      ${(props) => props.theme.colors.gray['600']};
+      ${(props) => {
+        return props.$size === 'small'
+          ? props.theme.colors.gray['400']
+          : props.theme.colors.gray['600'];
+      }};
   }
 
   input:checked ~ & {
     border: ${(props) => props.theme.borderWidths['100']} solid
-      ${(props) => props.theme.colors.blue['700']};
+      ${(props) => {
+        return props.$size === 'small'
+          ? props.theme.colors.gray['400']
+          : props.theme.colors.blue['700'];
+      }};
   }
 
   input:disabled ~ & {

--- a/packages/matchbox/src/components/RadioCard/RadioCard.tsx
+++ b/packages/matchbox/src/components/RadioCard/RadioCard.tsx
@@ -64,6 +64,7 @@ const RadioCard = React.forwardRef<HTMLInputElement, RadioCardProps>(function Ra
           <Box flex="1" pl="300">
             <StyledHeader
               data-id="radio-card-header"
+              $size={size}
               fontSize={isSmall ? '200' : '300'}
               lineHeight={isSmall ? '200' : '400'}
               fontWeight={isSmall ? 'medium' : 'semibold'}

--- a/packages/matchbox/src/components/RadioCard/styles.ts
+++ b/packages/matchbox/src/components/RadioCard/styles.ts
@@ -87,9 +87,10 @@ export const StyledChecked = styled.svg`
   }
 `;
 
-export const StyledHeader = styled(Box)`
+export const StyledHeader = styled(Box)<{ $size?: 'small' | 'default' }>`
   input:checked ~ ${StyledLabel} & {
-    color: ${(props) => props.theme.colors.blue['700']};
+    color: ${(props) =>
+      props.$size === 'small' ? props.theme.colors.gray['800'] : props.theme.colors.blue['700']};
   }
 
   input:disabled ~ ${StyledLabel} & {

--- a/packages/matchbox/src/components/RadioCard/styles.ts
+++ b/packages/matchbox/src/components/RadioCard/styles.ts
@@ -18,12 +18,20 @@ export const StyledLabel = styled(Box)<{ $size?: 'small' | 'default' }>`
 
   &:hover {
     border: ${(props) => props.theme.borderWidths['100']} solid
-      ${(props) => props.theme.colors.gray['600']};
+      ${(props) => {
+        return props.$size === 'small'
+          ? props.theme.colors.gray['400']
+          : props.theme.colors.gray['600'];
+      }};
   }
 
   input:checked ~ & {
     border: ${(props) => props.theme.borderWidths['100']} solid
-      ${(props) => props.theme.colors.blue['700']};
+      ${(props) => {
+        return props.$size === 'small'
+          ? props.theme.colors.gray['400']
+          : props.theme.colors.blue['700'];
+      }};
   }
 
   input:disabled ~ & {


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed

- Removed :selected and :hover styles from small CheckboxCard and RadioCard

### How To Test or Verify

- `npm run start:libby`
- Confirm hover and checked styles have been removed on small Card variants

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
