### PR TITLE
UX-784 add arrow controls to Text Field with type 'number'

### DIFF
--- a/libby/feedback/Banner.lib.tsx
+++ b/libby/feedback/Banner.lib.tsx
@@ -13,9 +13,11 @@ function noop() {
 describe('Banner', () => {
   add('success Banner', () => {
     return (
-      <Banner title="Thank you for your dedicated IP purchase" status="success" onDismiss={noop}>
-        <p>Happy Sending!</p>
-      </Banner>
+      <Banner
+        title="Thank you for your dedicated IP purchase"
+        status="success"
+        onDismiss={noop}
+      ></Banner>
     );
   });
 

--- a/libby/form/TextField.lib.tsx
+++ b/libby/form/TextField.lib.tsx
@@ -31,6 +31,25 @@ describe('TextField', () => {
 
   add('disabled', () => <TextField id="id" label="Template ID" value="template-12" disabled />);
 
+  add('number', () => <TextField type="number" id="id" label="Alert Threshold" />);
+
+  add('number disabled', () => (
+    <TextField type="number" id="id" label="Alert Threshold" disabled />
+  ));
+
+  add('number with buttons', () => (
+    <TextField
+      type="number"
+      id="id"
+      label="Alert Threshold"
+      connectRight={
+        <Button color="red" outline>
+          Delete
+        </Button>
+      }
+    />
+  ));
+
   add('text alignment', () => (
     <Stack>
       <TextField id="id" label="Right" value={500} align="right" suffix="emails" />

--- a/packages/matchbox/src/components/TextField/TextField.tsx
+++ b/packages/matchbox/src/components/TextField/TextField.tsx
@@ -111,13 +111,14 @@ const FieldBox = React.forwardRef<HTMLInputElement, FieldBoxProps>(function Fiel
         ref={assignRefs}
       />
       {type == 'number' && !disabled && (
-        <StyledNumberControls $disabled={disabled} tabIndex={-1}>
+        <StyledNumberControls $disabled={disabled}>
           <StyledButton
             onClick={increment}
             as="button"
             type="button"
             aria-hidden={true}
             disabled={disabled}
+            tabIndex={-1}
           >
             <StyledArrowUp size={20} />
           </StyledButton>
@@ -127,6 +128,7 @@ const FieldBox = React.forwardRef<HTMLInputElement, FieldBoxProps>(function Fiel
             type="button"
             aria-hidden={true}
             disabled={disabled}
+            tabIndex={-1}
           >
             <StyledArrowDown size={20} />
           </StyledButton>

--- a/packages/matchbox/src/components/TextField/TextField.tsx
+++ b/packages/matchbox/src/components/TextField/TextField.tsx
@@ -35,8 +35,9 @@ const StyledInput = styled(Box)<BoxProps>`
     margin: 0;
   }
 `;
-
-const StyledButton = styled(Box)<Omit<React.ComponentProps<typeof Box>, 'as'>>`
+const StyledButton = styled.button<
+  React.ComponentPropsWithRef<'button'> & Omit<React.ComponentProps<typeof Box>, 'as'>
+>`
   ${buttonReset}
   cursor: pointer;
 `;
@@ -110,11 +111,23 @@ const FieldBox = React.forwardRef<HTMLInputElement, FieldBoxProps>(function Fiel
         ref={assignRefs}
       />
       {type == 'number' && !disabled && (
-        <StyledNumberControls $disabled={disabled}>
-          <StyledButton onClick={increment} as="button" disabled={disabled}>
+        <StyledNumberControls $disabled={disabled} tabIndex={-1}>
+          <StyledButton
+            onClick={increment}
+            as="button"
+            type="button"
+            aria-hidden={true}
+            disabled={disabled}
+          >
             <StyledArrowUp size={20} />
           </StyledButton>
-          <StyledButton onClick={decrement} as="button" disabled={disabled}>
+          <StyledButton
+            onClick={decrement}
+            as="button"
+            type="button"
+            aria-hidden={true}
+            disabled={disabled}
+          >
             <StyledArrowDown size={20} />
           </StyledButton>
         </StyledNumberControls>


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

<img width="1007" alt="Screen Shot 2022-04-18 at 1 12 43 PM" src="https://user-images.githubusercontent.com/3878251/163854150-fb226c51-4124-4044-94f9-d2f5040ad687.png">


### What Changed

- Adds control arrows for TextField with type="number"

### How To Test or Verify

- `npm run start:libby`
- verify number TextField styles are correct and stepping up and down works by clicking the arrows and with keyboard control

### PR Checklist

- [ ] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
