### PR TITLE
Fix uncontrolled checked state conflicting with controlled indeterminate state

### DIFF
--- a/libby/form/Checkbox.lib.tsx
+++ b/libby/form/Checkbox.lib.tsx
@@ -2,6 +2,59 @@ import React from 'react';
 import { describe, add } from '@sparkpost/libby-react';
 import { Box, Checkbox, UnstyledLink } from '@sparkpost/matchbox';
 
+const Indeterminate = () => {
+  const [checked1, setChecked1] = React.useState(false);
+  const [checked2, setChecked2] = React.useState(false);
+  const [indeterminate, setIndeterminate] = React.useState(null);
+
+  React.useLayoutEffect(() => {
+    if (checked1 || checked2) {
+      setIndeterminate('indeterminate');
+    }
+    if (checked1 && checked2) {
+      setIndeterminate(true);
+    }
+
+    if (!checked1 && !checked2) {
+      setIndeterminate(false);
+    }
+  }, [checked1, checked2]);
+
+  function handleIndeterminate() {
+    setIndeterminate(!indeterminate);
+    setChecked1(!indeterminate);
+    setChecked2(!indeterminate);
+  }
+
+  function flip(cb, value) {
+    return () => {
+      cb(!value);
+    };
+  }
+
+  return (
+    <div>
+      <Checkbox.Group label="Example">
+        <Checkbox id="id" label="Check Me" checked={indeterminate} onChange={handleIndeterminate} />
+        <Box pl="500">
+          <Checkbox
+            id="child1"
+            onChange={flip(setChecked1, checked1)}
+            checked={checked1}
+            label="Check Me"
+          />
+          <Checkbox
+            id="child2"
+            onChange={flip(setChecked2, checked2)}
+            checked={checked2}
+            label="Check Me"
+          />
+        </Box>
+      </Checkbox.Group>
+    </div>
+  );
+};
+
 describe('Checkbox', () => {
   add('basic usage', () => <Checkbox id="id" label="Check Me" />);
   add('without label', () => <Checkbox id="id" label="Check Me" labelHidden />);
@@ -56,61 +109,8 @@ describe('Checkbox', () => {
     </Checkbox.Group>
   ));
 
-  add('indeterminate group', () => {
-    const [checked1, setChecked1] = React.useState(false);
-    const [checked2, setChecked2] = React.useState(false);
-    const [indeterminate, setIndeterminate] = React.useState(null);
-
-    React.useLayoutEffect(() => {
-      if (checked1 || checked2) {
-        setIndeterminate('indeterminate');
-      }
-      if (checked1 && checked2) {
-        setIndeterminate(true);
-      }
-
-      if (!checked1 && !checked2) {
-        setIndeterminate(false);
-      }
-    }, [checked1, checked2]);
-
-    function handleIndeterminate() {
-      setIndeterminate(!indeterminate);
-      setChecked1(!indeterminate);
-      setChecked2(!indeterminate);
-    }
-
-    function flip(cb, value) {
-      return () => {
-        cb(!value);
-      };
-    }
-
-    return (
-      <div>
-        <Checkbox.Group label="Example">
-          <Checkbox
-            id="id"
-            label="Check Me"
-            checked={indeterminate}
-            onChange={handleIndeterminate}
-          />
-          <Box pl="500">
-            <Checkbox
-              id="child1"
-              onChange={flip(setChecked1, checked1)}
-              checked={checked1}
-              label="Check Me"
-            />
-            <Checkbox
-              id="child2"
-              onChange={flip(setChecked2, checked2)}
-              checked={checked2}
-              label="Check Me"
-            />
-          </Box>
-        </Checkbox.Group>
-      </div>
-    );
-  });
+  add('indeterminate group', () => <Indeterminate />);
+  add('indeterminate controlled', () => (
+    <Checkbox id="id2" checked="indeterminate" label="Check Me" />
+  ));
 });

--- a/packages/matchbox/src/components/Checkbox/Checkbox.tsx
+++ b/packages/matchbox/src/components/Checkbox/Checkbox.tsx
@@ -20,8 +20,8 @@ import {
 
 export type CheckboxProps = {
   id: string;
-  checked?: boolean | string | 'indeterminate';
-  defaultChecked?: boolean | string;
+  checked?: boolean | 'indeterminate';
+  defaultChecked?: boolean;
   disabled?: boolean;
   error?: React.ReactNode;
   helpText?: React.ReactNode;
@@ -29,7 +29,7 @@ export type CheckboxProps = {
   labelHidden?: boolean;
   required?: boolean;
   value?: string;
-} & React.ComponentPropsWithoutRef<'input'>;
+} & Omit<React.ComponentPropsWithoutRef<'input'>, 'checked'>;
 
 const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(function Checkbox(
   props,
@@ -59,7 +59,7 @@ const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(function Chec
 
   const isIndeterminate = typeof checked === 'string' && checked === 'indeterminate';
   const indeterminateAttributes = isIndeterminate
-    ? { $indeterminate: 'true', 'aria-checked': 'mixed' }
+    ? { 'aria-checked': 'mixed', checked: false }
     : { 'aria-checked': checked ? 'true' : 'false', checked };
 
   return (

--- a/packages/matchbox/src/components/Checkbox/Checkbox.tsx
+++ b/packages/matchbox/src/components/Checkbox/Checkbox.tsx
@@ -50,6 +50,7 @@ const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(function Chec
 
   const componentProps = omit(rest, margin.propNames);
   const systemProps = pick(rest);
+  const isControlled = checked !== undefined;
 
   const { describedBy, errorId, helpTextId } = useInputDescribedBy({
     id,
@@ -60,7 +61,7 @@ const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(function Chec
   const isIndeterminate = typeof checked === 'string' && checked === 'indeterminate';
   const indeterminateAttributes = isIndeterminate
     ? { 'aria-checked': 'mixed', checked: false }
-    : { 'aria-checked': checked ? 'true' : 'false', checked };
+    : { 'aria-checked': checked ? 'true' : 'false', checked: Boolean(checked) };
 
   return (
     <Wrapper {...systemProps}>
@@ -73,7 +74,7 @@ const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(function Chec
           disabled={disabled}
           type="checkbox"
           ref={userRef}
-          {...indeterminateAttributes}
+          {...(isControlled ? indeterminateAttributes : {})}
           {...describedBy}
           {...componentProps}
         />


### PR DESCRIPTION
<!-- Give your PR a recognizable title. For example: "FE-123: Add new prop to component" or "Resolve Issue #123: Fix bug in component" -->
<!-- Your PR title will be visible in changelogs -->

### What Changed
- Fixes a bug where controlled indeterminate checkboxes conflicting with uncontrolled behavior

### How To Test or Verify
- Visit: http://localhost:9001/?path=Checkbox__indeterminate-controlled
- Try clicking on the checkbox, it shouldnt show a check

### PR Checklist

- [x] Add the correct `type` label
- [ ] Pull request approval from #uxfe or #design-guild
