### PR TITLE
build: fix type compilation

### DIFF
--- a/.changeset/short-beans-sparkle.md
+++ b/.changeset/short-beans-sparkle.md
@@ -1,0 +1,6 @@
+---
+'@sparkpost/matchbox': patch
+'@sparkpost/matchbox-icons': patch
+---
+
+Typescript types are now bundled properly

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
   "files.exclude": {
     "**/.git": true,
     "**/.DS_Store": true,
-    "**/dist": true,
+    // "**/dist": true,
     "**/node_modules": true,
     "**/.turbo": true
   },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,6 @@
   "files.exclude": {
     "**/.git": true,
     "**/.DS_Store": true,
-    // "**/dist": true,
     "**/node_modules": true,
     "**/.turbo": true
   },

--- a/packages/matchbox-icons/rollup/plugins/js.js
+++ b/packages/matchbox-icons/rollup/plugins/js.js
@@ -2,7 +2,7 @@
 
 import resolve from 'rollup-plugin-node-resolve';
 import babel from 'rollup-plugin-babel';
-import { terser } from 'rollup-plugin-terser';
+// import { terser } from 'rollup-plugin-terser';
 import typescript from '@rollup/plugin-typescript';
 import { DEFAULT_EXTENSIONS } from '@babel/core';
 
@@ -16,6 +16,6 @@ export default [
     presets: ['@babel/env', '@babel/react', '@babel/preset-typescript'],
     plugins: ['@babel/proposal-object-rest-spread', '@babel/proposal-class-properties'],
   }),
-  terser(),
+  // terser(),
   typescript({ tsconfig: './tsconfig.json' }),
 ];

--- a/packages/matchbox-icons/tsconfig.json
+++ b/packages/matchbox-icons/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
+    "baseUrl": "src",
     "target": "es6",
     "lib": ["es6", "dom", "dom.iterable", "esnext"],
     "allowJs": true,

--- a/packages/matchbox/rollup/plugins/js.js
+++ b/packages/matchbox/rollup/plugins/js.js
@@ -2,7 +2,7 @@
 
 import resolve from 'rollup-plugin-node-resolve';
 import babel from 'rollup-plugin-babel';
-import { terser } from 'rollup-plugin-terser';
+// import { terser } from 'rollup-plugin-terser';
 import typescript from '@rollup/plugin-typescript';
 import { DEFAULT_EXTENSIONS } from '@babel/core';
 
@@ -16,6 +16,6 @@ export default [
     presets: ['@babel/env', '@babel/react', '@babel/preset-typescript'],
     plugins: ['@babel/proposal-object-rest-spread', '@babel/proposal-class-properties'],
   }),
-  terser(),
+  // terser(), Fix me, causing `Error: kill EPERM`
   typescript({ tsconfig: './tsconfig.json' }),
 ];

--- a/packages/matchbox/tsconfig.json
+++ b/packages/matchbox/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
+    "baseUrl": "src",
     "paths": {
       "@sparkpost/matchbox-icons*": ["../matchbox-icons/src", "../matchbox-icons/src*"]
     },
@@ -10,7 +10,6 @@
     "sourceMap": true,
     "skipLibCheck": true,
     "outDir": "./dist",
-    "declarationDir": "./",
     "strict": false,
     "forceConsistentCasingInFileNames": true,
     "noEmit": false,


### PR DESCRIPTION
### What Changed
- Temporarily removes the `terser` plugin. Was causing a `Error: kill EPERM` error. Need to find an alternative.
- Fixes the types compiled from the build scripts by changing tsconfig's base url. They were missing before. No idea why this works.

### How To Verify
- Run `npm run build`
- Verify that the types are generated in `the dist` folders. Only affects `matchbox` and `matchbox-icons`
